### PR TITLE
Pull in updates to pulumi/pulumi-terraform

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1010,6 +1010,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "43bca9cc98e42a860891cee31c7886a1af0afaea34b6ef587cff4f712b8fae27"
+  inputs-digest = "5144e4a00dc7f2772edea79a0f5070f803e5bbbb2b7f083152c14d20e4c1321e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,14 +1,6 @@
 [[constraint]]
-  name = "github.com/pulumi/pulumi"
-  version = "v0.15.1"
-
-[[constraint]]
   name = "github.com/pulumi/pulumi-terraform"
   branch = "master"
-
-[[override]]
-  name = "github.com/hashicorp/terraform"
-  revision = "35d82b055591e9d47a254e68754216d8849ba67a"
 
 [[override]]
   name = "github.com/terraform-providers/terraform-provider-google"


### PR DESCRIPTION
This commit modifies the constraints in Gopkg.toml to allow solving for an update of `pulumi-terraform`, given the changes to the dependencies of `pulumi-terraform`.

This pulls in the changes to use Terraform importers.