### PR TITLE
Ingest latest Terraform code-gen

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -575,13 +575,13 @@
   revision = "a337fd73793c8fba7db7b602fec9cf32aab1c72f"
 
 [[projects]]
-  branch = "master"
+  branch = "joeduffy/skip_markdown_header_fix"
   name = "github.com/pulumi/pulumi-terraform"
   packages = [
     "pkg/tfbridge",
     "pkg/tfgen"
   ]
-  revision = "8c7d4154b4c9bed966f720e4e10941d1d391b2a9"
+  revision = "c040e8e9f8cb904c31e145a838a599dd31c50ebe"
 
 [[projects]]
   branch = "master"
@@ -1013,6 +1013,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5144e4a00dc7f2772edea79a0f5070f803e5bbbb2b7f083152c14d20e4c1321e"
+  inputs-digest = "f32882d410bcb94e442bafc13d9709f343de0aa65eceed7c075fe6ec68651cf1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/pulumi/pulumi-terraform"
-  branch = "master"
+  branch = "joeduffy/skip_markdown_header_fix"
 
 [[override]]
   name = "github.com/terraform-providers/terraform-provider-google"

--- a/sdk/go/gcp/appengine/application.go
+++ b/sdk/go/gcp/appengine/application.go
@@ -10,7 +10,7 @@ import (
 
 // Allows creation and management of an App Engine application.
 // 
-// ~> App Engine applications cannot be deleted once they're created; you have to delete the
+// > App Engine applications cannot be deleted once they're created; you have to delete the
 //    entire project to delete the application. Terraform will report the application has been
 //    successfully deleted; this is a limitation of Terraform, and will go away in the future.
 //    Terraform is not able to delete App Engine applications.

--- a/sdk/go/gcp/binaryauthorization/attestor.go
+++ b/sdk/go/gcp/binaryauthorization/attestor.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// An attestor that attests to container image artifacts.
+// 
+// > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+// See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+// 
+// To get more information about Attestor, see:
+// 
+// * [API documentation](https://cloud.google.com/binary-authorization/docs/reference/rest/)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/binary-authorization/)
 type Attestor struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/binaryauthorization/policy.go
+++ b/sdk/go/gcp/binaryauthorization/policy.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// A policy for container image binary authorization.
+// 
+// > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+// See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+// 
+// To get more information about Policy, see:
+// 
+// * [API documentation](https://cloud.google.com/binary-authorization/docs/reference/rest/)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/binary-authorization/)
 type Policy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/address.go
+++ b/sdk/go/gcp/compute/address.go
@@ -7,6 +7,27 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents an Address resource.
+// 
+// Each virtual machine instance has an ephemeral internal IP address and,
+// optionally, an external IP address. To communicate between instances on
+// the same network, you can use an instance's internal IP address. To
+// communicate with the Internet and instances outside of the same network,
+// you must specify the instance's external IP address.
+// 
+// Internal IP addresses are ephemeral and only belong to an instance for
+// the lifetime of the instance; if the instance is deleted and recreated,
+// the instance is assigned a new internal IP address, either by Compute
+// Engine or by you. External IP addresses can be either ephemeral or
+// static.
+// 
+// 
+// To get more information about Address, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/beta/addresses)
+// * How-to Guides
+//     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/instances-and-network)
+//     * [Reserving a Static Internal IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
 type Address struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/autoscalar.go
+++ b/sdk/go/gcp/compute/autoscalar.go
@@ -8,6 +8,18 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents an Autoscaler resource.
+// 
+// Autoscalers allow you to automatically scale virtual machine instances in
+// managed instance groups according to an autoscaling policy that you
+// define.
+// 
+// 
+// To get more information about Autoscaler, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers)
+// * How-to Guides
+//     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
 type Autoscalar struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/backendBucket.go
+++ b/sdk/go/gcp/compute/backendBucket.go
@@ -8,6 +8,20 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Backend buckets allow you to use Google Cloud Storage buckets with HTTP(S)
+// load balancing.
+// 
+// An HTTP(S) load balancer can direct traffic to specified URLs to a
+// backend bucket rather than a backend service. It can send requests for
+// static content to a Cloud Storage bucket and requests for dynamic content
+// a virtual machine instance.
+// 
+// 
+// To get more information about BackendBucket, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/backendBuckets)
+// * How-to Guides
+//     * [Using a Cloud Storage bucket as a load balancer backend](https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket)
 type BackendBucket struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/disk.go
+++ b/sdk/go/gcp/compute/disk.go
@@ -7,6 +7,32 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Persistent disks are durable storage devices that function similarly to
+// the physical disks in a desktop or a server. Compute Engine manages the
+// hardware behind these devices to ensure data redundancy and optimize
+// performance for you. Persistent disks are available as either standard
+// hard disk drives (HDD) or solid-state drives (SSD).
+// 
+// Persistent disks are located independently from your virtual machine
+// instances, so you can detach or move persistent disks to keep your data
+// even after you delete your instances. Persistent disk performance scales
+// automatically with size, so you can resize your existing persistent disks
+// or add more persistent disks to an instance to meet your performance and
+// storage space requirements.
+// 
+// Add a persistent disk to your instance when you need reliable and
+// affordable storage with consistent performance characteristics.
+// 
+// 
+// To get more information about Disk, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/disks)
+// * How-to Guides
+//     * [Adding a persistent disk](https://cloud.google.com/compute/docs/disks/add-persistent-disk)
+// 
+// > **Warning:** All arguments including the disk encryption key will be stored in the raw
+// state as plain-text.
+// [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type Disk struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/firewall.go
+++ b/sdk/go/gcp/compute/firewall.go
@@ -8,6 +8,25 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Each network has its own firewall controlling access to and from the
+// instances.
+// 
+// All traffic to instances, even from other instances, is blocked by the
+// firewall unless firewall rules are created to allow it.
+// 
+// The default network has automatically created firewall rules that are
+// shown in default firewall rules. No manually created network has
+// automatically created firewall rules except for a default "allow" rule for
+// outgoing traffic and a default "deny" for incoming traffic. For all
+// networks except the default network, you must create any firewall rules
+// you need.
+// 
+// 
+// To get more information about Firewall, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/firewalls)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/vpc/docs/firewalls)
 type Firewall struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/forwardingRule.go
+++ b/sdk/go/gcp/compute/forwardingRule.go
@@ -7,6 +7,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// A ForwardingRule resource. A ForwardingRule resource specifies which pool
+// of target virtual machines to forward a packet to if it matches the given
+// [IPAddress, IPProtocol, portRange] tuple.
+// 
+// 
+// To get more information about ForwardingRule, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/forwardingRule)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules)
 type ForwardingRule struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/globalAddress.go
+++ b/sdk/go/gcp/compute/globalAddress.go
@@ -7,6 +7,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a Global Address resource. Global addresses are used for
+// HTTP(S) load balancing.
+// 
+// 
+// To get more information about GlobalAddress, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/globalAddresses)
+// * How-to Guides
+//     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address)
 type GlobalAddress struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/healthCheck.go
+++ b/sdk/go/gcp/compute/healthCheck.go
@@ -7,6 +7,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Health Checks determine whether instances are responsive and able to do work.
+// They are an important part of a comprehensive load balancing configuration,
+// as they enable monitoring instances behind load balancers.
+// 
+// Health Checks poll instances at a specified interval. Instances that
+// do not respond successfully to some number of probes in a row are marked
+// as unhealthy. No new connections are sent to unhealthy instances,
+// though existing connections will continue. The health check will
+// continue to poll unhealthy instances. If an instance later responds
+// successfully to some number of consecutive probes, it is marked
+// healthy again and can receive new connections.
+// 
+// 
+// To get more information about HealthCheck, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/latest/healthChecks)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/load-balancing/docs/health-checks)
 type HealthCheck struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/httpHealthCheck.go
+++ b/sdk/go/gcp/compute/httpHealthCheck.go
@@ -7,6 +7,22 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// An HttpHealthCheck resource. This resource defines a template for how
+// individual VMs should be checked for health, via HTTP.
+// 
+// 
+// > **Note:** google_compute_http_health_check is a legacy health check.
+// The newer [google_compute_health_check](https://www.terraform.io/docs/providers/google/r/compute_health_check.html)
+// should be preferred for all uses except
+// [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/)
+// which still require the legacy version.
+// 
+// 
+// To get more information about HttpHealthCheck, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/httpHealthChecks)
+// * How-to Guides
+//     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
 type HttpHealthCheck struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/httpsHealthCheck.go
+++ b/sdk/go/gcp/compute/httpsHealthCheck.go
@@ -7,6 +7,22 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// An HttpsHealthCheck resource. This resource defines a template for how
+// individual VMs should be checked for health, via HTTPS.
+// 
+// 
+// > **Note:** google_compute_https_health_check is a legacy health check.
+// The newer [google_compute_health_check](https://www.terraform.io/docs/providers/google/r/compute_health_check.html)
+// should be preferred for all uses except
+// [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/)
+// which still require the legacy version.
+// 
+// 
+// To get more information about HttpsHealthCheck, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/httpsHealthChecks)
+// * How-to Guides
+//     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
 type HttpsHealthCheck struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/instanceGroupManager.go
+++ b/sdk/go/gcp/compute/instanceGroupManager.go
@@ -13,7 +13,7 @@ import (
 // template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/manager)
 // and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers)
 // 
-// ~> **Note:** Use [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
+// > **Note:** Use [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
 type InstanceGroupManager struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/interconnectAttachment.go
+++ b/sdk/go/gcp/compute/interconnectAttachment.go
@@ -8,6 +8,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents an InterconnectAttachment (VLAN attachment) resource. For more
+// information, see Creating VLAN Attachments.
+// 
 type InterconnectAttachment struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/networkPeering.go
+++ b/sdk/go/gcp/compute/networkPeering.go
@@ -13,9 +13,9 @@ import (
 // and
 // [API](https://cloud.google.com/compute/docs/reference/latest/networks).
 // 
-// ~> **Note:** Both network must create a peering with each other for the peering to be functional.
+// > **Note:** Both network must create a peering with each other for the peering to be functional.
 // 
-// ~> **Note:** Subnets IP ranges across peered VPC networks cannot overlap.
+// > **Note:** Subnets IP ranges across peered VPC networks cannot overlap.
 type NetworkPeering struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/projectMetadata.go
+++ b/sdk/go/gcp/compute/projectMetadata.go
@@ -13,7 +13,7 @@ import (
 // and
 // [API](https://cloud.google.com/compute/docs/reference/latest/projects/setCommonInstanceMetadata).
 // 
-// ~> **Note:**  If you want to manage only single key/value pairs within the project metadata
+// > **Note:**  If you want to manage only single key/value pairs within the project metadata
 // rather than the entire set, then use
 // google_compute_project_metadata_item.
 type ProjectMetadata struct {

--- a/sdk/go/gcp/compute/regionAutoscaler.go
+++ b/sdk/go/gcp/compute/regionAutoscaler.go
@@ -8,6 +8,18 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents an Autoscaler resource.
+// 
+// Autoscalers allow you to automatically scale virtual machine instances in
+// managed instance groups according to an autoscaling policy that you
+// define.
+// 
+// 
+// To get more information about RegionAutoscaler, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionAutoscalers)
+// * How-to Guides
+//     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
 type RegionAutoscaler struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/regionBackendService.go
+++ b/sdk/go/gcp/compute/regionBackendService.go
@@ -12,7 +12,7 @@ import (
 // For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/internal/)
 // and [API](https://cloud.google.com/compute/docs/reference/latest/regionBackendServices).
 // 
-// ~> **Note**: Region backend services can only be used when using internal load balancing. For external load balancing, use
+// > **Note**: Region backend services can only be used when using internal load balancing. For external load balancing, use
 //   `google_compute_backend_service` instead.
 type RegionBackendService struct {
 	s *pulumi.ResourceState

--- a/sdk/go/gcp/compute/regionDisk.go
+++ b/sdk/go/gcp/compute/regionDisk.go
@@ -8,6 +8,32 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Persistent disks are durable storage devices that function similarly to
+// the physical disks in a desktop or a server. Compute Engine manages the
+// hardware behind these devices to ensure data redundancy and optimize
+// performance for you. Persistent disks are available as either standard
+// hard disk drives (HDD) or solid-state drives (SSD).
+// 
+// Persistent disks are located independently from your virtual machine
+// instances, so you can detach or move persistent disks to keep your data
+// even after you delete your instances. Persistent disk performance scales
+// automatically with size, so you can resize your existing persistent disks
+// or add more persistent disks to an instance to meet your performance and
+// storage space requirements.
+// 
+// Add a persistent disk to your instance when you need reliable and
+// affordable storage with consistent performance characteristics.
+// 
+// 
+// To get more information about RegionDisk, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/regionDisks)
+// * How-to Guides
+//     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
+// 
+// > **Warning:** All arguments including the disk encryption key will be stored in the raw
+// state as plain-text.
+// [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type RegionDisk struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/regionInstanceGroupManager.go
+++ b/sdk/go/gcp/compute/regionInstanceGroupManager.go
@@ -13,7 +13,7 @@ import (
 // template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups)
 // and [API](https://cloud.google.com/compute/docs/reference/latest/regionInstanceGroupManagers)
 // 
-// ~> **Note:** Use [google_compute_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html) to create a single-zone instance group manager.
+// > **Note:** Use [google_compute_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html) to create a single-zone instance group manager.
 type RegionInstanceGroupManager struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/route.go
+++ b/sdk/go/gcp/compute/route.go
@@ -8,6 +8,34 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a Route resource.
+// 
+// A route is a rule that specifies how certain packets should be handled by
+// the virtual network. Routes are associated with virtual machines by tag,
+// and the set of routes for a particular virtual machine is called its
+// routing table. For each packet leaving a virtual machine, the system
+// searches that virtual machine's routing table for a single best matching
+// route.
+// 
+// Routes match packets by destination IP address, preferring smaller or more
+// specific ranges over larger ones. If there is a tie, the system selects
+// the route with the smallest priority value. If there is still a tie, it
+// uses the layer three and four packet headers to select just one of the
+// remaining matching routes. The packet is then forwarded as specified by
+// the next_hop field of the winning route -- either to another virtual
+// machine destination, a virtual machine gateway or a Compute
+// Engine-operated gateway. Packets that do not match any route in the
+// sending virtual machine's routing table will be dropped.
+// 
+// A Route resource must have exactly one specification of either
+// nextHopGateway, nextHopInstance, nextHopIp, or nextHopVpnTunnel.
+// 
+// 
+// To get more information about Route, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routes)
+// * How-to Guides
+//     * [Using Routes](https://cloud.google.com/vpc/docs/using-routes)
 type Route struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/router.go
+++ b/sdk/go/gcp/compute/router.go
@@ -8,6 +8,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a Router resource.
+// 
+// 
+// To get more information about Router, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routers)
+// * How-to Guides
+//     * [Google Cloud Router](https://cloud.google.com/router/docs/)
 type Router struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/sSLCertificate.go
+++ b/sdk/go/gcp/compute/sSLCertificate.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// An SslCertificate resource, used for HTTPS load balancing. This resource
+// provides a mechanism to upload an SSL key and certificate to
+// the load balancer to serve secure connections from the user.
+// 
+// 
+// To get more information about SslCertificate, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 type SSLCertificate struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/sSLPolicy.go
+++ b/sdk/go/gcp/compute/sSLPolicy.go
@@ -7,6 +7,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a SSL policy. SSL policies give you the ability to control the
+// features of SSL that your SSL proxy or HTTPS load balancer negotiates.
+// 
+// 
+// To get more information about SslPolicy, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies)
+// * How-to Guides
+//     * [Using SSL Policies](https://cloud.google.com/compute/docs/load-balancing/ssl-policies)
 type SSLPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/subnetwork.go
+++ b/sdk/go/gcp/compute/subnetwork.go
@@ -8,6 +8,36 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// A VPC network is a virtual version of the traditional physical networks
+// that exist within and between physical data centers. A VPC network
+// provides connectivity for your Compute Engine virtual machine (VM)
+// instances, Container Engine containers, App Engine Flex services, and
+// other network-related resources.
+// 
+// Each GCP project contains one or more VPC networks. Each VPC network is a
+// global entity spanning all GCP regions. This global VPC network allows VM
+// instances and other resources to communicate with each other via internal,
+// private IP addresses.
+// 
+// Each VPC network is subdivided into subnets, and each subnet is contained
+// within a single region. You can have more than one subnet in a region for
+// a given VPC network. Each subnet has a contiguous private RFC1918 IP
+// space. You create instances, containers, and the like in these subnets.
+// When you create an instance, you must create it in a subnet, and the
+// instance draws its internal IP address from that subnet.
+// 
+// Virtual machine (VM) instances in a VPC network can communicate with
+// instances in all other subnets of the same VPC network, regardless of
+// region, using their RFC1918 private IP addresses. You can isolate portions
+// of the network, even entire subnets, using firewall rules.
+// 
+// 
+// To get more information about Subnetwork, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/subnetworks)
+// * How-to Guides
+//     * [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
+//     * [Cloud Networking](https://cloud.google.com/vpc/docs/using-vpc)
 type Subnetwork struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/subnetworkIAMBinding.go
+++ b/sdk/go/gcp/compute/subnetworkIAMBinding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
-// ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+// > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
 // See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
 // 
 // Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -17,9 +17,9 @@ import (
 // * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
 // * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
 // 
-// ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
 type SubnetworkIAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/subnetworkIAMMember.go
+++ b/sdk/go/gcp/compute/subnetworkIAMMember.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
-// ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+// > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
 // See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
 // 
 // Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -17,9 +17,9 @@ import (
 // * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
 // * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
 // 
-// ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
 type SubnetworkIAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/subnetworkIAMPolicy.go
+++ b/sdk/go/gcp/compute/subnetworkIAMPolicy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
-// ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+// > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
 // See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
 // 
 // Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -17,9 +17,9 @@ import (
 // * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
 // * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
 // 
-// ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
 type SubnetworkIAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetHttpProxy.go
+++ b/sdk/go/gcp/compute/targetHttpProxy.go
@@ -8,6 +8,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a TargetHttpProxy resource, which is used by one or more global
+// forwarding rule to route incoming HTTP requests to a URL map.
+// 
+// 
+// To get more information about TargetHttpProxy, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetHttpProxies)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
 type TargetHttpProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetHttpsProxy.go
+++ b/sdk/go/gcp/compute/targetHttpsProxy.go
@@ -8,6 +8,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a TargetHttpsProxy resource, which is used by one or more
+// global forwarding rule to route incoming HTTPS requests to a URL map.
+// 
+// 
+// To get more information about TargetHttpsProxy, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetHttpsProxies)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
 type TargetHttpsProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetSSLProxy.go
+++ b/sdk/go/gcp/compute/targetSSLProxy.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a TargetSslProxy resource, which is used by one or more
+// global forwarding rule to route incoming SSL requests to a backend
+// service.
+// 
+// 
+// To get more information about TargetSslProxy, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetSslProxies)
+// * How-to Guides
+//     * [Setting Up SSL proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/)
 type TargetSSLProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetTCPProxy.go
+++ b/sdk/go/gcp/compute/targetTCPProxy.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a TargetTcpProxy resource, which is used by one or more
+// global forwarding rule to route incoming TCP requests to a Backend
+// service.
+// 
+// 
+// To get more information about TargetTcpProxy, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetTcpProxies)
+// * How-to Guides
+//     * [Setting Up TCP proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy)
 type TargetTCPProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/vPNGateway.go
+++ b/sdk/go/gcp/compute/vPNGateway.go
@@ -8,6 +8,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Represents a VPN gateway running in GCP. This virtual device is managed
+// by Google, but used only by you.
+// 
+// 
+// To get more information about VpnGateway, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways)
 type VPNGateway struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/vPNTunnel.go
+++ b/sdk/go/gcp/compute/vPNTunnel.go
@@ -8,6 +8,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// VPN tunnel resource.
+// 
+// 
+// To get more information about VpnTunnel, see:
+// 
+// * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels)
+// * How-to Guides
+//     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
+//     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
+// 
+// > **Warning:** All arguments including the shared secret will be stored in the raw
+// state as plain-text.
+// [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type VPNTunnel struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/container/cluster.go
+++ b/sdk/go/gcp/container/cluster.go
@@ -12,7 +12,7 @@ import (
 // and
 // [API](https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters).
 // 
-// ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 type Cluster struct {
 	s *pulumi.ResourceState

--- a/sdk/go/gcp/containeranalysis/note.go
+++ b/sdk/go/gcp/containeranalysis/note.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// Provides a detailed description of a Note.
+// 
+// > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+// See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+// 
+// To get more information about Note, see:
+// 
+// * [API documentation](https://cloud.google.com/container-analysis/api/reference/rest/)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/container-analysis/)
 type Note struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/dns/recordSet.go
+++ b/sdk/go/gcp/dns/recordSet.go
@@ -11,7 +11,7 @@ import (
 // Manages a set of DNS records within Google Cloud DNS. For more information see [the official documentation](https://cloud.google.com/dns/records/) and
 // [API](https://cloud.google.com/dns/api/v1/resourceRecordSets).
 // 
-// ~> **Note:** The Google Cloud DNS API requires NS records be present at all
+// > **Note:** The Google Cloud DNS API requires NS records be present at all
 // times. To accommodate this, when creating NS records, the default records
 // Google automatically creates will be silently overwritten.  Also, when
 // destroying NS records, Terraform will not actually remove NS records, but will

--- a/sdk/go/gcp/filestore/instance.go
+++ b/sdk/go/gcp/filestore/instance.go
@@ -8,6 +8,18 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// A Google Cloud Filestore instance.
+// 
+// > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+// See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+// 
+// To get more information about Instance, see:
+// 
+// * [API documentation](https://cloud.google.com/filestore/docs/reference/rest/v1beta1/projects.locations.instances/create)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/filestore/docs/creating-instances)
+//     * [Use with Kubernetes](https://cloud.google.com/filestore/docs/accessing-fileshares)
+//     * [Copying Data In/Out](https://cloud.google.com/filestore/docs/copying-data)
 type Instance struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/folder/iAMBinding.go
+++ b/sdk/go/gcp/folder/iAMBinding.go
@@ -11,7 +11,7 @@ import (
 // Allows creation and management of a single binding within IAM policy for
 // an existing Google Cloud Platform folder.
 // 
-// ~> **Note:** This resource _must not_ be used in conjunction with
+// > **Note:** This resource _must not_ be used in conjunction with
 //    `google_folder_iam_policy` or they will fight over what your policy
 //    should be.
 type IAMBinding struct {

--- a/sdk/go/gcp/folder/iAMMember.go
+++ b/sdk/go/gcp/folder/iAMMember.go
@@ -11,7 +11,7 @@ import (
 // Allows creation and management of a single member for a single binding within
 // the IAM policy for an existing Google Cloud Platform folder.
 // 
-// ~> **Note:** This resource _must not_ be used in conjunction with
+// > **Note:** This resource _must not_ be used in conjunction with
 //    `google_folder_iam_policy` or they will fight over what your policy
 //    should be. Similarly, roles controlled by `google_folder_iam_binding`
 //    should not be assigned to using `google_folder_iam_member`.

--- a/sdk/go/gcp/kms/cryptoKey.go
+++ b/sdk/go/gcp/kms/cryptoKey.go
@@ -16,7 +16,7 @@ import (
 // A CryptoKey is an interface to key material which can be used to encrypt and decrypt data. A CryptoKey belongs to a
 // Google Cloud KMS KeyRing.
 // 
-// ~> Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a
+// > Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a
 // Terraform-managed CryptoKey will remove it from state and delete all
 // CryptoKeyVersions, rendering the key unusable, but **will not delete the
 // resource on the server**. When Terraform destroys these keys, any data

--- a/sdk/go/gcp/kms/cryptoKeyIAMMember.go
+++ b/sdk/go/gcp/kms/cryptoKeyIAMMember.go
@@ -11,7 +11,7 @@ import (
 // Allows creation and management of a single member for a single binding within
 // the IAM policy for an existing Google Cloud KMS crypto key.
 // 
-// ~> **Note:** This resource _must not_ be used in conjunction with
+// > **Note:** This resource _must not_ be used in conjunction with
 //    `google_kms_crypto_key_iam_policy` or they will fight over what your policy
 //    should be. Similarly, roles controlled by `google_kms_crypto_key_iam_binding`
 //    should not be assigned to using `google_kms_crypto_key_iam_member`.

--- a/sdk/go/gcp/kms/getKMSSecret.go
+++ b/sdk/go/gcp/kms/getKMSSecret.go
@@ -13,7 +13,7 @@ import (
 // For more information see
 // [the official documentation](https://cloud.google.com/kms/docs/encrypt-decrypt).
 // 
-// ~> **NOTE**: Using this data provider will allow you to conceal secret data within your
+// > **NOTE**: Using this data provider will allow you to conceal secret data within your
 // resource definitions, but it does not take care of protecting that data in the
 // logging output, plan output, or state output.  Please take care to secure your secret
 // data outside of resource definitions.

--- a/sdk/go/gcp/kms/keyRing.go
+++ b/sdk/go/gcp/kms/keyRing.go
@@ -16,7 +16,7 @@ import (
 // A KeyRing is a grouping of CryptoKeys for organizational purposes. A KeyRing belongs to a Google Cloud Platform Project
 // and resides in a specific location.
 // 
-// ~> Note: KeyRings cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyRing will remove it
+// > Note: KeyRings cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyRing will remove it
 // from state but **will not delete the resource on the server**.
 type KeyRing struct {
 	s *pulumi.ResourceState

--- a/sdk/go/gcp/kms/keyRingIAMBinding.go
+++ b/sdk/go/gcp/kms/keyRingIAMBinding.go
@@ -14,9 +14,9 @@ import (
 // * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
 // * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
 // 
-// ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
 type KeyRingIAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/kms/keyRingIAMMember.go
+++ b/sdk/go/gcp/kms/keyRingIAMMember.go
@@ -14,9 +14,9 @@ import (
 // * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
 // * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
 // 
-// ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
 type KeyRingIAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/kms/keyRingIAMPolicy.go
+++ b/sdk/go/gcp/kms/keyRingIAMPolicy.go
@@ -14,9 +14,9 @@ import (
 // * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
 // * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
 // 
-// ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
 type KeyRingIAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/logging/billingAccountSink.go
+++ b/sdk/go/gcp/logging/billingAccountSink.go
@@ -12,7 +12,7 @@ import (
 // [the official documentation](https://cloud.google.com/logging/docs/) and
 // [Exporting Logs in the API](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
 // 
-// ~> **Note** You must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
+// > **Note** You must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
 // [granted on the billing account](https://cloud.google.com/billing/reference/rest/v1/billingAccounts/getIamPolicy) to
 // the credentials used with Terraform. [IAM roles granted on a billing account](https://cloud.google.com/billing/docs/how-to/billing-access) are separate from the
 // typical IAM roles granted on a project.

--- a/sdk/go/gcp/logging/projectSink.go
+++ b/sdk/go/gcp/logging/projectSink.go
@@ -14,9 +14,9 @@ import (
 // and
 // [API](https://cloud.google.com/logging/docs/reference/v2/rest/).
 // 
-// ~> **Note:** You must have [granted the "Logs Configuration Writer"](https://cloud.google.com/logging/docs/access-control) IAM role (`roles/logging.configWriter`) to the credentials used with terraform.
+// > **Note:** You must have [granted the "Logs Configuration Writer"](https://cloud.google.com/logging/docs/access-control) IAM role (`roles/logging.configWriter`) to the credentials used with terraform.
 // 
-// ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
+// > **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 type ProjectSink struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/monitoring/alertPolicy.go
+++ b/sdk/go/gcp/monitoring/alertPolicy.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// A description of the conditions under which some aspect of your system is
+// considered to be "unhealthy" and the ways to notify people or services
+// about this state.
+// 
+// 
+// To get more information about AlertPolicy, see:
+// 
+// * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/monitoring/alerts/)
 type AlertPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/organizations/getFolder.go
+++ b/sdk/go/gcp/organizations/getFolder.go
@@ -10,6 +10,26 @@ import (
 // Use this data source to get information about a Google Cloud Folder.
 // 
 // ```hcl
+// # Get folder by id
+// data "google_folder" "my_folder_1" {
+//   folder = "folders/12345"
+//   lookup_organization = true
+// }
+// 
+// # Search by fields
+// data "google_folder" "my_folder_2" {
+//   folder = "folders/23456"
+// }
+// 
+// output "my_folder_1_organization" {
+//   value = "${data.google_folder.my_folder_1.organization}"
+// }
+// 
+// output "my_folder_2_parent" {
+//   value = "${data.google_folder.my_folder_2.parent}"
+// }
+// 
+// ```
 func LookupFolder(ctx *pulumi.Context, args *GetFolderArgs) (*GetFolderResult, error) {
 	inputs := make(map[string]interface{})
 	if args != nil {

--- a/sdk/go/gcp/organizations/iAMBinding.go
+++ b/sdk/go/gcp/organizations/iAMBinding.go
@@ -11,7 +11,7 @@ import (
 // Allows creation and management of a single binding within IAM policy for
 // an existing Google Cloud Platform Organization.
 // 
-// ~> **Note:** This resource __must not__ be used in conjunction with
+// > **Note:** This resource __must not__ be used in conjunction with
 //    `google_organization_iam_member` for the __same role__ or they will fight over
 //    what your policy should be.
 type IAMBinding struct {

--- a/sdk/go/gcp/organizations/iAMCustomRole.go
+++ b/sdk/go/gcp/organizations/iAMCustomRole.go
@@ -13,7 +13,7 @@ import (
 // and
 // [API](https://cloud.google.com/iam/reference/rest/v1/organizations.roles).
 // 
-// ~> **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
+// > **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
 //  from this and how roles are propagated. 1) creating a role may involve undeleting and then updating a role with the
 //  same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
 //  after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is

--- a/sdk/go/gcp/organizations/iAMMember.go
+++ b/sdk/go/gcp/organizations/iAMMember.go
@@ -11,7 +11,7 @@ import (
 // Allows creation and management of a single member for a single binding within
 // the IAM policy for an existing Google Cloud Platform Organization.
 // 
-// ~> **Note:** This resource __must not__ be used in conjunction with
+// > **Note:** This resource __must not__ be used in conjunction with
 //    `google_organization_iam_binding` for the __same role__ or they will fight over
 //    what your policy should be.
 type IAMMember struct {

--- a/sdk/go/gcp/organizations/iAMPolicy.go
+++ b/sdk/go/gcp/organizations/iAMPolicy.go
@@ -10,7 +10,7 @@ import (
 
 // Allows management of the entire IAM policy for an existing Google Cloud Platform Organization.
 // 
-// ~> **Warning:** New organizations have several default policies which will,
+// > **Warning:** New organizations have several default policies which will,
 //    without extreme caution, be **overwritten** by use of this resource.
 //    The safest alternative is to use multiple `google_organization_iam_binding`
 //    resources.  It is easy to use this resource to remove your own access to
@@ -19,7 +19,7 @@ import (
 //    the best way to be sure that you are not making dangerous changes is to start
 //    by importing your existing policy, and examining the diff very closely.
 // 
-// ~> **Note:** This resource __must not__ be used in conjunction with
+// > **Note:** This resource __must not__ be used in conjunction with
 //    `google_organization_iam_member` or `google_organization_iam_binding`
 //    or they will fight over what your policy should be.
 type IAMPolicy struct {

--- a/sdk/go/gcp/organizations/project.go
+++ b/sdk/go/gcp/organizations/project.go
@@ -32,7 +32,7 @@ import (
 //   used just like always, keeping in mind that Terraform will attempt to undo any changes
 //   made outside Terraform.
 // 
-// ~> It's important to note that any project resources that were added to your Terraform config
+// > It's important to note that any project resources that were added to your Terraform config
 // prior to 0.8.5 will continue to function as they always have, and will not be managed by
 // Terraform. Only newly added projects are affected.
 type Project struct {

--- a/sdk/go/gcp/projects/iAMBinding.go
+++ b/sdk/go/gcp/projects/iAMBinding.go
@@ -14,9 +14,9 @@ import (
 // * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
 // * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
 // 
-// ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
 type IAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/projects/iAMCustomRole.go
+++ b/sdk/go/gcp/projects/iAMCustomRole.go
@@ -13,7 +13,7 @@ import (
 // and
 // [API](https://cloud.google.com/iam/reference/rest/v1/projects.roles).
 // 
-// ~> **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
+// > **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
 //  from this and how roles are propagated. 1) creating a role may involve undeleting and then updating a role with the
 //  same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
 //  after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is

--- a/sdk/go/gcp/projects/iAMMember.go
+++ b/sdk/go/gcp/projects/iAMMember.go
@@ -14,9 +14,9 @@ import (
 // * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
 // * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
 // 
-// ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
 type IAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/projects/iAMPolicy.go
+++ b/sdk/go/gcp/projects/iAMPolicy.go
@@ -14,9 +14,9 @@ import (
 // * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
 // * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
 // 
-// ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
 type IAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/projects/service.go
+++ b/sdk/go/gcp/projects/service.go
@@ -13,7 +13,7 @@ import (
 // For a list of services available, visit the
 // [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
 // 
-// ~> **Note:** This resource _must not_ be used in conjunction with
+// > **Note:** This resource _must not_ be used in conjunction with
 //    `google_project_services` or they will fight over which services should be enabled.
 type Service struct {
 	s *pulumi.ResourceState

--- a/sdk/go/gcp/projects/services.go
+++ b/sdk/go/gcp/projects/services.go
@@ -15,7 +15,7 @@ import (
 // For a list of services available, visit the
 // [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
 // 
-// ~> **Note:** This resource attempts to be the authoritative source on *all* enabled APIs, which often
+// > **Note:** This resource attempts to be the authoritative source on *all* enabled APIs, which often
 // 	leads to conflicts when certain actions enable other APIs. If you do not need to ensure that
 // 	*exclusively* a particular set of APIs are enabled, you should most likely use the
 // 	google_project_service resource, one resource per API.

--- a/sdk/go/gcp/projects/usageExportBucket.go
+++ b/sdk/go/gcp/projects/usageExportBucket.go
@@ -32,7 +32,7 @@ import (
 //   used just like always, keeping in mind that Terraform will attempt to undo any changes
 //   made outside Terraform.
 // 
-// ~> It's important to note that any project resources that were added to your Terraform config
+// > It's important to note that any project resources that were added to your Terraform config
 // prior to 0.8.5 will continue to function as they always have, and will not be managed by
 // Terraform. Only newly added projects are affected.
 type UsageExportBucket struct {

--- a/sdk/go/gcp/pubsub/subscriptionIAMBinding.go
+++ b/sdk/go/gcp/pubsub/subscriptionIAMBinding.go
@@ -14,9 +14,9 @@ import (
 // * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
 // * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
 // 
-// ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
 type SubscriptionIAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/pubsub/subscriptionIAMMember.go
+++ b/sdk/go/gcp/pubsub/subscriptionIAMMember.go
@@ -14,9 +14,9 @@ import (
 // * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
 // * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
 // 
-// ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
 type SubscriptionIAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/pubsub/subscriptionIAMPolicy.go
+++ b/sdk/go/gcp/pubsub/subscriptionIAMPolicy.go
@@ -14,9 +14,9 @@ import (
 // * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
 // * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
 // 
-// ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
 type SubscriptionIAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/pubsub/topicIAMBinding.go
+++ b/sdk/go/gcp/pubsub/topicIAMBinding.go
@@ -14,9 +14,9 @@ import (
 // * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
 // * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
 // 
-// ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
 type TopicIAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/pubsub/topicIAMMember.go
+++ b/sdk/go/gcp/pubsub/topicIAMMember.go
@@ -14,9 +14,9 @@ import (
 // * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
 // * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
 // 
-// ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
 type TopicIAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/pubsub/topicIAMPolicy.go
+++ b/sdk/go/gcp/pubsub/topicIAMPolicy.go
@@ -14,9 +14,9 @@ import (
 // * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
 // * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
 // 
-// ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
 type TopicIAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/redis/instance.go
+++ b/sdk/go/gcp/redis/instance.go
@@ -8,6 +8,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// A Google Cloud Redis instance.
+// 
+// 
+// To get more information about Instance, see:
+// 
+// * [API documentation](https://cloud.google.com/memorystore/docs/redis/reference/rest/)
+// * How-to Guides
+//     * [Official Documentation](https://cloud.google.com/memorystore/docs/redis/)
 type Instance struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/resourcemanager/lien.go
+++ b/sdk/go/gcp/resourcemanager/lien.go
@@ -8,6 +8,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+// A Lien represents an encumbrance on the actions that can be performed on a resource.
+// 
+// 
 type Lien struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/serviceAccount/iAMBinding.go
+++ b/sdk/go/gcp/serviceAccount/iAMBinding.go
@@ -16,9 +16,9 @@ import (
 // * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
 // * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
 // 
-// ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
 type IAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/serviceAccount/iAMMember.go
+++ b/sdk/go/gcp/serviceAccount/iAMMember.go
@@ -16,9 +16,9 @@ import (
 // * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
 // * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
 // 
-// ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
 type IAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/serviceAccount/iAMPolicy.go
+++ b/sdk/go/gcp/serviceAccount/iAMPolicy.go
@@ -16,9 +16,9 @@ import (
 // * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
 // * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
 // 
-// ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
 type IAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/databaseIAMBinding.go
+++ b/sdk/go/gcp/spanner/databaseIAMBinding.go
@@ -12,14 +12,14 @@ import (
 // 
 // * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
 // 
-// ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+// > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
 // 
 // * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
 // * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
 // 
-// ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
 type DatabaseIAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/databaseIAMMember.go
+++ b/sdk/go/gcp/spanner/databaseIAMMember.go
@@ -12,14 +12,14 @@ import (
 // 
 // * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
 // 
-// ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+// > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
 // 
 // * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
 // * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
 // 
-// ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
 type DatabaseIAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/databaseIAMPolicy.go
+++ b/sdk/go/gcp/spanner/databaseIAMPolicy.go
@@ -12,14 +12,14 @@ import (
 // 
 // * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
 // 
-// ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+// > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
 // 
 // * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
 // * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
 // 
-// ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
 type DatabaseIAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/instanceIAMBinding.go
+++ b/sdk/go/gcp/spanner/instanceIAMBinding.go
@@ -12,14 +12,14 @@ import (
 // 
 // * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
 // 
-// ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+// > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
 // 
 // * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
 // * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
 // 
-// ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
 type InstanceIAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/instanceIAMMember.go
+++ b/sdk/go/gcp/spanner/instanceIAMMember.go
@@ -12,14 +12,14 @@ import (
 // 
 // * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
 // 
-// ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+// > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
 // 
 // * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
 // * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
 // 
-// ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
 type InstanceIAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/instanceIAMPolicy.go
+++ b/sdk/go/gcp/spanner/instanceIAMPolicy.go
@@ -12,14 +12,14 @@ import (
 // 
 // * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
 // 
-// ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+// > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
 // 
 // * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
 // * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
 // 
-// ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+// > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
 // 
-// ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
 type InstanceIAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/sql/databaseInstance.go
+++ b/sdk/go/gcp/sql/databaseInstance.go
@@ -11,7 +11,7 @@ import (
 // Creates a new Google SQL Database Instance. For more information, see the [official documentation](https://cloud.google.com/sql/),
 // or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/instances).
 // 
-// ~> **NOTE on `google_sql_database_instance`:** - Second-generation instances include a
+// > **NOTE on `google_sql_database_instance`:** - Second-generation instances include a
 // default 'root'@'%' user with no password. This user will be deleted by Terraform on
 // instance creation. You should use `google_sql_user` to define a custom user with
 // a restricted host and strong password.

--- a/sdk/go/gcp/sql/user.go
+++ b/sdk/go/gcp/sql/user.go
@@ -10,7 +10,7 @@ import (
 
 // Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
 // 
-// ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+// > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html). Passwords will not be retrieved when running
 // "terraform import".
 type User struct {

--- a/sdk/go/gcp/storage/bucketIAMBinding.go
+++ b/sdk/go/gcp/storage/bucketIAMBinding.go
@@ -15,7 +15,7 @@ import (
 // * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
 // 
 // 
-// ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
 type BucketIAMBinding struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/storage/bucketIAMMember.go
+++ b/sdk/go/gcp/storage/bucketIAMMember.go
@@ -15,7 +15,7 @@ import (
 // * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
 // 
 // 
-// ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
 type BucketIAMMember struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/storage/bucketIAMPolicy.go
+++ b/sdk/go/gcp/storage/bucketIAMPolicy.go
@@ -15,7 +15,7 @@ import (
 // * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
 // 
 // 
-// ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+// > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
 type BucketIAMPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/nodejs/appengine/application.ts
+++ b/sdk/nodejs/appengine/application.ts
@@ -7,7 +7,7 @@ import * as utilities from "../utilities";
 /**
  * Allows creation and management of an App Engine application.
  * 
- * ~> App Engine applications cannot be deleted once they're created; you have to delete the
+ * > App Engine applications cannot be deleted once they're created; you have to delete the
  *    entire project to delete the application. Terraform will report the application has been
  *    successfully deleted; this is a limitation of Terraform, and will go away in the future.
  *    Terraform is not able to delete App Engine applications.
@@ -21,8 +21,8 @@ export class Application extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ApplicationState): Application {
-        return new Application(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ApplicationState, opts?: pulumi.CustomResourceOptions): Application {
+        return new Application(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/bigquery/dataset.ts
+++ b/sdk/nodejs/bigquery/dataset.ts
@@ -9,6 +9,34 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/bigquery/docs/) and
  * [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_bigquery_dataset_default = new gcp.bigquery.Dataset("default", {
+ *     accesses: [
+ *         {
+ *             domain: "example.com",
+ *             role: "READER",
+ *         },
+ *         {
+ *             groupByEmail: "writers@example.com",
+ *             role: "WRITER",
+ *         },
+ *     ],
+ *     datasetId: "foo",
+ *     defaultTableExpirationMs: 3600000,
+ *     description: "This is a test description",
+ *     friendlyName: "test",
+ *     labels: {
+ *         env: "default",
+ *     },
+ *     location: "EU",
+ * });
+ * ```
  */
 export class Dataset extends pulumi.CustomResource {
     /**
@@ -19,8 +47,8 @@ export class Dataset extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatasetState): Dataset {
-        return new Dataset(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatasetState, opts?: pulumi.CustomResourceOptions): Dataset {
+        return new Dataset(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/bigquery/table.ts
+++ b/sdk/nodejs/bigquery/table.ts
@@ -9,6 +9,36 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/bigquery/docs/) and
  * [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * import * as fs from "fs";
+ * 
+ * const google_bigquery_dataset_default = new gcp.bigquery.Dataset("default", {
+ *     datasetId: "foo",
+ *     defaultTableExpirationMs: 3600000,
+ *     description: "This is a test description",
+ *     friendlyName: "test",
+ *     labels: {
+ *         env: "default",
+ *     },
+ *     location: "EU",
+ * });
+ * const google_bigquery_table_default = new gcp.bigquery.Table("default", {
+ *     datasetId: google_bigquery_dataset_default.datasetId,
+ *     labels: {
+ *         env: "default",
+ *     },
+ *     schema: fs.readFileSync("schema.json", "utf-8"),
+ *     tableId: "bar",
+ *     timePartitioning: {
+ *         type: "DAY",
+ *     },
+ * });
+ * ```
  */
 export class Table extends pulumi.CustomResource {
     /**
@@ -19,8 +49,8 @@ export class Table extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TableState): Table {
-        return new Table(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TableState, opts?: pulumi.CustomResourceOptions): Table {
+        return new Table(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/bigtable/instance.ts
+++ b/sdk/nodejs/bigtable/instance.ts
@@ -9,6 +9,23 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/bigtable/) and
  * [API](https://cloud.google.com/bigtable/docs/go/reference).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_bigtable_instance_instance = new gcp.bigtable.Instance("instance", {
+ *     cluster: {
+ *         clusterId: "tf-instance-cluster",
+ *         numNodes: 3,
+ *         storageType: "HDD",
+ *         zone: "us-central1-b",
+ *     },
+ *     name: "tf-instance",
+ * });
+ * ```
  */
 export class Instance extends pulumi.CustomResource {
     /**
@@ -19,8 +36,8 @@ export class Instance extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState): Instance {
-        return new Instance(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState, opts?: pulumi.CustomResourceOptions): Instance {
+        return new Instance(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/bigtable/table.ts
+++ b/sdk/nodejs/bigtable/table.ts
@@ -9,6 +9,30 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/bigtable/) and
  * [API](https://cloud.google.com/bigtable/docs/go/reference).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_bigtable_instance_instance = new gcp.bigtable.Instance("instance", {
+ *     clusterId: "tf-instance-cluster",
+ *     name: "tf-instance",
+ *     numNodes: 3,
+ *     storageType: "HDD",
+ *     zone: "us-central1-b",
+ * });
+ * const google_bigtable_table_table = new gcp.bigtable.Table("table", {
+ *     instanceName: google_bigtable_instance_instance.name,
+ *     name: "tf-table",
+ *     splitKeys: [
+ *         "a",
+ *         "b",
+ *         "c",
+ *     ],
+ * });
+ * ```
  */
 export class Table extends pulumi.CustomResource {
     /**
@@ -19,8 +43,8 @@ export class Table extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TableState): Table {
-        return new Table(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TableState, opts?: pulumi.CustomResourceOptions): Table {
+        return new Table(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/binaryauthorization/attestor.ts
+++ b/sdk/nodejs/binaryauthorization/attestor.ts
@@ -4,6 +4,43 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * An attestor that attests to container image artifacts.
+ * 
+ * > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+ * See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+ * 
+ * To get more information about Attestor, see:
+ * 
+ * * [API documentation](https://cloud.google.com/binary-authorization/docs/reference/rest/)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/binary-authorization/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_container_analysis_note_note = new gcp.containeranalysis.Note("note", {
+ *     attestationAuthority: {
+ *         hint: {
+ *             humanReadableName: "Attestor Note",
+ *         },
+ *     },
+ *     name: "test-attestor-note",
+ * });
+ * const google_binary_authorization_attestor_attestor = new gcp.binaryauthorization.Attestor("attestor", {
+ *     attestationAuthorityNote: {
+ *         noteReference: google_container_analysis_note_note.name,
+ *         publicKeys: [{
+ *             asciiArmoredPgpPublicKey: "mQENBFtP0doBCADF+joTiXWKVuP8kJt3fgpBSjT9h8ezMfKA4aXZctYLx5wslWQl\nbB7Iu2ezkECNzoEeU7WxUe8a61pMCh9cisS9H5mB2K2uM4Jnf8tgFeXn3akJDVo0\noR1IC+Dp9mXbRSK3MAvKkOwWlG99sx3uEdvmeBRHBOO+grchLx24EThXFOyP9Fk6\nV39j6xMjw4aggLD15B4V0v9JqBDdJiIYFzszZDL6pJwZrzcP0z8JO4rTZd+f64bD\nMpj52j/pQfA8lZHOaAgb1OrthLdMrBAjoDjArV4Ek7vSbrcgYWcI6BhsQrFoxKdX\n83TZKai55ZCfCLIskwUIzA1NLVwyzCS+fSN/ABEBAAG0KCJUZXN0IEF0dGVzdG9y\nIiA8ZGFuYWhvZmZtYW5AZ29vZ2xlLmNvbT6JAU4EEwEIADgWIQRfWkqHt6hpTA1L\nuY060eeM4dc66AUCW0/R2gIbLwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRA6\n0eeM4dc66HdpCAC4ot3b0OyxPb0Ip+WT2U0PbpTBPJklesuwpIrM4Lh0N+1nVRLC\n51WSmVbM8BiAFhLbN9LpdHhds1kUrHF7+wWAjdR8sqAj9otc6HGRM/3qfa2qgh+U\nWTEk/3us/rYSi7T7TkMuutRMIa1IkR13uKiW56csEMnbOQpn9rDqwIr5R8nlZP5h\nMAU9vdm1DIv567meMqTaVZgR3w7bck2P49AO8lO5ERFpVkErtu/98y+rUy9d789l\n+OPuS1NGnxI1YKsNaWJF4uJVuvQuZ1twrhCbGNtVorO2U12+cEq+YtUxj7kmdOC1\nqoIRW6y0+UlAc+MbqfL0ziHDOAmcqz1GnROg\n=6Bvm\n",
+ *         }],
+ *     },
+ *     name: "test-attestor",
+ * });
+ * ```
+ */
 export class Attestor extends pulumi.CustomResource {
     /**
      * Get an existing Attestor resource's state with the given name, ID, and optional extra
@@ -13,8 +50,8 @@ export class Attestor extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AttestorState): Attestor {
-        return new Attestor(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AttestorState, opts?: pulumi.CustomResourceOptions): Attestor {
+        return new Attestor(name, <any>state, { ...opts, id: id });
     }
 
     public readonly attestationAuthorityNote: pulumi.Output<{ delegationServiceAccountEmail: string, noteReference: string, publicKeys?: { asciiArmoredPgpPublicKey: string, comment?: string, id: string }[] }>;

--- a/sdk/nodejs/binaryauthorization/policy.ts
+++ b/sdk/nodejs/binaryauthorization/policy.ts
@@ -4,6 +4,55 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * A policy for container image binary authorization.
+ * 
+ * > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+ * See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+ * 
+ * To get more information about Policy, see:
+ * 
+ * * [API documentation](https://cloud.google.com/binary-authorization/docs/reference/rest/)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/binary-authorization/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_container_analysis_note_note = new gcp.containeranalysis.Note("note", {
+ *     attestationAuthority: {
+ *         hint: {
+ *             humanReadableName: "My attestor",
+ *         },
+ *     },
+ *     name: "test-attestor-note",
+ * });
+ * const google_binary_authorization_attestor_attestor = new gcp.binaryauthorization.Attestor("attestor", {
+ *     attestationAuthorityNote: {
+ *         noteReference: google_container_analysis_note_note.name,
+ *     },
+ *     name: "test-attestor",
+ * });
+ * const google_binary_authorization_policy_policy = new gcp.binaryauthorization.Policy("policy", {
+ *     admissionWhitelistPatterns: [{
+ *         namePattern: "gcr.io/google_containers/*",
+ *     }],
+ *     clusterAdmissionRules: [{
+ *         cluster: "us-central1-a.prod-cluster",
+ *         enforcementMode: "ENFORCED_BLOCK_AND_AUDIT_LOG",
+ *         evaluationMode: "REQUIRE_ATTESTATION",
+ *         requireAttestationsBies: [google_binary_authorization_attestor_attestor.name],
+ *     }],
+ *     defaultAdmissionRule: {
+ *         enforcementMode: "ENFORCED_BLOCK_AND_AUDIT_LOG",
+ *         evaluationMode: "ALWAYS_ALLOW",
+ *     },
+ * });
+ * ```
+ */
 export class Policy extends pulumi.CustomResource {
     /**
      * Get an existing Policy resource's state with the given name, ID, and optional extra
@@ -13,8 +62,8 @@ export class Policy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: PolicyState): Policy {
-        return new Policy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: PolicyState, opts?: pulumi.CustomResourceOptions): Policy {
+        return new Policy(name, <any>state, { ...opts, id: id });
     }
 
     public readonly admissionWhitelistPatterns: pulumi.Output<{ namePattern?: string }[] | undefined>;

--- a/sdk/nodejs/cloudbuild/trigger.ts
+++ b/sdk/nodejs/cloudbuild/trigger.ts
@@ -9,6 +9,46 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/container-builder/docs/running-builds/automate-builds)
  * and
  * [API](https://godoc.org/google.golang.org/api/cloudbuild/v1#BuildTrigger).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_cloudbuild_trigger_build_trigger = new gcp.cloudbuild.Trigger("build_trigger", {
+ *     build: {
+ *         images: ["gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"],
+ *         steps: [{
+ *             args: "build -t gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA -f Dockerfile .",
+ *             name: "gcr.io/cloud-builders/docker",
+ *         }],
+ *     },
+ *     project: "my-project",
+ *     triggerTemplate: {
+ *         branchName: "master",
+ *         project: "my-project",
+ *         repoName: "some-repo",
+ *     },
+ * });
+ * ```
+ * OR
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_cloudbuild_trigger_build_trigger = new gcp.cloudbuild.Trigger("build_trigger", {
+ *     filename: "cloudbuild.yaml",
+ *     project: "my-project",
+ *     triggerTemplate: {
+ *         branchName: "master",
+ *         project: "my-project",
+ *         repoName: "some-repo",
+ *     },
+ * });
+ * ```
+ * 
  */
 export class Trigger extends pulumi.CustomResource {
     /**
@@ -19,8 +59,8 @@ export class Trigger extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TriggerState): Trigger {
-        return new Trigger(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TriggerState, opts?: pulumi.CustomResourceOptions): Trigger {
+        return new Trigger(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/cloudfunctions/function.ts
+++ b/sdk/nodejs/cloudfunctions/function.ts
@@ -9,6 +9,38 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/functions/docs/)
  * and
  * [API](https://cloud.google.com/functions/docs/apis).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_bucket = new gcp.storage.Bucket("bucket", {
+ *     name: "test-bucket",
+ * });
+ * const google_storage_bucket_object_archive = new gcp.storage.BucketObject("archive", {
+ *     bucket: google_storage_bucket_bucket.name,
+ *     name: "index.zip",
+ *     source: new pulumi.asset.FileArchive("./path/to/zip/file/which/contains/code"),
+ * });
+ * const google_cloudfunctions_function_function = new gcp.cloudfunctions.Function("function", {
+ *     availableMemoryMb: 128,
+ *     description: "My function",
+ *     entryPoint: "helloGET",
+ *     environmentVariables: {
+ *         MY_ENV_VAR: "my-env-var-value",
+ *     },
+ *     labels: {
+ *         my-label: "my-label-value",
+ *     },
+ *     name: "function-test",
+ *     sourceArchiveBucket: google_storage_bucket_bucket.name,
+ *     sourceArchiveObject: google_storage_bucket_object_archive.name,
+ *     timeout: 60,
+ *     triggerHttp: true,
+ * });
+ * ```
  */
 export class Function extends pulumi.CustomResource {
     /**
@@ -19,8 +51,8 @@ export class Function extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FunctionState): Function {
-        return new Function(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FunctionState, opts?: pulumi.CustomResourceOptions): Function {
+        return new Function(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/cloudfunctions/getFunction.ts
+++ b/sdk/nodejs/cloudfunctions/getFunction.ts
@@ -8,6 +8,17 @@ import * as utilities from "../utilities";
  * Get information about a Google Cloud Function. For more information see
  * the [official documentation](https://cloud.google.com/functions/docs/)
  * and [API](https://cloud.google.com/functions/docs/apis).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_cloudfunctions_function_my_function = pulumi.output(gcp.cloudfunctions.getFunction({
+ *     name: "function",
+ * }));
+ * ```
  */
 export function getFunction(args: GetFunctionArgs, opts?: pulumi.InvokeOptions): Promise<GetFunctionResult> {
     return pulumi.runtime.invoke("gcp:cloudfunctions/getFunction:getFunction", {

--- a/sdk/nodejs/compute/address.ts
+++ b/sdk/nodejs/compute/address.ts
@@ -4,6 +4,89 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents an Address resource.
+ * 
+ * Each virtual machine instance has an ephemeral internal IP address and,
+ * optionally, an external IP address. To communicate between instances on
+ * the same network, you can use an instance's internal IP address. To
+ * communicate with the Internet and instances outside of the same network,
+ * you must specify the instance's external IP address.
+ * 
+ * Internal IP addresses are ephemeral and only belong to an instance for
+ * the lifetime of the instance; if the instance is deleted and recreated,
+ * the instance is assigned a new internal IP address, either by Compute
+ * Engine or by you. External IP addresses can be either ephemeral or
+ * static.
+ * 
+ * 
+ * To get more information about Address, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/beta/addresses)
+ * * How-to Guides
+ *     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/instances-and-network)
+ *     * [Reserving a Static Internal IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_address_ip_address = new gcp.compute.Address("ip_address", {
+ *     name: "my-address",
+ * });
+ * ```
+ * resource "google_compute_network" "default" {
+ *   name = "my-network"
+ * }
+ * 
+ * resource "google_compute_subnetwork" "default" {
+ *   name          = "my-subnet"
+ *   ip_cidr_range = "10.0.0.0/16"
+ *   region        = "us-central1"
+ *   network       = "${google_compute_network.default.self_link}"
+ * }
+ * 
+ * resource "google_compute_address" "internal_with_subnet_and_address" {
+ *   name         = "my-internal-address"
+ *   subnetwork   = "${google_compute_subnetwork.default.self_link}"
+ *   address_type = "INTERNAL"
+ *   address      = "10.0.42.42"
+ *   region       = "us-central1"
+ * }
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * 
+ * ```
+ *   name = "ipv4-address"
+ * }
+ * 
+ * data "google_compute_image" "debian_image" {
+ * 	family  = "debian-9"
+ * 	project = "debian-cloud"
+ * }
+ * 
+ * resource "google_compute_instance" "instance_with_ip" {
+ * 	name         = "vm-instance"
+ * 	machine_type = "f1-micro"
+ * 	zone         = "us-central1-a"
+ * 
+ * 	boot_disk {
+ * 		initialize_params{
+ * 			image = "${data.google_compute_image.debian_image.self_link}"
+ * 		}
+ * 	}
+ * 
+ * 	network_interface {
+ * 		network = "default"
+ * 		access_config {
+ * 			nat_ip = "${google_compute_address.static.address}"
+ * 		}
+ * 	}
+ * }
+ * 
+ */
 export class Address extends pulumi.CustomResource {
     /**
      * Get an existing Address resource's state with the given name, ID, and optional extra
@@ -13,8 +96,8 @@ export class Address extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AddressState): Address {
-        return new Address(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AddressState, opts?: pulumi.CustomResourceOptions): Address {
+        return new Address(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/attachedDisk.ts
+++ b/sdk/nodejs/compute/attachedDisk.ts
@@ -29,8 +29,8 @@ export class AttachedDisk extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AttachedDiskState): AttachedDisk {
-        return new AttachedDisk(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AttachedDiskState, opts?: pulumi.CustomResourceOptions): AttachedDisk {
+        return new AttachedDisk(name, <any>state, { ...opts, id: id });
     }
 
     public readonly deviceName: pulumi.Output<string>;

--- a/sdk/nodejs/compute/autoscalar.ts
+++ b/sdk/nodejs/compute/autoscalar.ts
@@ -4,6 +4,80 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents an Autoscaler resource.
+ * 
+ * Autoscalers allow you to automatically scale virtual machine instances in
+ * managed instance groups according to an autoscaling policy that you
+ * define.
+ * 
+ * 
+ * To get more information about Autoscaler, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers)
+ * * How-to Guides
+ *     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_image_debian_9 = pulumi.output(gcp.compute.getImage({
+ *     family: "debian-9",
+ *     project: "debian-cloud",
+ * }));
+ * const google_compute_target_pool_foobar = new gcp.compute.TargetPool("foobar", {
+ *     name: "my-target-pool",
+ * });
+ * const google_compute_instance_template_foobar = new gcp.compute.InstanceTemplate("foobar", {
+ *     canIpForward: false,
+ *     disks: [{
+ *         sourceImage: google_compute_image_debian_9.apply(__arg0 => __arg0.selfLink),
+ *     }],
+ *     machineType: "n1-standard-1",
+ *     metadata: {
+ *         foo: "bar",
+ *     },
+ *     name: "my-instance-template",
+ *     networkInterfaces: [{
+ *         network: "default",
+ *     }],
+ *     serviceAccount: {
+ *         scopes: [
+ *             "userinfo-email",
+ *             "compute-ro",
+ *             "storage-ro",
+ *         ],
+ *     },
+ *     tags: [
+ *         "foo",
+ *         "bar",
+ *     ],
+ * });
+ * const google_compute_instance_group_manager_foobar = new gcp.compute.InstanceGroupManager("foobar", {
+ *     baseInstanceName: "foobar",
+ *     instanceTemplate: google_compute_instance_template_foobar.selfLink,
+ *     name: "my-igm",
+ *     targetPools: [google_compute_target_pool_foobar.selfLink],
+ *     zone: "us-central1-f",
+ * });
+ * const google_compute_autoscaler_foobar = new gcp.compute.Autoscalar("foobar", {
+ *     autoscalingPolicy: {
+ *         cooldownPeriod: 60,
+ *         cpuUtilization: {
+ *             target: 0.500000,
+ *         },
+ *         maxReplicas: 5,
+ *         minReplicas: 1,
+ *     },
+ *     name: "my-autoscaler",
+ *     target: google_compute_instance_group_manager_foobar.selfLink,
+ *     zone: "us-central1-f",
+ * });
+ * ```
+ */
 export class Autoscalar extends pulumi.CustomResource {
     /**
      * Get an existing Autoscalar resource's state with the given name, ID, and optional extra
@@ -13,8 +87,8 @@ export class Autoscalar extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AutoscalarState): Autoscalar {
-        return new Autoscalar(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AutoscalarState, opts?: pulumi.CustomResourceOptions): Autoscalar {
+        return new Autoscalar(name, <any>state, { ...opts, id: id });
     }
 
     public readonly autoscalingPolicy: pulumi.Output<{ cooldownPeriod?: number, cpuUtilization: { target: number }, loadBalancingUtilization?: { target: number }, maxReplicas: number, metrics?: { name: string, target: number, type: string }[], minReplicas: number }>;

--- a/sdk/nodejs/compute/backendBucket.ts
+++ b/sdk/nodejs/compute/backendBucket.ts
@@ -4,6 +4,40 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Backend buckets allow you to use Google Cloud Storage buckets with HTTP(S)
+ * load balancing.
+ * 
+ * An HTTP(S) load balancer can direct traffic to specified URLs to a
+ * backend bucket rather than a backend service. It can send requests for
+ * static content to a Cloud Storage bucket and requests for dynamic content
+ * a virtual machine instance.
+ * 
+ * 
+ * To get more information about BackendBucket, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/backendBuckets)
+ * * How-to Guides
+ *     * [Using a Cloud Storage bucket as a load balancer backend](https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_image_bucket = new gcp.storage.Bucket("image_bucket", {
+ *     location: "EU",
+ *     name: "image-store-bucket",
+ * });
+ * const google_compute_backend_bucket_image_backend = new gcp.compute.BackendBucket("image_backend", {
+ *     bucketName: google_storage_bucket_image_bucket.name,
+ *     description: "Contains beautiful images",
+ *     enableCdn: true,
+ *     name: "image-backend-bucket",
+ * });
+ * ```
+ */
 export class BackendBucket extends pulumi.CustomResource {
     /**
      * Get an existing BackendBucket resource's state with the given name, ID, and optional extra
@@ -13,8 +47,8 @@ export class BackendBucket extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BackendBucketState): BackendBucket {
-        return new BackendBucket(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BackendBucketState, opts?: pulumi.CustomResourceOptions): BackendBucket {
+        return new BackendBucket(name, <any>state, { ...opts, id: id });
     }
 
     public readonly bucketName: pulumi.Output<string>;

--- a/sdk/nodejs/compute/backendService.ts
+++ b/sdk/nodejs/compute/backendService.ts
@@ -10,6 +10,51 @@ import * as utilities from "../utilities";
  * and the [API](https://cloud.google.com/compute/docs/reference/latest/backendServices).
  * 
  * For internal load balancing, use a [google_compute_region_backend_service](https://www.terraform.io/docs/providers/google/r/compute_region_backend_service.html).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_http_health_check_default = new gcp.compute.HttpHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "test",
+ *     requestPath: "/",
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_instance_template_webserver = new gcp.compute.InstanceTemplate("webserver", {
+ *     disks: [{
+ *         autoDelete: true,
+ *         boot: true,
+ *         sourceImage: "debian-cloud/debian-9",
+ *     }],
+ *     machineType: "n1-standard-1",
+ *     name: "standard-webserver",
+ *     networkInterfaces: [{
+ *         network: "default",
+ *     }],
+ * });
+ * const google_compute_instance_group_manager_webservers = new gcp.compute.InstanceGroupManager("webservers", {
+ *     baseInstanceName: "webserver",
+ *     instanceTemplate: google_compute_instance_template_webserver.selfLink,
+ *     name: "my-webservers",
+ *     targetSize: 1,
+ *     zone: "us-central1-f",
+ * });
+ * const google_compute_backend_service_website = new gcp.compute.BackendService("website", {
+ *     backends: [{
+ *         group: google_compute_instance_group_manager_webservers.instanceGroup,
+ *     }],
+ *     description: "Our company website",
+ *     enableCdn: false,
+ *     healthChecks: google_compute_http_health_check_default.selfLink,
+ *     name: "my-backend",
+ *     portName: "http",
+ *     protocol: "HTTP",
+ *     timeoutSec: 10,
+ * });
+ * ```
  */
 export class BackendService extends pulumi.CustomResource {
     /**
@@ -20,8 +65,8 @@ export class BackendService extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BackendServiceState): BackendService {
-        return new BackendService(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BackendServiceState, opts?: pulumi.CustomResourceOptions): BackendService {
+        return new BackendService(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/disk.ts
+++ b/sdk/nodejs/compute/disk.ts
@@ -4,6 +4,51 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Persistent disks are durable storage devices that function similarly to
+ * the physical disks in a desktop or a server. Compute Engine manages the
+ * hardware behind these devices to ensure data redundancy and optimize
+ * performance for you. Persistent disks are available as either standard
+ * hard disk drives (HDD) or solid-state drives (SSD).
+ * 
+ * Persistent disks are located independently from your virtual machine
+ * instances, so you can detach or move persistent disks to keep your data
+ * even after you delete your instances. Persistent disk performance scales
+ * automatically with size, so you can resize your existing persistent disks
+ * or add more persistent disks to an instance to meet your performance and
+ * storage space requirements.
+ * 
+ * Add a persistent disk to your instance when you need reliable and
+ * affordable storage with consistent performance characteristics.
+ * 
+ * 
+ * To get more information about Disk, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/disks)
+ * * How-to Guides
+ *     * [Adding a persistent disk](https://cloud.google.com/compute/docs/disks/add-persistent-disk)
+ * 
+ * > **Warning:** All arguments including the disk encryption key will be stored in the raw
+ * state as plain-text.
+ * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_disk_default = new gcp.compute.Disk("default", {
+ *     image: "debian-8-jessie-v20170523",
+ *     labels: {
+ *         environment: "dev",
+ *     },
+ *     name: "test-disk",
+ *     type: "pd-ssd",
+ *     zone: "us-central1-a",
+ * });
+ * ```
+ */
 export class Disk extends pulumi.CustomResource {
     /**
      * Get an existing Disk resource's state with the given name, ID, and optional extra
@@ -13,8 +58,8 @@ export class Disk extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DiskState): Disk {
-        return new Disk(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DiskState, opts?: pulumi.CustomResourceOptions): Disk {
+        return new Disk(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/compute/firewall.ts
+++ b/sdk/nodejs/compute/firewall.ts
@@ -4,6 +4,56 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Each network has its own firewall controlling access to and from the
+ * instances.
+ * 
+ * All traffic to instances, even from other instances, is blocked by the
+ * firewall unless firewall rules are created to allow it.
+ * 
+ * The default network has automatically created firewall rules that are
+ * shown in default firewall rules. No manually created network has
+ * automatically created firewall rules except for a default "allow" rule for
+ * outgoing traffic and a default "deny" for incoming traffic. For all
+ * networks except the default network, you must create any firewall rules
+ * you need.
+ * 
+ * 
+ * To get more information about Firewall, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/firewalls)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/vpc/docs/firewalls)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_network_default = new gcp.compute.Network("default", {
+ *     name: "test-network",
+ * });
+ * const google_compute_firewall_default = new gcp.compute.Firewall("default", {
+ *     allows: [
+ *         {
+ *             protocol: "icmp",
+ *         },
+ *         {
+ *             ports: [
+ *                 "80",
+ *                 "8080",
+ *                 "1000-2000",
+ *             ],
+ *             protocol: "tcp",
+ *         },
+ *     ],
+ *     name: "test-firewall",
+ *     network: google_compute_network_default.name,
+ *     sourceTags: ["web"],
+ * });
+ * ```
+ */
 export class Firewall extends pulumi.CustomResource {
     /**
      * Get an existing Firewall resource's state with the given name, ID, and optional extra
@@ -13,8 +63,8 @@ export class Firewall extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FirewallState): Firewall {
-        return new Firewall(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FirewallState, opts?: pulumi.CustomResourceOptions): Firewall {
+        return new Firewall(name, <any>state, { ...opts, id: id });
     }
 
     public readonly allows: pulumi.Output<{ ports?: string[], protocol: string }[] | undefined>;

--- a/sdk/nodejs/compute/forwardingRule.ts
+++ b/sdk/nodejs/compute/forwardingRule.ts
@@ -4,6 +4,34 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * A ForwardingRule resource. A ForwardingRule resource specifies which pool
+ * of target virtual machines to forward a packet to if it matches the given
+ * [IPAddress, IPProtocol, portRange] tuple.
+ * 
+ * 
+ * To get more information about ForwardingRule, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/forwardingRule)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_target_pool_default = new gcp.compute.TargetPool("default", {
+ *     name: "website-target-pool",
+ * });
+ * const google_compute_forwarding_rule_default = new gcp.compute.ForwardingRule("default", {
+ *     name: "website-forwarding-rule",
+ *     portRange: "80",
+ *     target: google_compute_target_pool_default.selfLink,
+ * });
+ * ```
+ */
 export class ForwardingRule extends pulumi.CustomResource {
     /**
      * Get an existing ForwardingRule resource's state with the given name, ID, and optional extra
@@ -13,8 +41,8 @@ export class ForwardingRule extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ForwardingRuleState): ForwardingRule {
-        return new ForwardingRule(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ForwardingRuleState, opts?: pulumi.CustomResourceOptions): ForwardingRule {
+        return new ForwardingRule(name, <any>state, { ...opts, id: id });
     }
 
     public readonly backendService: pulumi.Output<string | undefined>;

--- a/sdk/nodejs/compute/getAddress.ts
+++ b/sdk/nodejs/compute/getAddress.ts
@@ -7,6 +7,28 @@ import * as utilities from "../utilities";
 /**
  * Get the IP address from a static address. For more information see
  * the official [API](https://cloud.google.com/compute/docs/reference/latest/addresses/get) documentation.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_address_my_address = pulumi.output(gcp.compute.getAddress({
+ *     name: "foobar",
+ * }));
+ * const google_dns_managed_zone_prod = new gcp.dns.ManagedZone("prod", {
+ *     dnsName: "prod.mydomain.com.",
+ *     name: "prod-zone",
+ * });
+ * const google_dns_record_set_frontend = new gcp.dns.RecordSet("frontend", {
+ *     managedZone: google_dns_managed_zone_prod.name,
+ *     name: google_dns_managed_zone_prod.dnsName.apply(__arg0 => `frontend.${__arg0}`),
+ *     rrdatas: [google_compute_address_my_address.apply(__arg0 => __arg0.address)],
+ *     ttl: 300,
+ *     type: "A",
+ * });
+ * ```
  */
 export function getAddress(args: GetAddressArgs, opts?: pulumi.InvokeOptions): Promise<GetAddressResult> {
     return pulumi.runtime.invoke("gcp:compute/getAddress:getAddress", {

--- a/sdk/nodejs/compute/getBackendService.ts
+++ b/sdk/nodejs/compute/getBackendService.ts
@@ -8,6 +8,17 @@ import * as utilities from "../utilities";
  * Provide acces to a Backend Service's attribute. For more information
  * see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
  * and the [API](https://cloud.google.com/compute/docs/reference/latest/backendServices).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_backend_service_baz = pulumi.output(gcp.compute.getBackendService({
+ *     name: "foobar",
+ * }));
+ * ```
  */
 export function getBackendService(args: GetBackendServiceArgs, opts?: pulumi.InvokeOptions): Promise<GetBackendServiceResult> {
     return pulumi.runtime.invoke("gcp:compute/getBackendService:getBackendService", {

--- a/sdk/nodejs/compute/getDefaultServiceAccount.ts
+++ b/sdk/nodejs/compute/getDefaultServiceAccount.ts
@@ -6,6 +6,17 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to retrieve default service account for this project
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_default_service_account_default = pulumi.output(gcp.compute.getDefaultServiceAccount({}));
+ * 
+ * export const defaultAccount = google_compute_default_service_account_default.apply(__arg0 => __arg0.email);
+ * ```
  */
 export function getDefaultServiceAccount(args?: GetDefaultServiceAccountArgs, opts?: pulumi.InvokeOptions): Promise<GetDefaultServiceAccountResult> {
     args = args || {};

--- a/sdk/nodejs/compute/getForwardingRule.ts
+++ b/sdk/nodejs/compute/getForwardingRule.ts
@@ -6,6 +6,17 @@ import * as utilities from "../utilities";
 
 /**
  * Get a forwarding rule within GCE from its name.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_forwarding_rule_my_forwarding_rule = pulumi.output(gcp.compute.getForwardingRule({
+ *     name: "forwarding-rule-us-east1",
+ * }));
+ * ```
  */
 export function getForwardingRule(args: GetForwardingRuleArgs, opts?: pulumi.InvokeOptions): Promise<GetForwardingRuleResult> {
     return pulumi.runtime.invoke("gcp:compute/getForwardingRule:getForwardingRule", {

--- a/sdk/nodejs/compute/getGlobalAddress.ts
+++ b/sdk/nodejs/compute/getGlobalAddress.ts
@@ -7,6 +7,28 @@ import * as utilities from "../utilities";
 /**
  * Get the IP address from a static address reserved for a Global Forwarding Rule which are only used for HTTP load balancing. For more information see
  * the official [API](https://cloud.google.com/compute/docs/reference/latest/globalAddresses) documentation.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_global_address_my_address = pulumi.output(gcp.compute.getGlobalAddress({
+ *     name: "foobar",
+ * }));
+ * const google_dns_managed_zone_prod = new gcp.dns.ManagedZone("prod", {
+ *     dnsName: "prod.mydomain.com.",
+ *     name: "prod-zone",
+ * });
+ * const google_dns_record_set_frontend = new gcp.dns.RecordSet("frontend", {
+ *     managedZone: google_dns_managed_zone_prod.name,
+ *     name: google_dns_managed_zone_prod.dnsName.apply(__arg0 => `lb.${__arg0}`),
+ *     rrdatas: [google_compute_global_address_my_address.apply(__arg0 => __arg0.address)],
+ *     ttl: 300,
+ *     type: "A",
+ * });
+ * ```
  */
 export function getGlobalAddress(args: GetGlobalAddressArgs, opts?: pulumi.InvokeOptions): Promise<GetGlobalAddressResult> {
     return pulumi.runtime.invoke("gcp:compute/getGlobalAddress:getGlobalAddress", {

--- a/sdk/nodejs/compute/getImage.ts
+++ b/sdk/nodejs/compute/getImage.ts
@@ -7,6 +7,25 @@ import * as utilities from "../utilities";
 /**
  * Get information about a Google Compute Image. Check that your service account has the `compute.imageUser` role if you want to share [custom images](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) from another project. If you want to use [public images][pubimg], do not forget to specify the dedicated project. For more information see
  * [the official documentation](https://cloud.google.com/compute/docs/images) and its [API](https://cloud.google.com/compute/docs/reference/latest/images).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_image_my_image = pulumi.output(gcp.compute.getImage({
+ *     name: "debian-9",
+ *     project: "debian-cloud",
+ * }));
+ * const google_compute_instance_default = new gcp.compute.Instance("default", {
+ *     bootDisk: {
+ *         initializeParams: {
+ *             image: google_compute_image_my_image.apply(__arg0 => __arg0.selfLink),
+ *         },
+ *     },
+ * });
+ * ```
  */
 export function getImage(args?: GetImageArgs, opts?: pulumi.InvokeOptions): Promise<GetImageResult> {
     args = args || {};

--- a/sdk/nodejs/compute/getInstance.ts
+++ b/sdk/nodejs/compute/getInstance.ts
@@ -10,6 +10,18 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/instances).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_instance_appserver = pulumi.output(gcp.compute.getInstance({
+ *     name: "primary-application-server",
+ *     zone: "us-central1-a",
+ * }));
+ * ```
  */
 export function getInstance(args: GetInstanceArgs, opts?: pulumi.InvokeOptions): Promise<GetInstanceResult> {
     return pulumi.runtime.invoke("gcp:compute/getInstance:getInstance", {

--- a/sdk/nodejs/compute/getNetblockIPRanges.ts
+++ b/sdk/nodejs/compute/getNetblockIPRanges.ts
@@ -8,6 +8,19 @@ import * as utilities from "../utilities";
  * Use this data source to get the IP ranges from the sender policy framework (SPF) record of \_cloud-netblocks.googleusercontent
  * 
  * https://cloud.google.com/compute/docs/faq#where_can_i_find_product_name_short_ip_ranges
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_netblock_ip_ranges_netblock = pulumi.output(gcp.compute.getNetblockIPRanges({}));
+ * 
+ * export const cidrBlocks = google_netblock_ip_ranges_netblock.apply(__arg0 => __arg0.cidrBlocks);
+ * export const cidrBlocksIpv4 = google_netblock_ip_ranges_netblock.apply(__arg0 => __arg0.cidrBlocksIpv4s);
+ * export const cidrBlocksIpv6 = google_netblock_ip_ranges_netblock.apply(__arg0 => __arg0.cidrBlocksIpv6s);
+ * ```
  */
 export function getNetblockIPRanges(opts?: pulumi.InvokeOptions): Promise<GetNetblockIPRangesResult> {
     return pulumi.runtime.invoke("gcp:compute/getNetblockIPRanges:getNetblockIPRanges", {

--- a/sdk/nodejs/compute/getNetwork.ts
+++ b/sdk/nodejs/compute/getNetwork.ts
@@ -6,6 +6,17 @@ import * as utilities from "../utilities";
 
 /**
  * Get a network within GCE from its name.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_network_my_network = pulumi.output(gcp.compute.getNetwork({
+ *     name: "default-us-east1",
+ * }));
+ * ```
  */
 export function getNetwork(args: GetNetworkArgs, opts?: pulumi.InvokeOptions): Promise<GetNetworkResult> {
     return pulumi.runtime.invoke("gcp:compute/getNetwork:getNetwork", {

--- a/sdk/nodejs/compute/getSSLPolicy.ts
+++ b/sdk/nodejs/compute/getSSLPolicy.ts
@@ -7,6 +7,17 @@ import * as utilities from "../utilities";
 /**
  * Gets an SSL Policy within GCE from its name, for use with Target HTTPS and Target SSL Proxies.
  *     For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_ssl_policy_my_ssl_policy = pulumi.output(gcp.compute.getSSLPolicy({
+ *     name: "production-ssl-policy",
+ * }));
+ * ```
  */
 export function getSSLPolicy(args: GetSSLPolicyArgs, opts?: pulumi.InvokeOptions): Promise<GetSSLPolicyResult> {
     return pulumi.runtime.invoke("gcp:compute/getSSLPolicy:getSSLPolicy", {

--- a/sdk/nodejs/compute/getSubnetwork.ts
+++ b/sdk/nodejs/compute/getSubnetwork.ts
@@ -6,6 +6,18 @@ import * as utilities from "../utilities";
 
 /**
  * Get a subnetwork within GCE from its name and region.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_subnetwork_my_subnetwork = pulumi.output(gcp.compute.getSubnetwork({
+ *     name: "default-us-east1",
+ *     region: "us-east1",
+ * }));
+ * ```
  */
 export function getSubnetwork(args: GetSubnetworkArgs, opts?: pulumi.InvokeOptions): Promise<GetSubnetworkResult> {
     return pulumi.runtime.invoke("gcp:compute/getSubnetwork:getSubnetwork", {

--- a/sdk/nodejs/compute/getVPNGateway.ts
+++ b/sdk/nodejs/compute/getVPNGateway.ts
@@ -6,6 +6,17 @@ import * as utilities from "../utilities";
 
 /**
  * Get a VPN gateway within GCE from its name.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_vpn_gateway_my_vpn_gateway = pulumi.output(gcp.compute.getVPNGateway({
+ *     name: "vpn-gateway-us-east1",
+ * }));
+ * ```
  */
 export function getVPNGateway(args: GetVPNGatewayArgs, opts?: pulumi.InvokeOptions): Promise<GetVPNGatewayResult> {
     return pulumi.runtime.invoke("gcp:compute/getVPNGateway:getVPNGateway", {

--- a/sdk/nodejs/compute/globalAddress.ts
+++ b/sdk/nodejs/compute/globalAddress.ts
@@ -4,6 +4,28 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a Global Address resource. Global addresses are used for
+ * HTTP(S) load balancing.
+ * 
+ * 
+ * To get more information about GlobalAddress, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/globalAddresses)
+ * * How-to Guides
+ *     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_global_address_default = new gcp.compute.GlobalAddress("default", {
+ *     name: "global-appserver-ip",
+ * });
+ * ```
+ */
 export class GlobalAddress extends pulumi.CustomResource {
     /**
      * Get an existing GlobalAddress resource's state with the given name, ID, and optional extra
@@ -13,8 +35,8 @@ export class GlobalAddress extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: GlobalAddressState): GlobalAddress {
-        return new GlobalAddress(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: GlobalAddressState, opts?: pulumi.CustomResourceOptions): GlobalAddress {
+        return new GlobalAddress(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly address: pulumi.Output<string>;

--- a/sdk/nodejs/compute/globalForwardingRule.ts
+++ b/sdk/nodejs/compute/globalForwardingRule.ts
@@ -9,6 +9,54 @@ import * as utilities from "../utilities";
  * information see [the official
  * documentation](https://cloud.google.com/compute/docs/load-balancing/http/global-forwarding-rules) and
  * [API](https://cloud.google.com/compute/docs/reference/latest/globalForwardingRules).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_http_health_check_default = new gcp.compute.HttpHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "test",
+ *     requestPath: "/",
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_backend_service_default = new gcp.compute.BackendService("default", {
+ *     healthChecks: google_compute_http_health_check_default.selfLink,
+ *     name: "default-backend",
+ *     portName: "http",
+ *     protocol: "HTTP",
+ *     timeoutSec: 10,
+ * });
+ * const google_compute_url_map_default = new gcp.compute.URLMap("default", {
+ *     defaultService: google_compute_backend_service_default.selfLink,
+ *     description: "a description",
+ *     hostRules: [{
+ *         hosts: ["mysite.com"],
+ *         pathMatcher: "allpaths",
+ *     }],
+ *     name: "url-map",
+ *     pathMatchers: [{
+ *         defaultService: google_compute_backend_service_default.selfLink,
+ *         name: "allpaths",
+ *         pathRules: [{
+ *             paths: ["/*"],
+ *             service: google_compute_backend_service_default.selfLink,
+ *         }],
+ *     }],
+ * });
+ * const google_compute_target_http_proxy_default = new gcp.compute.TargetHttpProxy("default", {
+ *     description: "a description",
+ *     name: "test-proxy",
+ *     urlMap: google_compute_url_map_default.selfLink,
+ * });
+ * const google_compute_global_forwarding_rule_default = new gcp.compute.GlobalForwardingRule("default", {
+ *     name: "default-rule",
+ *     portRange: "80",
+ *     target: google_compute_target_http_proxy_default.selfLink,
+ * });
+ * ```
  */
 export class GlobalForwardingRule extends pulumi.CustomResource {
     /**
@@ -19,8 +67,8 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: GlobalForwardingRuleState): GlobalForwardingRule {
-        return new GlobalForwardingRule(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: GlobalForwardingRuleState, opts?: pulumi.CustomResourceOptions): GlobalForwardingRule {
+        return new GlobalForwardingRule(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/healthCheck.ts
+++ b/sdk/nodejs/compute/healthCheck.ts
@@ -4,6 +4,42 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Health Checks determine whether instances are responsive and able to do work.
+ * They are an important part of a comprehensive load balancing configuration,
+ * as they enable monitoring instances behind load balancers.
+ * 
+ * Health Checks poll instances at a specified interval. Instances that
+ * do not respond successfully to some number of probes in a row are marked
+ * as unhealthy. No new connections are sent to unhealthy instances,
+ * though existing connections will continue. The health check will
+ * continue to poll unhealthy instances. If an instance later responds
+ * successfully to some number of consecutive probes, it is marked
+ * healthy again and can receive new connections.
+ * 
+ * 
+ * To get more information about HealthCheck, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/latest/healthChecks)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/health-checks)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_health_check_internal_health_check = new gcp.compute.HealthCheck("internal-health-check", {
+ *     checkIntervalSec: 1,
+ *     name: "internal-service-health-check",
+ *     tcpHealthCheck: {
+ *         port: Number.parseFloat("80"),
+ *     },
+ *     timeoutSec: 1,
+ * });
+ * ```
+ */
 export class HealthCheck extends pulumi.CustomResource {
     /**
      * Get an existing HealthCheck resource's state with the given name, ID, and optional extra
@@ -13,8 +49,8 @@ export class HealthCheck extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: HealthCheckState): HealthCheck {
-        return new HealthCheck(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: HealthCheckState, opts?: pulumi.CustomResourceOptions): HealthCheck {
+        return new HealthCheck(name, <any>state, { ...opts, id: id });
     }
 
     public readonly checkIntervalSec: pulumi.Output<number | undefined>;

--- a/sdk/nodejs/compute/httpHealthCheck.ts
+++ b/sdk/nodejs/compute/httpHealthCheck.ts
@@ -4,6 +4,38 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * An HttpHealthCheck resource. This resource defines a template for how
+ * individual VMs should be checked for health, via HTTP.
+ * 
+ * 
+ * > **Note:** google_compute_http_health_check is a legacy health check.
+ * The newer [google_compute_health_check](https://www.terraform.io/docs/providers/google/r/compute_health_check.html)
+ * should be preferred for all uses except
+ * [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/)
+ * which still require the legacy version.
+ * 
+ * 
+ * To get more information about HttpHealthCheck, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/httpHealthChecks)
+ * * How-to Guides
+ *     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_http_health_check_default = new gcp.compute.HttpHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "authentication-health-check",
+ *     requestPath: "/health_check",
+ *     timeoutSec: 1,
+ * });
+ * ```
+ */
 export class HttpHealthCheck extends pulumi.CustomResource {
     /**
      * Get an existing HttpHealthCheck resource's state with the given name, ID, and optional extra
@@ -13,8 +45,8 @@ export class HttpHealthCheck extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: HttpHealthCheckState): HttpHealthCheck {
-        return new HttpHealthCheck(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: HttpHealthCheckState, opts?: pulumi.CustomResourceOptions): HttpHealthCheck {
+        return new HttpHealthCheck(name, <any>state, { ...opts, id: id });
     }
 
     public readonly checkIntervalSec: pulumi.Output<number | undefined>;

--- a/sdk/nodejs/compute/httpsHealthCheck.ts
+++ b/sdk/nodejs/compute/httpsHealthCheck.ts
@@ -4,6 +4,38 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * An HttpsHealthCheck resource. This resource defines a template for how
+ * individual VMs should be checked for health, via HTTPS.
+ * 
+ * 
+ * > **Note:** google_compute_https_health_check is a legacy health check.
+ * The newer [google_compute_health_check](https://www.terraform.io/docs/providers/google/r/compute_health_check.html)
+ * should be preferred for all uses except
+ * [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/)
+ * which still require the legacy version.
+ * 
+ * 
+ * To get more information about HttpsHealthCheck, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/httpsHealthChecks)
+ * * How-to Guides
+ *     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_https_health_check_default = new gcp.compute.HttpsHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "authentication-health-check",
+ *     requestPath: "/health_check",
+ *     timeoutSec: 1,
+ * });
+ * ```
+ */
 export class HttpsHealthCheck extends pulumi.CustomResource {
     /**
      * Get an existing HttpsHealthCheck resource's state with the given name, ID, and optional extra
@@ -13,8 +45,8 @@ export class HttpsHealthCheck extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: HttpsHealthCheckState): HttpsHealthCheck {
-        return new HttpsHealthCheck(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: HttpsHealthCheckState, opts?: pulumi.CustomResourceOptions): HttpsHealthCheck {
+        return new HttpsHealthCheck(name, <any>state, { ...opts, id: id });
     }
 
     public readonly checkIntervalSec: pulumi.Output<number | undefined>;

--- a/sdk/nodejs/compute/image.ts
+++ b/sdk/nodejs/compute/image.ts
@@ -9,6 +9,34 @@ import * as utilities from "../utilities";
  * tarball. For more information see [the official documentation](https://cloud.google.com/compute/docs/images) and
  * [API](https://cloud.google.com/compute/docs/reference/latest/images).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_image_bootable_image = new gcp.compute.Image("bootable-image", {
+ *     licenses: ["https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"],
+ *     name: "my-custom-image",
+ *     rawDisk: {
+ *         source: "https://storage.googleapis.com/my-bucket/my-disk-image-tarball.tar.gz",
+ *     },
+ * });
+ * const google_compute_instance_vm = new gcp.compute.Instance("vm", {
+ *     bootDisk: {
+ *         initializeParams: {
+ *             image: google_compute_image_bootable_image.selfLink,
+ *         },
+ *     },
+ *     machineType: "n1-standard-1",
+ *     name: "vm-from-custom-image",
+ *     networkInterfaces: [{
+ *         network: "default",
+ *     }],
+ *     zone: "us-east1-c",
+ * });
+ * ```
  */
 export class Image extends pulumi.CustomResource {
     /**
@@ -19,8 +47,8 @@ export class Image extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ImageState): Image {
-        return new Image(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ImageState, opts?: pulumi.CustomResourceOptions): Image {
+        return new Image(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/instance.ts
+++ b/sdk/nodejs/compute/instance.ts
@@ -10,6 +10,44 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/instances).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_instance_default = new gcp.compute.Instance("default", {
+ *     bootDisk: {
+ *         initializeParams: {
+ *             image: "debian-cloud/debian-9",
+ *         },
+ *     },
+ *     machineType: "n1-standard-1",
+ *     metadata: {
+ *         foo: "bar",
+ *     },
+ *     metadataStartupScript: "echo hi > /test.txt",
+ *     name: "test",
+ *     networkInterfaces: [{
+ *         accessConfigs: [{}],
+ *         network: "default",
+ *     }],
+ *     scratchDisks: [{}],
+ *     serviceAccount: {
+ *         scopes: [
+ *             "userinfo-email",
+ *             "compute-ro",
+ *             "storage-ro",
+ *         ],
+ *     },
+ *     tags: [
+ *         "foo",
+ *         "bar",
+ *     ],
+ *     zone: "us-central1-a",
+ * });
+ * ```
  */
 export class Instance extends pulumi.CustomResource {
     /**
@@ -20,8 +58,8 @@ export class Instance extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState): Instance {
-        return new Instance(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState, opts?: pulumi.CustomResourceOptions): Instance {
+        return new Instance(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/instanceFromTemplate.ts
+++ b/sdk/nodejs/compute/instanceFromTemplate.ts
@@ -14,6 +14,40 @@ import * as utilities from "../utilities";
  * `source_instance_template`. To create an instance without a template, use the
  * `google_compute_instance` resource.
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_instance_template_tpl = new gcp.compute.InstanceTemplate("tpl", {
+ *     canIpForward: true,
+ *     disks: [{
+ *         autoDelete: true,
+ *         boot: true,
+ *         diskSizeGb: 100,
+ *         sourceImage: "debian-cloud/debian-9",
+ *     }],
+ *     machineType: "n1-standard-1",
+ *     metadata: {
+ *         foo: "bar",
+ *     },
+ *     name: "template",
+ *     networkInterfaces: [{
+ *         network: "default",
+ *     }],
+ * });
+ * const google_compute_instance_from_template_tpl = new gcp.compute.InstanceFromTemplate("tpl", {
+ *     canIpForward: false,
+ *     labels: {
+ *         my_key: "my_value",
+ *     },
+ *     name: "instance-from-template",
+ *     sourceInstanceTemplate: google_compute_instance_template_tpl.selfLink,
+ *     zone: "us-central1-a",
+ * });
+ * ```
  */
 export class InstanceFromTemplate extends pulumi.CustomResource {
     /**
@@ -24,8 +58,8 @@ export class InstanceFromTemplate extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceFromTemplateState): InstanceFromTemplate {
-        return new InstanceFromTemplate(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceFromTemplateState, opts?: pulumi.CustomResourceOptions): InstanceFromTemplate {
+        return new InstanceFromTemplate(name, <any>state, { ...opts, id: id });
     }
 
     public readonly allowStoppingForUpdate: pulumi.Output<boolean>;

--- a/sdk/nodejs/compute/instanceGroup.ts
+++ b/sdk/nodejs/compute/instanceGroup.ts
@@ -18,8 +18,8 @@ export class InstanceGroup extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceGroupState): InstanceGroup {
-        return new InstanceGroup(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceGroupState, opts?: pulumi.CustomResourceOptions): InstanceGroup {
+        return new InstanceGroup(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/instanceGroupManager.ts
+++ b/sdk/nodejs/compute/instanceGroupManager.ts
@@ -10,7 +10,7 @@ import * as utilities from "../utilities";
  * template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/manager)
  * and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers)
  * 
- * ~> **Note:** Use [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
+ * > **Note:** Use [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
  */
 export class InstanceGroupManager extends pulumi.CustomResource {
     /**
@@ -21,8 +21,8 @@ export class InstanceGroupManager extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceGroupManagerState): InstanceGroupManager {
-        return new InstanceGroupManager(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceGroupManagerState, opts?: pulumi.CustomResourceOptions): InstanceGroupManager {
+        return new InstanceGroupManager(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/instanceTemplate.ts
+++ b/sdk/nodejs/compute/instanceTemplate.ts
@@ -10,6 +10,68 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/instanceTemplates).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_image_my_image = pulumi.output(gcp.compute.getImage({
+ *     family: "debian-9",
+ *     project: "debian-cloud",
+ * }));
+ * const google_compute_disk_foobar = new gcp.compute.Disk("foobar", {
+ *     image: google_compute_image_my_image.apply(__arg0 => __arg0.selfLink),
+ *     name: "existing-disk",
+ *     size: 10,
+ *     type: "pd-ssd",
+ *     zone: "us-central1-a",
+ * });
+ * const google_compute_instance_template_default = new gcp.compute.InstanceTemplate("default", {
+ *     canIpForward: false,
+ *     description: "This template is used to create app server instances.",
+ *     disks: [
+ *         {
+ *             autoDelete: true,
+ *             boot: true,
+ *             sourceImage: "debian-cloud/debian-9",
+ *         },
+ *         {
+ *             autoDelete: false,
+ *             boot: false,
+ *             source: google_compute_disk_foobar.name,
+ *         },
+ *     ],
+ *     instanceDescription: "description assigned to instances",
+ *     labels: {
+ *         environment: "dev",
+ *     },
+ *     machineType: "n1-standard-1",
+ *     metadata: {
+ *         foo: "bar",
+ *     },
+ *     name: "appserver-template",
+ *     networkInterfaces: [{
+ *         network: "default",
+ *     }],
+ *     schedulings: [{
+ *         automaticRestart: true,
+ *         onHostMaintenance: "MIGRATE",
+ *     }],
+ *     serviceAccount: {
+ *         scopes: [
+ *             "userinfo-email",
+ *             "compute-ro",
+ *             "storage-ro",
+ *         ],
+ *     },
+ *     tags: [
+ *         "foo",
+ *         "bar",
+ *     ],
+ * });
+ * ```
  */
 export class InstanceTemplate extends pulumi.CustomResource {
     /**
@@ -20,8 +82,8 @@ export class InstanceTemplate extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceTemplateState): InstanceTemplate {
-        return new InstanceTemplate(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceTemplateState, opts?: pulumi.CustomResourceOptions): InstanceTemplate {
+        return new InstanceTemplate(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/interconnectAttachment.ts
+++ b/sdk/nodejs/compute/interconnectAttachment.ts
@@ -4,6 +4,11 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents an InterconnectAttachment (VLAN attachment) resource. For more
+ * information, see Creating VLAN Attachments.
+ * 
+ */
 export class InterconnectAttachment extends pulumi.CustomResource {
     /**
      * Get an existing InterconnectAttachment resource's state with the given name, ID, and optional extra
@@ -13,8 +18,8 @@ export class InterconnectAttachment extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InterconnectAttachmentState): InterconnectAttachment {
-        return new InterconnectAttachment(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InterconnectAttachmentState, opts?: pulumi.CustomResourceOptions): InterconnectAttachment {
+        return new InterconnectAttachment(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly cloudRouterIpAddress: pulumi.Output<string>;

--- a/sdk/nodejs/compute/network.ts
+++ b/sdk/nodejs/compute/network.ts
@@ -9,6 +9,18 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/compute/docs/vpc)
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/networks).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_network_default = new gcp.compute.Network("default", {
+ *     autoCreateSubnetworks: true,
+ *     name: "foobar",
+ * });
+ * ```
  */
 export class Network extends pulumi.CustomResource {
     /**
@@ -19,8 +31,8 @@ export class Network extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NetworkState): Network {
-        return new Network(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NetworkState, opts?: pulumi.CustomResourceOptions): Network {
+        return new Network(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/networkPeering.ts
+++ b/sdk/nodejs/compute/networkPeering.ts
@@ -10,9 +10,35 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/networks).
  * 
- * ~> **Note:** Both network must create a peering with each other for the peering to be functional.
+ * > **Note:** Both network must create a peering with each other for the peering to be functional.
  * 
- * ~> **Note:** Subnets IP ranges across peered VPC networks cannot overlap.
+ * > **Note:** Subnets IP ranges across peered VPC networks cannot overlap.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_network_default = new gcp.compute.Network("default", {
+ *     autoCreateSubnetworks: false,
+ *     name: "foobar",
+ * });
+ * const google_compute_network_other = new gcp.compute.Network("other", {
+ *     autoCreateSubnetworks: false,
+ *     name: "other",
+ * });
+ * const google_compute_network_peering_peering1 = new gcp.compute.NetworkPeering("peering1", {
+ *     name: "peering1",
+ *     network: google_compute_network_default.selfLink,
+ *     peerNetwork: google_compute_network_other.selfLink,
+ * });
+ * const google_compute_network_peering_peering2 = new gcp.compute.NetworkPeering("peering2", {
+ *     name: "peering2",
+ *     network: google_compute_network_other.selfLink,
+ *     peerNetwork: google_compute_network_default.selfLink,
+ * });
+ * ```
  */
 export class NetworkPeering extends pulumi.CustomResource {
     /**
@@ -23,8 +49,8 @@ export class NetworkPeering extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NetworkPeeringState): NetworkPeering {
-        return new NetworkPeering(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NetworkPeeringState, opts?: pulumi.CustomResourceOptions): NetworkPeering {
+        return new NetworkPeering(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/projectMetadata.ts
+++ b/sdk/nodejs/compute/projectMetadata.ts
@@ -10,9 +10,24 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/projects/setCommonInstanceMetadata).
  * 
- * ~> **Note:**  If you want to manage only single key/value pairs within the project metadata
+ * > **Note:**  If you want to manage only single key/value pairs within the project metadata
  * rather than the entire set, then use
  * google_compute_project_metadata_item.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_project_metadata_default = new gcp.compute.ProjectMetadata("default", {
+ *     metadata: {
+ *         13: "42",
+ *         fizz: "buzz",
+ *         foo: "bar",
+ *     },
+ * });
+ * ```
  */
 export class ProjectMetadata extends pulumi.CustomResource {
     /**
@@ -23,8 +38,8 @@ export class ProjectMetadata extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectMetadataState): ProjectMetadata {
-        return new ProjectMetadata(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectMetadataState, opts?: pulumi.CustomResourceOptions): ProjectMetadata {
+        return new ProjectMetadata(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/projectMetadataItem.ts
+++ b/sdk/nodejs/compute/projectMetadataItem.ts
@@ -9,6 +9,18 @@ import * as utilities from "../utilities";
  * a project in GCE. Using `google_compute_project_metadata_item` lets you
  * manage a single key/value setting in Terraform rather than the entire
  * project metadata map.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_project_metadata_item_default = new gcp.compute.ProjectMetadataItem("default", {
+ *     key: "my_metadata",
+ *     value: "my_value",
+ * });
+ * ```
  */
 export class ProjectMetadataItem extends pulumi.CustomResource {
     /**
@@ -19,8 +31,8 @@ export class ProjectMetadataItem extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectMetadataItemState): ProjectMetadataItem {
-        return new ProjectMetadataItem(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectMetadataItemState, opts?: pulumi.CustomResourceOptions): ProjectMetadataItem {
+        return new ProjectMetadataItem(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/regionAutoscaler.ts
+++ b/sdk/nodejs/compute/regionAutoscaler.ts
@@ -4,6 +4,80 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents an Autoscaler resource.
+ * 
+ * Autoscalers allow you to automatically scale virtual machine instances in
+ * managed instance groups according to an autoscaling policy that you
+ * define.
+ * 
+ * 
+ * To get more information about RegionAutoscaler, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionAutoscalers)
+ * * How-to Guides
+ *     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_image_debian_9 = pulumi.output(gcp.compute.getImage({
+ *     family: "debian-9",
+ *     project: "debian-cloud",
+ * }));
+ * const google_compute_target_pool_foobar = new gcp.compute.TargetPool("foobar", {
+ *     name: "my-target-pool",
+ * });
+ * const google_compute_instance_template_foobar = new gcp.compute.InstanceTemplate("foobar", {
+ *     canIpForward: false,
+ *     disks: [{
+ *         sourceImage: google_compute_image_debian_9.apply(__arg0 => __arg0.selfLink),
+ *     }],
+ *     machineType: "n1-standard-1",
+ *     metadata: {
+ *         foo: "bar",
+ *     },
+ *     name: "my-instance-template",
+ *     networkInterfaces: [{
+ *         network: "default",
+ *     }],
+ *     serviceAccount: {
+ *         scopes: [
+ *             "userinfo-email",
+ *             "compute-ro",
+ *             "storage-ro",
+ *         ],
+ *     },
+ *     tags: [
+ *         "foo",
+ *         "bar",
+ *     ],
+ * });
+ * const google_compute_region_instance_group_manager_foobar = new gcp.compute.RegionInstanceGroupManager("foobar", {
+ *     baseInstanceName: "foobar",
+ *     instanceTemplate: google_compute_instance_template_foobar.selfLink,
+ *     name: "my-region-igm",
+ *     region: "us-central1",
+ *     targetPools: [google_compute_target_pool_foobar.selfLink],
+ * });
+ * const google_compute_region_autoscaler_foobar = new gcp.compute.RegionAutoscaler("foobar", {
+ *     autoscalingPolicy: {
+ *         cooldownPeriod: 60,
+ *         cpuUtilization: {
+ *             target: 0.500000,
+ *         },
+ *         maxReplicas: 5,
+ *         minReplicas: 1,
+ *     },
+ *     name: "my-region-autoscaler",
+ *     region: "us-central1",
+ *     target: google_compute_region_instance_group_manager_foobar.selfLink,
+ * });
+ * ```
+ */
 export class RegionAutoscaler extends pulumi.CustomResource {
     /**
      * Get an existing RegionAutoscaler resource's state with the given name, ID, and optional extra
@@ -13,8 +87,8 @@ export class RegionAutoscaler extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionAutoscalerState): RegionAutoscaler {
-        return new RegionAutoscaler(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionAutoscalerState, opts?: pulumi.CustomResourceOptions): RegionAutoscaler {
+        return new RegionAutoscaler(name, <any>state, { ...opts, id: id });
     }
 
     public readonly autoscalingPolicy: pulumi.Output<{ cooldownPeriod?: number, cpuUtilization: { target: number }, loadBalancingUtilization?: { target: number }, maxReplicas: number, metrics?: { name: string, target: number, type: string }[], minReplicas: number }>;

--- a/sdk/nodejs/compute/regionBackendService.ts
+++ b/sdk/nodejs/compute/regionBackendService.ts
@@ -9,8 +9,54 @@ import * as utilities from "../utilities";
  * For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/internal/)
  * and [API](https://cloud.google.com/compute/docs/reference/latest/regionBackendServices).
  * 
- * ~> **Note**: Region backend services can only be used when using internal load balancing. For external load balancing, use
+ * > **Note**: Region backend services can only be used when using internal load balancing. For external load balancing, use
  *   `google_compute_backend_service` instead.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_health_check_default = new gcp.compute.HealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "test",
+ *     tcpHealthCheck: {
+ *         port: Number.parseFloat("80"),
+ *     },
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_instance_template_foobar = new gcp.compute.InstanceTemplate("foobar", {
+ *     disks: [{
+ *         autoDelete: true,
+ *         boot: true,
+ *         sourceImage: "debian-cloud/debian-9",
+ *     }],
+ *     machineType: "n1-standard-1",
+ *     name: "terraform-test",
+ *     networkInterfaces: [{
+ *         network: "default",
+ *     }],
+ * });
+ * const google_compute_region_instance_group_manager_foo = new gcp.compute.RegionInstanceGroupManager("foo", {
+ *     baseInstanceName: "foobar",
+ *     instanceTemplate: google_compute_instance_template_foobar.selfLink,
+ *     name: "terraform-test",
+ *     region: "us-central1",
+ *     targetSize: 1,
+ * });
+ * const google_compute_region_backend_service_foobar = new gcp.compute.RegionBackendService("foobar", {
+ *     backends: [{
+ *         group: google_compute_region_instance_group_manager_foo.instanceGroup,
+ *     }],
+ *     description: "Hello World 1234",
+ *     healthChecks: google_compute_health_check_default.selfLink,
+ *     name: "blablah",
+ *     protocol: "TCP",
+ *     sessionAffinity: "CLIENT_IP",
+ *     timeoutSec: 10,
+ * });
+ * ```
  */
 export class RegionBackendService extends pulumi.CustomResource {
     /**
@@ -21,8 +67,8 @@ export class RegionBackendService extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionBackendServiceState): RegionBackendService {
-        return new RegionBackendService(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionBackendServiceState, opts?: pulumi.CustomResourceOptions): RegionBackendService {
+        return new RegionBackendService(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/regionDisk.ts
+++ b/sdk/nodejs/compute/regionDisk.ts
@@ -4,6 +4,64 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Persistent disks are durable storage devices that function similarly to
+ * the physical disks in a desktop or a server. Compute Engine manages the
+ * hardware behind these devices to ensure data redundancy and optimize
+ * performance for you. Persistent disks are available as either standard
+ * hard disk drives (HDD) or solid-state drives (SSD).
+ * 
+ * Persistent disks are located independently from your virtual machine
+ * instances, so you can detach or move persistent disks to keep your data
+ * even after you delete your instances. Persistent disk performance scales
+ * automatically with size, so you can resize your existing persistent disks
+ * or add more persistent disks to an instance to meet your performance and
+ * storage space requirements.
+ * 
+ * Add a persistent disk to your instance when you need reliable and
+ * affordable storage with consistent performance characteristics.
+ * 
+ * 
+ * To get more information about RegionDisk, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/regionDisks)
+ * * How-to Guides
+ *     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
+ * 
+ * > **Warning:** All arguments including the disk encryption key will be stored in the raw
+ * state as plain-text.
+ * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_disk_disk = new gcp.compute.Disk("disk", {
+ *     image: "debian-cloud/debian-9",
+ *     name: "my-disk",
+ *     size: 50,
+ *     type: "pd-ssd",
+ *     zone: "us-central1-a",
+ * });
+ * const google_compute_snapshot_snapdisk = new gcp.compute.Snapshot("snapdisk", {
+ *     name: "my-snapshot",
+ *     sourceDisk: google_compute_disk_disk.name,
+ *     zone: "us-central1-a",
+ * });
+ * const google_compute_region_disk_regiondisk = new gcp.compute.RegionDisk("regiondisk", {
+ *     name: "my-region-disk",
+ *     region: "us-central1",
+ *     replicaZones: [
+ *         "us-central1-a",
+ *         "us-central1-f",
+ *     ],
+ *     snapshot: google_compute_snapshot_snapdisk.selfLink,
+ *     type: "pd-ssd",
+ * });
+ * ```
+ */
 export class RegionDisk extends pulumi.CustomResource {
     /**
      * Get an existing RegionDisk resource's state with the given name, ID, and optional extra
@@ -13,8 +71,8 @@ export class RegionDisk extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionDiskState): RegionDisk {
-        return new RegionDisk(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionDiskState, opts?: pulumi.CustomResourceOptions): RegionDisk {
+        return new RegionDisk(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/compute/regionInstanceGroupManager.ts
+++ b/sdk/nodejs/compute/regionInstanceGroupManager.ts
@@ -10,7 +10,7 @@ import * as utilities from "../utilities";
  * template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups)
  * and [API](https://cloud.google.com/compute/docs/reference/latest/regionInstanceGroupManagers)
  * 
- * ~> **Note:** Use [google_compute_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html) to create a single-zone instance group manager.
+ * > **Note:** Use [google_compute_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html) to create a single-zone instance group manager.
  */
 export class RegionInstanceGroupManager extends pulumi.CustomResource {
     /**
@@ -21,8 +21,8 @@ export class RegionInstanceGroupManager extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionInstanceGroupManagerState): RegionInstanceGroupManager {
-        return new RegionInstanceGroupManager(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegionInstanceGroupManagerState, opts?: pulumi.CustomResourceOptions): RegionInstanceGroupManager {
+        return new RegionInstanceGroupManager(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/route.ts
+++ b/sdk/nodejs/compute/route.ts
@@ -4,6 +4,54 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a Route resource.
+ * 
+ * A route is a rule that specifies how certain packets should be handled by
+ * the virtual network. Routes are associated with virtual machines by tag,
+ * and the set of routes for a particular virtual machine is called its
+ * routing table. For each packet leaving a virtual machine, the system
+ * searches that virtual machine's routing table for a single best matching
+ * route.
+ * 
+ * Routes match packets by destination IP address, preferring smaller or more
+ * specific ranges over larger ones. If there is a tie, the system selects
+ * the route with the smallest priority value. If there is still a tie, it
+ * uses the layer three and four packet headers to select just one of the
+ * remaining matching routes. The packet is then forwarded as specified by
+ * the next_hop field of the winning route -- either to another virtual
+ * machine destination, a virtual machine gateway or a Compute
+ * Engine-operated gateway. Packets that do not match any route in the
+ * sending virtual machine's routing table will be dropped.
+ * 
+ * A Route resource must have exactly one specification of either
+ * nextHopGateway, nextHopInstance, nextHopIp, or nextHopVpnTunnel.
+ * 
+ * 
+ * To get more information about Route, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routes)
+ * * How-to Guides
+ *     * [Using Routes](https://cloud.google.com/vpc/docs/using-routes)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_network_default = new gcp.compute.Network("default", {
+ *     name: "compute-network",
+ * });
+ * const google_compute_route_default = new gcp.compute.Route("default", {
+ *     destRange: "15.0.0.0/24",
+ *     name: "network-route",
+ *     network: google_compute_network_default.name,
+ *     nextHopIp: "10.132.1.5",
+ *     priority: 100,
+ * });
+ * ```
+ */
 export class Route extends pulumi.CustomResource {
     /**
      * Get an existing Route resource's state with the given name, ID, and optional extra
@@ -13,8 +61,8 @@ export class Route extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouteState): Route {
-        return new Route(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouteState, opts?: pulumi.CustomResourceOptions): Route {
+        return new Route(name, <any>state, { ...opts, id: id });
     }
 
     public readonly description: pulumi.Output<string | undefined>;

--- a/sdk/nodejs/compute/router.ts
+++ b/sdk/nodejs/compute/router.ts
@@ -4,6 +4,45 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a Router resource.
+ * 
+ * 
+ * To get more information about Router, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routers)
+ * * How-to Guides
+ *     * [Google Cloud Router](https://cloud.google.com/router/docs/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_network_foobar = new gcp.compute.Network("foobar", {
+ *     autoCreateSubnetworks: false,
+ *     name: "my-network",
+ * });
+ * const google_compute_router_foobar = new gcp.compute.Router("foobar", {
+ *     bgp: {
+ *         advertiseMode: "CUSTOM",
+ *         advertisedGroups: ["ALL_SUBNETS"],
+ *         advertisedIpRanges: [
+ *             {
+ *                 range: "1.2.3.4",
+ *             },
+ *             {
+ *                 range: "6.7.0.0/16",
+ *             },
+ *         ],
+ *         asn: 64514,
+ *     },
+ *     name: "my-router",
+ *     network: google_compute_network_foobar.name,
+ * });
+ * ```
+ */
 export class Router extends pulumi.CustomResource {
     /**
      * Get an existing Router resource's state with the given name, ID, and optional extra
@@ -13,8 +52,8 @@ export class Router extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouterState): Router {
-        return new Router(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouterState, opts?: pulumi.CustomResourceOptions): Router {
+        return new Router(name, <any>state, { ...opts, id: id });
     }
 
     public readonly bgp: pulumi.Output<{ advertiseMode?: string, advertisedGroups?: string[], advertisedIpRanges?: { description?: string, range?: string }[], asn: number } | undefined>;

--- a/sdk/nodejs/compute/routerInterface.ts
+++ b/sdk/nodejs/compute/routerInterface.ts
@@ -9,6 +9,21 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/compute/docs/cloudrouter)
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/routers).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_router_interface_foobar = new gcp.compute.RouterInterface("foobar", {
+ *     ipRange: "169.254.1.1/30",
+ *     name: "interface-1",
+ *     region: "us-central1",
+ *     router: "router-1",
+ *     vpnTunnel: "tunnel-1",
+ * });
+ * ```
  */
 export class RouterInterface extends pulumi.CustomResource {
     /**
@@ -19,8 +34,8 @@ export class RouterInterface extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouterInterfaceState): RouterInterface {
-        return new RouterInterface(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouterInterfaceState, opts?: pulumi.CustomResourceOptions): RouterInterface {
+        return new RouterInterface(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/routerPeer.ts
+++ b/sdk/nodejs/compute/routerPeer.ts
@@ -9,6 +9,23 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/compute/docs/cloudrouter)
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/routers).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_router_peer_foobar = new gcp.compute.RouterPeer("foobar", {
+ *     advertisedRoutePriority: 100,
+ *     interface: "interface-1",
+ *     name: "peer-1",
+ *     peerAsn: 65513,
+ *     peerIpAddress: "169.254.1.2",
+ *     region: "us-central1",
+ *     router: "router-1",
+ * });
+ * ```
  */
 export class RouterPeer extends pulumi.CustomResource {
     /**
@@ -19,8 +36,8 @@ export class RouterPeer extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouterPeerState): RouterPeer {
-        return new RouterPeer(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RouterPeerState, opts?: pulumi.CustomResourceOptions): RouterPeer {
+        return new RouterPeer(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/sSLPolicy.ts
+++ b/sdk/nodejs/compute/sSLPolicy.ts
@@ -4,6 +4,43 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a SSL policy. SSL policies give you the ability to control the
+ * features of SSL that your SSL proxy or HTTPS load balancer negotiates.
+ * 
+ * 
+ * To get more information about SslPolicy, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies)
+ * * How-to Guides
+ *     * [Using SSL Policies](https://cloud.google.com/compute/docs/load-balancing/ssl-policies)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_ssl_policy_custom_ssl_policy = new gcp.compute.SSLPolicy("custom-ssl-policy", {
+ *     customFeatures: [
+ *         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+ *         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+ *     ],
+ *     minTlsVersion: "TLS_1_2",
+ *     name: "custom-ssl-policy",
+ *     profile: "CUSTOM",
+ * });
+ * const google_compute_ssl_policy_nonprod_ssl_policy = new gcp.compute.SSLPolicy("nonprod-ssl-policy", {
+ *     minTlsVersion: "TLS_1_2",
+ *     name: "nonprod-ssl-policy",
+ *     profile: "MODERN",
+ * });
+ * const google_compute_ssl_policy_prod_ssl_policy = new gcp.compute.SSLPolicy("prod-ssl-policy", {
+ *     name: "production-ssl-policy",
+ *     profile: "MODERN",
+ * });
+ * ```
+ */
 export class SSLPolicy extends pulumi.CustomResource {
     /**
      * Get an existing SSLPolicy resource's state with the given name, ID, and optional extra
@@ -13,8 +50,8 @@ export class SSLPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SSLPolicyState): SSLPolicy {
-        return new SSLPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SSLPolicyState, opts?: pulumi.CustomResourceOptions): SSLPolicy {
+        return new SSLPolicy(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/compute/securityPolicy.ts
+++ b/sdk/nodejs/compute/securityPolicy.ts
@@ -8,6 +8,41 @@ import * as utilities from "../utilities";
  * A Security Policy defines an IP blacklist or whitelist that protects load balanced Google Cloud services by denying or permitting traffic from specified IP ranges. For more information
  * see the [official documentation](https://cloud.google.com/armor/docs/configure-security-policies)
  * and the [API](https://cloud.google.com/compute/docs/reference/rest/beta/securityPolicies).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_security_policy_policy = new gcp.compute.SecurityPolicy("policy", {
+ *     name: "my-policy",
+ *     rules: [
+ *         {
+ *             action: "deny(403)",
+ *             description: "Deny access to IPs in 9.9.9.0/24",
+ *             match: {
+ *                 config: {
+ *                     srcIpRanges: ["9.9.9.9/32"],
+ *                 },
+ *                 versionedExpr: "SRC_IPS_V1",
+ *             },
+ *             priority: Number.parseFloat("1000"),
+ *         },
+ *         {
+ *             action: "allow",
+ *             description: "default rule",
+ *             match: {
+ *                 config: {
+ *                     srcIpRanges: ["*"],
+ *                 },
+ *                 versionedExpr: "SRC_IPS_V1",
+ *             },
+ *             priority: Number.parseFloat("2147483647"),
+ *         },
+ *     ],
+ * });
+ * ```
  */
 export class SecurityPolicy extends pulumi.CustomResource {
     /**
@@ -18,8 +53,8 @@ export class SecurityPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SecurityPolicyState): SecurityPolicy {
-        return new SecurityPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SecurityPolicyState, opts?: pulumi.CustomResourceOptions): SecurityPolicy {
+        return new SecurityPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/sharedVPCHostProject.ts
+++ b/sdk/nodejs/compute/sharedVPCHostProject.ts
@@ -12,6 +12,25 @@ import * as utilities from "../utilities";
  * For more information, see,
  * [the Project API documentation](https://cloud.google.com/compute/docs/reference/latest/projects),
  * where the Shared VPC feature is referred to by its former name "XPN".
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_shared_vpc_host_project_host = new gcp.compute.SharedVPCHostProject("host", {
+ *     project: "host-project-id",
+ * });
+ * const google_compute_shared_vpc_service_project_service1 = new gcp.compute.SharedVPCServiceProject("service1", {
+ *     hostProject: google_compute_shared_vpc_host_project_host.project,
+ *     serviceProject: "service-project-id-1",
+ * });
+ * const google_compute_shared_vpc_service_project_service2 = new gcp.compute.SharedVPCServiceProject("service2", {
+ *     hostProject: google_compute_shared_vpc_host_project_host.project,
+ *     serviceProject: "service-project-id-2",
+ * });
+ * ```
  */
 export class SharedVPCHostProject extends pulumi.CustomResource {
     /**
@@ -22,8 +41,8 @@ export class SharedVPCHostProject extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SharedVPCHostProjectState): SharedVPCHostProject {
-        return new SharedVPCHostProject(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SharedVPCHostProjectState, opts?: pulumi.CustomResourceOptions): SharedVPCHostProject {
+        return new SharedVPCHostProject(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/sharedVPCServiceProject.ts
+++ b/sdk/nodejs/compute/sharedVPCServiceProject.ts
@@ -13,6 +13,21 @@ import * as utilities from "../utilities";
  * For more information, see,
  * [the Project API documentation](https://cloud.google.com/compute/docs/reference/latest/projects),
  * where the Shared VPC feature is referred to by its former name "XPN".
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_shared_vpc_service_project_service1 = new gcp.compute.SharedVPCServiceProject("service1", {
+ *     hostProject: "host-project-id",
+ *     serviceProject: "service-project-id-1",
+ * });
+ * ```
+ * For a complete Shared VPC example with both host and service projects, see
+ * [`google_compute_shared_vpc_host_project`](https://www.terraform.io/docs/providers/google/r/compute_shared_vpc_host_project.html).
+ * 
  */
 export class SharedVPCServiceProject extends pulumi.CustomResource {
     /**
@@ -23,8 +38,8 @@ export class SharedVPCServiceProject extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SharedVPCServiceProjectState): SharedVPCServiceProject {
-        return new SharedVPCServiceProject(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SharedVPCServiceProjectState, opts?: pulumi.CustomResourceOptions): SharedVPCServiceProject {
+        return new SharedVPCServiceProject(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/snapshot.ts
+++ b/sdk/nodejs/compute/snapshot.ts
@@ -9,6 +9,22 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/snapshots).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_snapshot_default = new gcp.compute.Snapshot("default", {
+ *     labels: {
+ *         my-label: "my-label-value",
+ *     },
+ *     name: "test-snapshot",
+ *     sourceDisk: "test-disk",
+ *     zone: "us-central1-a",
+ * });
+ * ```
  */
 export class Snapshot extends pulumi.CustomResource {
     /**
@@ -19,8 +35,8 @@ export class Snapshot extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SnapshotState): Snapshot {
-        return new Snapshot(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SnapshotState, opts?: pulumi.CustomResourceOptions): Snapshot {
+        return new Snapshot(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/subnetwork.ts
+++ b/sdk/nodejs/compute/subnetwork.ts
@@ -4,6 +4,60 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * A VPC network is a virtual version of the traditional physical networks
+ * that exist within and between physical data centers. A VPC network
+ * provides connectivity for your Compute Engine virtual machine (VM)
+ * instances, Container Engine containers, App Engine Flex services, and
+ * other network-related resources.
+ * 
+ * Each GCP project contains one or more VPC networks. Each VPC network is a
+ * global entity spanning all GCP regions. This global VPC network allows VM
+ * instances and other resources to communicate with each other via internal,
+ * private IP addresses.
+ * 
+ * Each VPC network is subdivided into subnets, and each subnet is contained
+ * within a single region. You can have more than one subnet in a region for
+ * a given VPC network. Each subnet has a contiguous private RFC1918 IP
+ * space. You create instances, containers, and the like in these subnets.
+ * When you create an instance, you must create it in a subnet, and the
+ * instance draws its internal IP address from that subnet.
+ * 
+ * Virtual machine (VM) instances in a VPC network can communicate with
+ * instances in all other subnets of the same VPC network, regardless of
+ * region, using their RFC1918 private IP addresses. You can isolate portions
+ * of the network, even entire subnets, using firewall rules.
+ * 
+ * 
+ * To get more information about Subnetwork, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/subnetworks)
+ * * How-to Guides
+ *     * [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
+ *     * [Cloud Networking](https://cloud.google.com/vpc/docs/using-vpc)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_network_custom_test = new gcp.compute.Network("custom-test", {
+ *     autoCreateSubnetworks: false,
+ *     name: "test-network",
+ * });
+ * const google_compute_subnetwork_network_with_private_secondary_ip_ranges = new gcp.compute.Subnetwork("network-with-private-secondary-ip-ranges", {
+ *     ipCidrRange: "10.2.0.0/16",
+ *     name: "test-subnetwork",
+ *     network: google_compute_network_custom_test.selfLink,
+ *     region: "us-central1",
+ *     secondaryIpRanges: [{
+ *         ipCidrRange: "192.168.10.0/24",
+ *         rangeName: "tf-test-secondary-range-update1",
+ *     }],
+ * });
+ * ```
+ */
 export class Subnetwork extends pulumi.CustomResource {
     /**
      * Get an existing Subnetwork resource's state with the given name, ID, and optional extra
@@ -13,8 +67,8 @@ export class Subnetwork extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkState): Subnetwork {
-        return new Subnetwork(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkState, opts?: pulumi.CustomResourceOptions): Subnetwork {
+        return new Subnetwork(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/compute/subnetworkIAMBinding.ts
+++ b/sdk/nodejs/compute/subnetworkIAMBinding.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 /**
- * ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+ * > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
  * See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
  * 
  * Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -14,9 +14,9 @@ import * as utilities from "../utilities";
  * * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
  * * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
  * 
- * ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class SubnetworkIAMBinding extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class SubnetworkIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkIAMBindingState): SubnetworkIAMBinding {
-        return new SubnetworkIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkIAMBindingState, opts?: pulumi.CustomResourceOptions): SubnetworkIAMBinding {
+        return new SubnetworkIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/subnetworkIAMMember.ts
+++ b/sdk/nodejs/compute/subnetworkIAMMember.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 /**
- * ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+ * > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
  * See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
  * 
  * Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -14,9 +14,9 @@ import * as utilities from "../utilities";
  * * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
  * * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
  * 
- * ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class SubnetworkIAMMember extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class SubnetworkIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkIAMMemberState): SubnetworkIAMMember {
-        return new SubnetworkIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkIAMMemberState, opts?: pulumi.CustomResourceOptions): SubnetworkIAMMember {
+        return new SubnetworkIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/subnetworkIAMPolicy.ts
+++ b/sdk/nodejs/compute/subnetworkIAMPolicy.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
 /**
- * ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+ * > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
  * See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
  * 
  * Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -14,9 +14,9 @@ import * as utilities from "../utilities";
  * * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
  * * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
  * 
- * ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class SubnetworkIAMPolicy extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class SubnetworkIAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkIAMPolicyState): SubnetworkIAMPolicy {
-        return new SubnetworkIAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubnetworkIAMPolicyState, opts?: pulumi.CustomResourceOptions): SubnetworkIAMPolicy {
+        return new SubnetworkIAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/targetHttpProxy.ts
+++ b/sdk/nodejs/compute/targetHttpProxy.ts
@@ -4,6 +4,58 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a TargetHttpProxy resource, which is used by one or more global
+ * forwarding rule to route incoming HTTP requests to a URL map.
+ * 
+ * 
+ * To get more information about TargetHttpProxy, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetHttpProxies)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_http_health_check_default = new gcp.compute.HttpHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "http-health-check",
+ *     requestPath: "/",
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_backend_service_default = new gcp.compute.BackendService("default", {
+ *     healthChecks: google_compute_http_health_check_default.selfLink,
+ *     name: "backend-service",
+ *     portName: "http",
+ *     protocol: "HTTP",
+ *     timeoutSec: 10,
+ * });
+ * const google_compute_url_map_default = new gcp.compute.URLMap("default", {
+ *     defaultService: google_compute_backend_service_default.selfLink,
+ *     hostRules: [{
+ *         hosts: ["mysite.com"],
+ *         pathMatcher: "allpaths",
+ *     }],
+ *     name: "url-map",
+ *     pathMatchers: [{
+ *         defaultService: google_compute_backend_service_default.selfLink,
+ *         name: "allpaths",
+ *         pathRules: [{
+ *             paths: ["/*"],
+ *             service: google_compute_backend_service_default.selfLink,
+ *         }],
+ *     }],
+ * });
+ * const google_compute_target_http_proxy_default = new gcp.compute.TargetHttpProxy("default", {
+ *     name: "test-proxy",
+ *     urlMap: google_compute_url_map_default.selfLink,
+ * });
+ * ```
+ */
 export class TargetHttpProxy extends pulumi.CustomResource {
     /**
      * Get an existing TargetHttpProxy resource's state with the given name, ID, and optional extra
@@ -13,8 +65,8 @@ export class TargetHttpProxy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetHttpProxyState): TargetHttpProxy {
-        return new TargetHttpProxy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetHttpProxyState, opts?: pulumi.CustomResourceOptions): TargetHttpProxy {
+        return new TargetHttpProxy(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/compute/targetHttpsProxy.ts
+++ b/sdk/nodejs/compute/targetHttpsProxy.ts
@@ -4,6 +4,66 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a TargetHttpsProxy resource, which is used by one or more
+ * global forwarding rule to route incoming HTTPS requests to a URL map.
+ * 
+ * 
+ * To get more information about TargetHttpsProxy, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetHttpsProxies)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * import * as fs from "fs";
+ * 
+ * const google_compute_http_health_check_default = new gcp.compute.HttpHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "http-health-check",
+ *     requestPath: "/",
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_ssl_certificate_default = new gcp.compute.SSLCertificate("default", {
+ *     certificate: fs.readFileSync("path/to/certificate.crt", "utf-8"),
+ *     name: "my-certificate",
+ *     privateKey: fs.readFileSync("path/to/private.key", "utf-8"),
+ * });
+ * const google_compute_backend_service_default = new gcp.compute.BackendService("default", {
+ *     healthChecks: google_compute_http_health_check_default.selfLink,
+ *     name: "backend-service",
+ *     portName: "http",
+ *     protocol: "HTTP",
+ *     timeoutSec: 10,
+ * });
+ * const google_compute_url_map_default = new gcp.compute.URLMap("default", {
+ *     defaultService: google_compute_backend_service_default.selfLink,
+ *     description: "a description",
+ *     hostRules: [{
+ *         hosts: ["mysite.com"],
+ *         pathMatcher: "allpaths",
+ *     }],
+ *     name: "url-map",
+ *     pathMatchers: [{
+ *         defaultService: google_compute_backend_service_default.selfLink,
+ *         name: "allpaths",
+ *         pathRules: [{
+ *             paths: ["/*"],
+ *             service: google_compute_backend_service_default.selfLink,
+ *         }],
+ *     }],
+ * });
+ * const google_compute_target_https_proxy_default = new gcp.compute.TargetHttpsProxy("default", {
+ *     name: "test-proxy",
+ *     sslCertificates: [google_compute_ssl_certificate_default.selfLink],
+ *     urlMap: google_compute_url_map_default.selfLink,
+ * });
+ * ```
+ */
 export class TargetHttpsProxy extends pulumi.CustomResource {
     /**
      * Get an existing TargetHttpsProxy resource's state with the given name, ID, and optional extra
@@ -13,8 +73,8 @@ export class TargetHttpsProxy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetHttpsProxyState): TargetHttpsProxy {
-        return new TargetHttpsProxy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetHttpsProxyState, opts?: pulumi.CustomResourceOptions): TargetHttpsProxy {
+        return new TargetHttpsProxy(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/compute/targetPool.ts
+++ b/sdk/nodejs/compute/targetPool.ts
@@ -11,6 +11,28 @@ import * as utilities from "../utilities";
  * documentation](https://cloud.google.com/compute/docs/load-balancing/network/target-pools)
  * and [API](https://cloud.google.com/compute/docs/reference/latest/targetPools).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_http_health_check_default = new gcp.compute.HttpHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "default",
+ *     requestPath: "/",
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_target_pool_default = new gcp.compute.TargetPool("default", {
+ *     healthChecks: google_compute_http_health_check_default.name,
+ *     instances: [
+ *         "us-central1-a/myinstance1",
+ *         "us-central1-b/myinstance2",
+ *     ],
+ *     name: "instance-pool",
+ * });
+ * ```
  */
 export class TargetPool extends pulumi.CustomResource {
     /**
@@ -21,8 +43,8 @@ export class TargetPool extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetPoolState): TargetPool {
-        return new TargetPool(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetPoolState, opts?: pulumi.CustomResourceOptions): TargetPool {
+        return new TargetPool(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/targetSSLProxy.ts
+++ b/sdk/nodejs/compute/targetSSLProxy.ts
@@ -4,6 +4,50 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a TargetSslProxy resource, which is used by one or more
+ * global forwarding rule to route incoming SSL requests to a backend
+ * service.
+ * 
+ * 
+ * To get more information about TargetSslProxy, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetSslProxies)
+ * * How-to Guides
+ *     * [Setting Up SSL proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * import * as fs from "fs";
+ * 
+ * const google_compute_health_check_default = new gcp.compute.HealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "health-check",
+ *     tcpHealthCheck: {
+ *         port: Number.parseFloat("443"),
+ *     },
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_ssl_certificate_default = new gcp.compute.SSLCertificate("default", {
+ *     certificate: fs.readFileSync("path/to/certificate.crt", "utf-8"),
+ *     name: "default-cert",
+ *     privateKey: fs.readFileSync("path/to/private.key", "utf-8"),
+ * });
+ * const google_compute_backend_service_default = new gcp.compute.BackendService("default", {
+ *     healthChecks: google_compute_health_check_default.selfLink,
+ *     name: "backend-service",
+ *     protocol: "SSL",
+ * });
+ * const google_compute_target_ssl_proxy_default = new gcp.compute.TargetSSLProxy("default", {
+ *     backendService: google_compute_backend_service_default.selfLink,
+ *     name: "test-proxy",
+ *     sslCertificates: google_compute_ssl_certificate_default.selfLink,
+ * });
+ * ```
+ */
 export class TargetSSLProxy extends pulumi.CustomResource {
     /**
      * Get an existing TargetSSLProxy resource's state with the given name, ID, and optional extra
@@ -13,8 +57,8 @@ export class TargetSSLProxy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetSSLProxyState): TargetSSLProxy {
-        return new TargetSSLProxy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetSSLProxyState, opts?: pulumi.CustomResourceOptions): TargetSSLProxy {
+        return new TargetSSLProxy(name, <any>state, { ...opts, id: id });
     }
 
     public readonly backendService: pulumi.Output<string>;

--- a/sdk/nodejs/compute/targetTCPProxy.ts
+++ b/sdk/nodejs/compute/targetTCPProxy.ts
@@ -4,6 +4,44 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a TargetTcpProxy resource, which is used by one or more
+ * global forwarding rule to route incoming TCP requests to a Backend
+ * service.
+ * 
+ * 
+ * To get more information about TargetTcpProxy, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetTcpProxies)
+ * * How-to Guides
+ *     * [Setting Up TCP proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_health_check_default = new gcp.compute.HealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "health-check",
+ *     tcpHealthCheck: {
+ *         port: Number.parseFloat("443"),
+ *     },
+ *     timeoutSec: 1,
+ * });
+ * const google_compute_backend_service_default = new gcp.compute.BackendService("default", {
+ *     healthChecks: google_compute_health_check_default.selfLink,
+ *     name: "backend-service",
+ *     protocol: "TCP",
+ *     timeoutSec: 10,
+ * });
+ * const google_compute_target_tcp_proxy_default = new gcp.compute.TargetTCPProxy("default", {
+ *     backendService: google_compute_backend_service_default.selfLink,
+ *     name: "test-proxy",
+ * });
+ * ```
+ */
 export class TargetTCPProxy extends pulumi.CustomResource {
     /**
      * Get an existing TargetTCPProxy resource's state with the given name, ID, and optional extra
@@ -13,8 +51,8 @@ export class TargetTCPProxy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetTCPProxyState): TargetTCPProxy {
-        return new TargetTCPProxy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TargetTCPProxyState, opts?: pulumi.CustomResourceOptions): TargetTCPProxy {
+        return new TargetTCPProxy(name, <any>state, { ...opts, id: id });
     }
 
     public readonly backendService: pulumi.Output<string>;

--- a/sdk/nodejs/compute/uRLMap.ts
+++ b/sdk/nodejs/compute/uRLMap.ts
@@ -10,6 +10,75 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/compute/docs/reference/latest/urlMaps).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_http_health_check_default = new gcp.compute.HttpHealthCheck("default", {
+ *     checkIntervalSec: 1,
+ *     name: "test",
+ *     requestPath: "/",
+ *     timeoutSec: 1,
+ * });
+ * const google_storage_bucket_static = new gcp.storage.Bucket("static", {
+ *     location: "US",
+ *     name: "static-asset-bucket",
+ * });
+ * const google_compute_backend_bucket_static = new gcp.compute.BackendBucket("static", {
+ *     bucketName: google_storage_bucket_static.name,
+ *     enableCdn: true,
+ *     name: "static-asset-backend-bucket",
+ * });
+ * const google_compute_backend_service_home = new gcp.compute.BackendService("home", {
+ *     healthChecks: google_compute_http_health_check_default.selfLink,
+ *     name: "home-backend",
+ *     portName: "http",
+ *     protocol: "HTTP",
+ *     timeoutSec: 10,
+ * });
+ * const google_compute_backend_service_login = new gcp.compute.BackendService("login", {
+ *     healthChecks: google_compute_http_health_check_default.selfLink,
+ *     name: "login-backend",
+ *     portName: "http",
+ *     protocol: "HTTP",
+ *     timeoutSec: 10,
+ * });
+ * const google_compute_url_map_foobar = new gcp.compute.URLMap("foobar", {
+ *     defaultService: google_compute_backend_service_home.selfLink,
+ *     description: "a description",
+ *     hostRules: [{
+ *         hosts: ["mysite.com"],
+ *         pathMatcher: "allpaths",
+ *     }],
+ *     name: "urlmap",
+ *     pathMatchers: [{
+ *         defaultService: google_compute_backend_service_home.selfLink,
+ *         name: "allpaths",
+ *         pathRules: [
+ *             {
+ *                 paths: ["/home"],
+ *                 service: google_compute_backend_service_home.selfLink,
+ *             },
+ *             {
+ *                 paths: ["/login"],
+ *                 service: google_compute_backend_service_login.selfLink,
+ *             },
+ *             {
+ *                 paths: ["/static"],
+ *                 service: google_compute_backend_bucket_static.selfLink,
+ *             },
+ *         ],
+ *     }],
+ *     tests: [{
+ *         host: "hi.com",
+ *         path: "/home",
+ *         service: google_compute_backend_service_home.selfLink,
+ *     }],
+ * });
+ * ```
  */
 export class URLMap extends pulumi.CustomResource {
     /**
@@ -20,8 +89,8 @@ export class URLMap extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: URLMapState): URLMap {
-        return new URLMap(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: URLMapState, opts?: pulumi.CustomResourceOptions): URLMap {
+        return new URLMap(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/compute/vPNGateway.ts
+++ b/sdk/nodejs/compute/vPNGateway.ts
@@ -4,6 +4,66 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Represents a VPN gateway running in GCP. This virtual device is managed
+ * by Google, but used only by you.
+ * 
+ * 
+ * To get more information about VpnGateway, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_address_vpn_static_ip = new gcp.compute.Address("vpn_static_ip", {
+ *     name: "vpn-static-ip",
+ * });
+ * const google_compute_network_network1 = new gcp.compute.Network("network1", {
+ *     name: "network1",
+ * });
+ * const google_compute_vpn_gateway_target_gateway = new gcp.compute.VPNGateway("target_gateway", {
+ *     name: "vpn1",
+ *     network: google_compute_network_network1.selfLink,
+ * });
+ * const google_compute_forwarding_rule_fr_esp = new gcp.compute.ForwardingRule("fr_esp", {
+ *     ipAddress: google_compute_address_vpn_static_ip.address,
+ *     ipProtocol: "ESP",
+ *     name: "fr-esp",
+ *     target: google_compute_vpn_gateway_target_gateway.selfLink,
+ * });
+ * const google_compute_forwarding_rule_fr_udp4500 = new gcp.compute.ForwardingRule("fr_udp4500", {
+ *     ipAddress: google_compute_address_vpn_static_ip.address,
+ *     ipProtocol: "UDP",
+ *     name: "fr-udp4500",
+ *     portRange: "4500",
+ *     target: google_compute_vpn_gateway_target_gateway.selfLink,
+ * });
+ * const google_compute_forwarding_rule_fr_udp500 = new gcp.compute.ForwardingRule("fr_udp500", {
+ *     ipAddress: google_compute_address_vpn_static_ip.address,
+ *     ipProtocol: "UDP",
+ *     name: "fr-udp500",
+ *     portRange: "500",
+ *     target: google_compute_vpn_gateway_target_gateway.selfLink,
+ * });
+ * const google_compute_vpn_tunnel_tunnel1 = new gcp.compute.VPNTunnel("tunnel1", {
+ *     name: "tunnel1",
+ *     peerIp: "15.0.0.120",
+ *     sharedSecret: "a secret message",
+ *     targetVpnGateway: google_compute_vpn_gateway_target_gateway.selfLink,
+ * }, {dependsOn: [google_compute_forwarding_rule_fr_esp, google_compute_forwarding_rule_fr_udp4500, google_compute_forwarding_rule_fr_udp500]});
+ * const google_compute_route_route1 = new gcp.compute.Route("route1", {
+ *     destRange: "15.0.0.0/24",
+ *     name: "route1",
+ *     network: google_compute_network_network1.name,
+ *     nextHopVpnTunnel: google_compute_vpn_tunnel_tunnel1.selfLink,
+ *     priority: 1000,
+ * });
+ * ```
+ */
 export class VPNGateway extends pulumi.CustomResource {
     /**
      * Get an existing VPNGateway resource's state with the given name, ID, and optional extra
@@ -13,8 +73,8 @@ export class VPNGateway extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: VPNGatewayState): VPNGateway {
-        return new VPNGateway(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: VPNGatewayState, opts?: pulumi.CustomResourceOptions): VPNGateway {
+        return new VPNGateway(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/compute/vPNTunnel.ts
+++ b/sdk/nodejs/compute/vPNTunnel.ts
@@ -4,6 +4,72 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * VPN tunnel resource.
+ * 
+ * 
+ * To get more information about VpnTunnel, see:
+ * 
+ * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels)
+ * * How-to Guides
+ *     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
+ *     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
+ * 
+ * > **Warning:** All arguments including the shared secret will be stored in the raw
+ * state as plain-text.
+ * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_compute_address_vpn_static_ip = new gcp.compute.Address("vpn_static_ip", {
+ *     name: "vpn-static-ip",
+ * });
+ * const google_compute_network_network1 = new gcp.compute.Network("network1", {
+ *     name: "network1",
+ * });
+ * const google_compute_vpn_gateway_target_gateway = new gcp.compute.VPNGateway("target_gateway", {
+ *     name: "vpn1",
+ *     network: google_compute_network_network1.selfLink,
+ * });
+ * const google_compute_forwarding_rule_fr_esp = new gcp.compute.ForwardingRule("fr_esp", {
+ *     ipAddress: google_compute_address_vpn_static_ip.address,
+ *     ipProtocol: "ESP",
+ *     name: "fr-esp",
+ *     target: google_compute_vpn_gateway_target_gateway.selfLink,
+ * });
+ * const google_compute_forwarding_rule_fr_udp4500 = new gcp.compute.ForwardingRule("fr_udp4500", {
+ *     ipAddress: google_compute_address_vpn_static_ip.address,
+ *     ipProtocol: "UDP",
+ *     name: "fr-udp4500",
+ *     portRange: "4500",
+ *     target: google_compute_vpn_gateway_target_gateway.selfLink,
+ * });
+ * const google_compute_forwarding_rule_fr_udp500 = new gcp.compute.ForwardingRule("fr_udp500", {
+ *     ipAddress: google_compute_address_vpn_static_ip.address,
+ *     ipProtocol: "UDP",
+ *     name: "fr-udp500",
+ *     portRange: "500",
+ *     target: google_compute_vpn_gateway_target_gateway.selfLink,
+ * });
+ * const google_compute_vpn_tunnel_tunnel1 = new gcp.compute.VPNTunnel("tunnel1", {
+ *     name: "tunnel1",
+ *     peerIp: "15.0.0.120",
+ *     sharedSecret: "a secret message",
+ *     targetVpnGateway: google_compute_vpn_gateway_target_gateway.selfLink,
+ * }, {dependsOn: [google_compute_forwarding_rule_fr_esp, google_compute_forwarding_rule_fr_udp4500, google_compute_forwarding_rule_fr_udp500]});
+ * const google_compute_route_route1 = new gcp.compute.Route("route1", {
+ *     destRange: "15.0.0.0/24",
+ *     name: "route1",
+ *     network: google_compute_network_network1.name,
+ *     nextHopVpnTunnel: google_compute_vpn_tunnel_tunnel1.selfLink,
+ *     priority: 1000,
+ * });
+ * ```
+ */
 export class VPNTunnel extends pulumi.CustomResource {
     /**
      * Get an existing VPNTunnel resource's state with the given name, ID, and optional extra
@@ -13,8 +79,8 @@ export class VPNTunnel extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: VPNTunnelState): VPNTunnel {
-        return new VPNTunnel(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: VPNTunnelState, opts?: pulumi.CustomResourceOptions): VPNTunnel {
+        return new VPNTunnel(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly creationTimestamp: pulumi.Output<string>;

--- a/sdk/nodejs/container/cluster.ts
+++ b/sdk/nodejs/container/cluster.ts
@@ -10,8 +10,48 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters).
  * 
- * ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+ * 
+ * ## Example usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_container_cluster_primary = new gcp.container.Cluster("primary", {
+ *     additionalZones: [
+ *         "us-central1-b",
+ *         "us-central1-c",
+ *     ],
+ *     initialNodeCount: 3,
+ *     masterAuth: {
+ *         password: "adoy.rm",
+ *         username: "mr.yoda",
+ *     },
+ *     name: "marcellus-wallace",
+ *     nodeConfig: {
+ *         labels: {
+ *             foo: "bar",
+ *         },
+ *         oauthScopes: [
+ *             "https://www.googleapis.com/auth/compute",
+ *             "https://www.googleapis.com/auth/devstorage.read_only",
+ *             "https://www.googleapis.com/auth/logging.write",
+ *             "https://www.googleapis.com/auth/monitoring",
+ *         ],
+ *         tags: [
+ *             "foo",
+ *             "bar",
+ *         ],
+ *     },
+ *     zone: "us-central1-a",
+ * });
+ * 
+ * export const clientCertificate = google_container_cluster_primary.masterAuth.apply(__arg0 => __arg0.clientCertificate);
+ * export const clientKey = google_container_cluster_primary.masterAuth.apply(__arg0 => __arg0.clientKey);
+ * export const clusterCaCertificate = google_container_cluster_primary.masterAuth.apply(__arg0 => __arg0.clusterCaCertificate);
+ * ```
  */
 export class Cluster extends pulumi.CustomResource {
     /**
@@ -22,8 +62,8 @@ export class Cluster extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ClusterState): Cluster {
-        return new Cluster(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ClusterState, opts?: pulumi.CustomResourceOptions): Cluster {
+        return new Cluster(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/container/getCluster.ts
+++ b/sdk/nodejs/container/getCluster.ts
@@ -6,6 +6,25 @@ import * as utilities from "../utilities";
 
 /**
  * Get info about a cluster within GKE from its name and zone.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_container_cluster_my_cluster = pulumi.output(gcp.container.getCluster({
+ *     name: "my-cluster",
+ *     zone: "us-east1-a",
+ * }));
+ * 
+ * export const clusterPassword = google_container_cluster_my_cluster.apply(__arg0 => __arg0.masterAuths[0].password);
+ * export const clusterUsername = google_container_cluster_my_cluster.apply(__arg0 => __arg0.masterAuths[0].username);
+ * export const endpoint = google_container_cluster_my_cluster.apply(__arg0 => __arg0.endpoint);
+ * export const instanceGroupUrls = google_container_cluster_my_cluster.apply(__arg0 => __arg0.instanceGroupUrls);
+ * export const nodeConfig = google_container_cluster_my_cluster.apply(__arg0 => __arg0.nodeConfigs);
+ * export const nodePools = google_container_cluster_my_cluster.apply(__arg0 => __arg0.nodePools);
+ * ```
  */
 export function getCluster(args: GetClusterArgs, opts?: pulumi.InvokeOptions): Promise<GetClusterResult> {
     return pulumi.runtime.invoke("gcp:container/getCluster:getCluster", {

--- a/sdk/nodejs/container/getRegistryImage.ts
+++ b/sdk/nodejs/container/getRegistryImage.ts
@@ -8,6 +8,17 @@ import * as utilities from "../utilities";
  * This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project.
  * 
  * The URLs are computed entirely offline - as long as the project exists, they will be valid, but this data source does not contact Google Container Registry (GCR) at any point.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_container_registry_repository_foo = pulumi.output(gcp.container.getRegistryRepository({}));
+ * 
+ * export const gcrLocation = google_container_registry_repository_foo.apply(__arg0 => __arg0.repositoryUrl);
+ * ```
  */
 export function getRegistryImage(args: GetRegistryImageArgs, opts?: pulumi.InvokeOptions): Promise<GetRegistryImageResult> {
     return pulumi.runtime.invoke("gcp:container/getRegistryImage:getRegistryImage", {

--- a/sdk/nodejs/container/getRegistryRepository.ts
+++ b/sdk/nodejs/container/getRegistryRepository.ts
@@ -8,6 +8,17 @@ import * as utilities from "../utilities";
  * This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project.
  * 
  * The URLs are computed entirely offline - as long as the project exists, they will be valid, but this data source does not contact Google Container Registry (GCR) at any point.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_container_registry_repository_foo = pulumi.output(gcp.container.getRegistryRepository({}));
+ * 
+ * export const gcrLocation = google_container_registry_repository_foo.apply(__arg0 => __arg0.repositoryUrl);
+ * ```
  */
 export function getRegistryRepository(args?: GetRegistryRepositoryArgs, opts?: pulumi.InvokeOptions): Promise<GetRegistryRepositoryResult> {
     args = args || {};

--- a/sdk/nodejs/container/nodePool.ts
+++ b/sdk/nodejs/container/nodePool.ts
@@ -19,8 +19,8 @@ export class NodePool extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NodePoolState): NodePool {
-        return new NodePool(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NodePoolState, opts?: pulumi.CustomResourceOptions): NodePool {
+        return new NodePool(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/containeranalysis/note.ts
+++ b/sdk/nodejs/containeranalysis/note.ts
@@ -4,6 +4,34 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * Provides a detailed description of a Note.
+ * 
+ * > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+ * See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+ * 
+ * To get more information about Note, see:
+ * 
+ * * [API documentation](https://cloud.google.com/container-analysis/api/reference/rest/)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/container-analysis/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_container_analysis_note_note = new gcp.containeranalysis.Note("note", {
+ *     attestationAuthority: {
+ *         hint: {
+ *             humanReadableName: "Attestor Note",
+ *         },
+ *     },
+ *     name: "test-attestor-note",
+ * });
+ * ```
+ */
 export class Note extends pulumi.CustomResource {
     /**
      * Get an existing Note resource's state with the given name, ID, and optional extra
@@ -13,8 +41,8 @@ export class Note extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NoteState): Note {
-        return new Note(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NoteState, opts?: pulumi.CustomResourceOptions): Note {
+        return new Note(name, <any>state, { ...opts, id: id });
     }
 
     public readonly attestationAuthority: pulumi.Output<{ hint: { humanReadableName: string } }>;

--- a/sdk/nodejs/dataflow/job.ts
+++ b/sdk/nodejs/dataflow/job.ts
@@ -9,6 +9,23 @@ import * as utilities from "../utilities";
  * the official documentation for
  * [Beam](https://beam.apache.org) and [Dataflow](https://cloud.google.com/dataflow/).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_dataflow_job_big_data_job = new gcp.dataflow.Job("big_data_job", {
+ *     name: "dataflow-job",
+ *     parameters: {
+ *         baz: "qux",
+ *         foo: "bar",
+ *     },
+ *     tempGcsLocation: "gs://my-bucket/tmp_dir",
+ *     templateGcsPath: "gs://my-bucket/templates/template_file",
+ * });
+ * ```
  */
 export class Job extends pulumi.CustomResource {
     /**
@@ -19,8 +36,8 @@ export class Job extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: JobState): Job {
-        return new Job(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: JobState, opts?: pulumi.CustomResourceOptions): Job {
+        return new Job(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/dataproc/cluster.ts
+++ b/sdk/nodejs/dataproc/cluster.ts
@@ -12,6 +12,63 @@ import * as utilities from "../utilities";
  * !> **Warning:** Due to limitations of the API, all arguments except
  * `labels`,`cluster_config.worker_config.num_instances` and `cluster_config.preemptible_worker_config.num_instances` are non-updateable. Changing others will cause recreation of the
  * whole cluster!
+ * 
+ * ## Example usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_dataproc_cluster_mycluster = new gcp.dataproc.Cluster("mycluster", {
+ *     clusterConfig: {
+ *         gceClusterConfig: {
+ *             tags: [
+ *                 "foo",
+ *                 "bar",
+ *             ],
+ *         },
+ *         initializationActions: [{
+ *             script: "gs://dataproc-initialization-actions/stackdriver/stackdriver.sh",
+ *             timeoutSec: 500,
+ *         }],
+ *         masterConfig: {
+ *             diskConfig: {
+ *                 bootDiskSizeGb: 10,
+ *                 bootDiskType: "pd-ssd",
+ *             },
+ *             machineType: "n1-standard-1",
+ *             numInstances: 1,
+ *         },
+ *         preemptibleWorkerConfig: {
+ *             numInstances: 0,
+ *         },
+ *         softwareConfig: {
+ *             imageVersion: "1.3.7-deb9",
+ *             overrideProperties: {
+ *                 dataproc:dataproc.allow.zero.workers: "true",
+ *             },
+ *         },
+ *         stagingBucket: "dataproc-staging-bucket",
+ *         workerConfig: {
+ *             diskConfig: {
+ *                 bootDiskSizeGb: 10,
+ *                 numLocalSsds: 1,
+ *             },
+ *             machineType: "n1-standard-1",
+ *             numInstances: 2,
+ *         },
+ *     },
+ *     labels: {
+ *         foo: "bar",
+ *     },
+ *     name: "mycluster",
+ *     region: "us-central1",
+ * });
+ * const google_dataproc_cluster_simplecluster = new gcp.dataproc.Cluster("simplecluster", {
+ *     name: "simplecluster",
+ *     region: "us-central1",
+ * });
+ * ```
  */
 export class Cluster extends pulumi.CustomResource {
     /**
@@ -22,8 +79,8 @@ export class Cluster extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ClusterState): Cluster {
-        return new Cluster(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ClusterState, opts?: pulumi.CustomResourceOptions): Cluster {
+        return new Cluster(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/dataproc/job.ts
+++ b/sdk/nodejs/dataproc/job.ts
@@ -9,6 +9,54 @@ import * as utilities from "../utilities";
  * [the official dataproc documentation](https://cloud.google.com/dataproc/).
  * 
  * !> **Note:** This resource does not support 'update' and changing any attributes will cause the resource to be recreated.
+ * 
+ * ## Example usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_dataproc_cluster_mycluster = new gcp.dataproc.Cluster("mycluster", {
+ *     name: "dproc-cluster-unique-name",
+ *     region: "us-central1",
+ * });
+ * const google_dataproc_job_pyspark = new gcp.dataproc.Job("pyspark", {
+ *     forceDelete: true,
+ *     placement: {
+ *         clusterName: google_dataproc_cluster_mycluster.name,
+ *     },
+ *     pysparkConfig: {
+ *         mainPythonFileUri: "gs://dataproc-examples-2f10d78d114f6aaec76462e3c310f31f/src/pyspark/hello-world/hello-world.py",
+ *         properties: {
+ *             spark.logConf: "true",
+ *         },
+ *     },
+ *     region: google_dataproc_cluster_mycluster.region,
+ * });
+ * const google_dataproc_job_spark = new gcp.dataproc.Job("spark", {
+ *     forceDelete: true,
+ *     placement: {
+ *         clusterName: google_dataproc_cluster_mycluster.name,
+ *     },
+ *     region: google_dataproc_cluster_mycluster.region,
+ *     sparkConfig: {
+ *         args: ["1000"],
+ *         jarFileUris: ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+ *         loggingConfig: {
+ *             driverLogLevels: {
+ *                 root: "INFO",
+ *             },
+ *         },
+ *         mainClass: "org.apache.spark.examples.SparkPi",
+ *         properties: {
+ *             spark.logConf: "true",
+ *         },
+ *     },
+ * });
+ * 
+ * export const pysparkStatus = google_dataproc_job_pyspark.status.apply(__arg0 => __arg0.state);
+ * export const sparkStatus = google_dataproc_job_spark.status.apply(__arg0 => __arg0.state);
+ * ```
  */
 export class Job extends pulumi.CustomResource {
     /**
@@ -19,8 +67,8 @@ export class Job extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: JobState): Job {
-        return new Job(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: JobState, opts?: pulumi.CustomResourceOptions): Job {
+        return new Job(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/dns/managedZone.ts
+++ b/sdk/nodejs/dns/managedZone.ts
@@ -7,6 +7,22 @@ import * as utilities from "../utilities";
 /**
  * Manages a zone within Google Cloud DNS. For more information see [the official documentation](https://cloud.google.com/dns/zones/) and
  * [API](https://cloud.google.com/dns/api/v1/managedZones).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_dns_managed_zone_prod = new gcp.dns.ManagedZone("prod", {
+ *     description: "Production DNS zone",
+ *     dnsName: "prod.mydomain.com.",
+ *     labels: {
+ *         foo: "bar",
+ *     },
+ *     name: "prod-zone",
+ * });
+ * ```
  */
 export class ManagedZone extends pulumi.CustomResource {
     /**
@@ -17,8 +33,8 @@ export class ManagedZone extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ManagedZoneState): ManagedZone {
-        return new ManagedZone(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ManagedZoneState, opts?: pulumi.CustomResourceOptions): ManagedZone {
+        return new ManagedZone(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/endpoints/service.ts
+++ b/sdk/nodejs/endpoints/service.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * This resource creates and rolls out a Cloud Endpoints service using OpenAPI or gRPC.  View the relevant docs for [OpenAPI](https://cloud.google.com/endpoints/docs/openapi/) and [gRPC](https://cloud.google.com/endpoints/docs/grpc/).
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * import * as fs from "fs";
+ * 
+ * const google_endpoints_service_grpc_service = new gcp.endpoints.Service("grpc_service", {
+ *     grpcConfig: fs.readFileSync("service_spec.yml", "utf-8"),
+ *     project: "project-id",
+ *     protocOutput: fs.readFileSync("compiled_descriptor_file.pb", "utf-8"),
+ *     serviceName: "api-name.endpoints.project-id.cloud.goog",
+ * });
+ * const google_endpoints_service_openapi_service = new gcp.endpoints.Service("openapi_service", {
+ *     openapiConfig: fs.readFileSync("openapi_spec.yml", "utf-8"),
+ *     project: "project-id",
+ *     serviceName: "api-name.endpoints.project-id.cloud.goog",
+ * });
+ * ```
+ * The example in `examples/endpoints_on_compute_engine` shows the API from the quickstart running on a Compute Engine VM and reachable through Cloud Endpoints, which may also be useful.
+ * 
  */
 export class Service extends pulumi.CustomResource {
     /**
@@ -16,8 +38,8 @@ export class Service extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ServiceState): Service {
-        return new Service(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ServiceState, opts?: pulumi.CustomResourceOptions): Service {
+        return new Service(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly apis: pulumi.Output<{ methods: { name: string, requestType: string, responseType: string, syntax: string }[], name: string, syntax: string, version: string }[]>;

--- a/sdk/nodejs/filestore/instance.ts
+++ b/sdk/nodejs/filestore/instance.ts
@@ -4,6 +4,41 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * A Google Cloud Filestore instance.
+ * 
+ * > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+ * See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+ * 
+ * To get more information about Instance, see:
+ * 
+ * * [API documentation](https://cloud.google.com/filestore/docs/reference/rest/v1beta1/projects.locations.instances/create)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/filestore/docs/creating-instances)
+ *     * [Use with Kubernetes](https://cloud.google.com/filestore/docs/accessing-fileshares)
+ *     * [Copying Data In/Out](https://cloud.google.com/filestore/docs/copying-data)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_filestore_instance_instance = new gcp.filestore.Instance("instance", {
+ *     fileShares: {
+ *         capacityGb: 2660,
+ *         name: "share1",
+ *     },
+ *     name: "test-instance",
+ *     networks: [{
+ *         modes: ["MODE_IPV4"],
+ *         network: "default",
+ *     }],
+ *     tier: "PREMIUM",
+ *     zone: "us-central1-b",
+ * });
+ * ```
+ */
 export class Instance extends pulumi.CustomResource {
     /**
      * Get an existing Instance resource's state with the given name, ID, and optional extra
@@ -13,8 +48,8 @@ export class Instance extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState): Instance {
-        return new Instance(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState, opts?: pulumi.CustomResourceOptions): Instance {
+        return new Instance(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly createTime: pulumi.Output<string>;

--- a/sdk/nodejs/folder/iAMBinding.ts
+++ b/sdk/nodejs/folder/iAMBinding.ts
@@ -8,9 +8,26 @@ import * as utilities from "../utilities";
  * Allows creation and management of a single binding within IAM policy for
  * an existing Google Cloud Platform folder.
  * 
- * ~> **Note:** This resource _must not_ be used in conjunction with
+ * > **Note:** This resource _must not_ be used in conjunction with
  *    `google_folder_iam_policy` or they will fight over what your policy
  *    should be.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_department1 = new gcp.organizations.Folder("department1", {
+ *     displayName: "Department 1",
+ *     parent: "organizations/1234567",
+ * });
+ * const google_folder_iam_binding_admin = new gcp.folder.IAMBinding("admin", {
+ *     folder: google_folder_department1.name,
+ *     members: ["user:jane@example.com"],
+ *     role: "roles/editor",
+ * });
+ * ```
  */
 export class IAMBinding extends pulumi.CustomResource {
     /**
@@ -21,8 +38,8 @@ export class IAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState): IAMBinding {
-        return new IAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState, opts?: pulumi.CustomResourceOptions): IAMBinding {
+        return new IAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/folder/iAMMember.ts
+++ b/sdk/nodejs/folder/iAMMember.ts
@@ -8,10 +8,27 @@ import * as utilities from "../utilities";
  * Allows creation and management of a single member for a single binding within
  * the IAM policy for an existing Google Cloud Platform folder.
  * 
- * ~> **Note:** This resource _must not_ be used in conjunction with
+ * > **Note:** This resource _must not_ be used in conjunction with
  *    `google_folder_iam_policy` or they will fight over what your policy
  *    should be. Similarly, roles controlled by `google_folder_iam_binding`
  *    should not be assigned to using `google_folder_iam_member`.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_department1 = new gcp.organizations.Folder("department1", {
+ *     displayName: "Department 1",
+ *     parent: "organizations/1234567",
+ * });
+ * const google_folder_iam_member_admin = new gcp.folder.IAMMember("admin", {
+ *     folder: google_folder_department1.name,
+ *     member: "user:jane@example.com",
+ *     role: "roles/editor",
+ * });
+ * ```
  */
 export class IAMMember extends pulumi.CustomResource {
     /**
@@ -22,8 +39,8 @@ export class IAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState): IAMMember {
-        return new IAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState, opts?: pulumi.CustomResourceOptions): IAMMember {
+        return new IAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/folder/iAMPolicy.ts
+++ b/sdk/nodejs/folder/iAMPolicy.ts
@@ -7,6 +7,28 @@ import * as utilities from "../utilities";
 /**
  * Allows creation and management of the IAM policy for an existing Google Cloud
  * Platform folder.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_iam_policy_admin = pulumi.output(gcp.organizations.getIAMPolicy({
+ *     bindings: [{
+ *         members: ["user:jane@example.com"],
+ *         role: "roles/editor",
+ *     }],
+ * }));
+ * const google_folder_department1 = new gcp.organizations.Folder("department1", {
+ *     displayName: "Department 1",
+ *     parent: "organizations/1234567",
+ * });
+ * const google_folder_iam_policy_folder_admin_policy = new gcp.folder.IAMPolicy("folder_admin_policy", {
+ *     folder: google_folder_department1.name,
+ *     policyData: google_iam_policy_admin.apply(__arg0 => __arg0.policyData),
+ * });
+ * ```
  */
 export class IAMPolicy extends pulumi.CustomResource {
     /**
@@ -17,8 +39,8 @@ export class IAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState): IAMPolicy {
-        return new IAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState, opts?: pulumi.CustomResourceOptions): IAMPolicy {
+        return new IAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/folder/organizationPolicy.ts
+++ b/sdk/nodejs/folder/organizationPolicy.ts
@@ -9,6 +9,72 @@ import * as utilities from "../utilities";
  * [the official
  * documentation](https://cloud.google.com/resource-manager/docs/organization-policy/overview) and
  * [API](https://cloud.google.com/resource-manager/reference/rest/v1/folders/setOrgPolicy).
+ * 
+ * ## Example Usage
+ * 
+ * To set policy with a [boolean constraint](https://cloud.google.com/resource-manager/docs/organization-policy/quickstart-boolean-constraints):
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_organization_policy_serial_port_policy = new gcp.folder.OrganizationPolicy("serial_port_policy", {
+ *     booleanPolicy: {
+ *         enforced: true,
+ *     },
+ *     constraint: "compute.disableSerialPortAccess",
+ *     folder: "folders/123456789",
+ * });
+ * ```
+ * 
+ * To set a policy with a [list contraint](https://cloud.google.com/resource-manager/docs/organization-policy/quickstart-list-constraints):
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_organization_policy_services_policy = new gcp.folder.OrganizationPolicy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     folder: "folders/123456789",
+ *     listPolicy: {
+ *         allow: {
+ *             all: true,
+ *         },
+ *     },
+ * });
+ * ```
+ * 
+ * Or to deny some services, use the following instead:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_organization_policy_services_policy = new gcp.folder.OrganizationPolicy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     folder: "folders/123456789",
+ *     listPolicy: {
+ *         deny: {
+ *             values: ["cloudresourcemanager.googleapis.com"],
+ *         },
+ *         suggestedValues: "compute.googleapis.com",
+ *     },
+ * });
+ * ```
+ * To restore the default folder organization policy, use the following instead:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_organization_policy_services_policy = new gcp.folder.OrganizationPolicy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     folder: "folders/123456789",
+ *     restorePolicy: {
+ *         default: true,
+ *     },
+ * });
+ * ```
  */
 export class OrganizationPolicy extends pulumi.CustomResource {
     /**
@@ -19,8 +85,8 @@ export class OrganizationPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationPolicyState): OrganizationPolicy {
-        return new OrganizationPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationPolicyState, opts?: pulumi.CustomResourceOptions): OrganizationPolicy {
+        return new OrganizationPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/cryptoKey.ts
+++ b/sdk/nodejs/kms/cryptoKey.ts
@@ -13,13 +13,31 @@ import * as utilities from "../utilities";
  * A CryptoKey is an interface to key material which can be used to encrypt and decrypt data. A CryptoKey belongs to a
  * Google Cloud KMS KeyRing.
  * 
- * ~> Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a
+ * > Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a
  * Terraform-managed CryptoKey will remove it from state and delete all
  * CryptoKeyVersions, rendering the key unusable, but **will not delete the
  * resource on the server**. When Terraform destroys these keys, any data
  * previously encrypted with these keys will be irrecoverable. For this reason, it
  * is strongly recommended that you add lifecycle hooks to the resource to prevent
  * accidental destruction.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_kms_key_ring_my_key_ring = new gcp.kms.KeyRing("my_key_ring", {
+ *     location: "us-central1",
+ *     name: "my-key-ring",
+ *     project: "my-project",
+ * });
+ * const google_kms_crypto_key_my_crypto_key = new gcp.kms.CryptoKey("my_crypto_key", {
+ *     keyRing: google_kms_key_ring_my_key_ring.selfLink,
+ *     name: "my-crypto-key",
+ *     rotationPeriod: "100000s",
+ * });
+ * ```
  */
 export class CryptoKey extends pulumi.CustomResource {
     /**
@@ -30,8 +48,8 @@ export class CryptoKey extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: CryptoKeyState): CryptoKey {
-        return new CryptoKey(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: CryptoKeyState, opts?: pulumi.CustomResourceOptions): CryptoKey {
+        return new CryptoKey(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/cryptoKeyIAMBinding.ts
+++ b/sdk/nodejs/kms/cryptoKeyIAMBinding.ts
@@ -7,6 +7,19 @@ import * as utilities from "../utilities";
 /**
  * Allows creation and management of a single binding within IAM policy for
  * an existing Google Cloud KMS crypto key.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_kms_crypto_key_iam_binding_crypto_key = new gcp.kms.CryptoKeyIAMBinding("crypto_key", {
+ *     cryptoKeyId: "my-gcp-project/us-central1/my-key-ring/my-crypto-key",
+ *     members: ["user:jane@example.com"],
+ *     role: "roles/editor",
+ * });
+ * ```
  */
 export class CryptoKeyIAMBinding extends pulumi.CustomResource {
     /**
@@ -17,8 +30,8 @@ export class CryptoKeyIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: CryptoKeyIAMBindingState): CryptoKeyIAMBinding {
-        return new CryptoKeyIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: CryptoKeyIAMBindingState, opts?: pulumi.CustomResourceOptions): CryptoKeyIAMBinding {
+        return new CryptoKeyIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/cryptoKeyIAMMember.ts
+++ b/sdk/nodejs/kms/cryptoKeyIAMMember.ts
@@ -8,10 +8,23 @@ import * as utilities from "../utilities";
  * Allows creation and management of a single member for a single binding within
  * the IAM policy for an existing Google Cloud KMS crypto key.
  * 
- * ~> **Note:** This resource _must not_ be used in conjunction with
+ * > **Note:** This resource _must not_ be used in conjunction with
  *    `google_kms_crypto_key_iam_policy` or they will fight over what your policy
  *    should be. Similarly, roles controlled by `google_kms_crypto_key_iam_binding`
  *    should not be assigned to using `google_kms_crypto_key_iam_member`.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_kms_crypto_key_iam_member_crypto_key = new gcp.kms.CryptoKeyIAMMember("crypto_key", {
+ *     cryptoKeyId: "your-crypto-key-id",
+ *     member: "user:jane@example.com",
+ *     role: "roles/editor",
+ * });
+ * ```
  */
 export class CryptoKeyIAMMember extends pulumi.CustomResource {
     /**
@@ -22,8 +35,8 @@ export class CryptoKeyIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: CryptoKeyIAMMemberState): CryptoKeyIAMMember {
-        return new CryptoKeyIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: CryptoKeyIAMMemberState, opts?: pulumi.CustomResourceOptions): CryptoKeyIAMMember {
+        return new CryptoKeyIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/getKMSSecret.ts
+++ b/sdk/nodejs/kms/getKMSSecret.ts
@@ -11,10 +11,12 @@ import * as utilities from "../utilities";
  * For more information see
  * [the official documentation](https://cloud.google.com/kms/docs/encrypt-decrypt).
  * 
- * ~> **NOTE**: Using this data provider will allow you to conceal secret data within your
+ * > **NOTE**: Using this data provider will allow you to conceal secret data within your
  * resource definitions, but it does not take care of protecting that data in the
  * logging output, plan output, or state output.  Please take care to secure your secret
  * data outside of resource definitions.
+ * This will result in a Cloud SQL user being created with password `my-secret-password`.
+ * 
  */
 export function getKMSSecret(args: GetKMSSecretArgs, opts?: pulumi.InvokeOptions): Promise<GetKMSSecretResult> {
     return pulumi.runtime.invoke("gcp:kms/getKMSSecret:getKMSSecret", {

--- a/sdk/nodejs/kms/keyRing.ts
+++ b/sdk/nodejs/kms/keyRing.ts
@@ -13,8 +13,20 @@ import * as utilities from "../utilities";
  * A KeyRing is a grouping of CryptoKeys for organizational purposes. A KeyRing belongs to a Google Cloud Platform Project
  * and resides in a specific location.
  * 
- * ~> Note: KeyRings cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyRing will remove it
+ * > Note: KeyRings cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyRing will remove it
  * from state but **will not delete the resource on the server**.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_kms_key_ring_my_key_ring = new gcp.kms.KeyRing("my_key_ring", {
+ *     location: "us-central1",
+ *     name: "my-key-ring",
+ * });
+ * ```
  */
 export class KeyRing extends pulumi.CustomResource {
     /**
@@ -25,8 +37,8 @@ export class KeyRing extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingState): KeyRing {
-        return new KeyRing(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingState, opts?: pulumi.CustomResourceOptions): KeyRing {
+        return new KeyRing(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/keyRingIAMBinding.ts
+++ b/sdk/nodejs/kms/keyRingIAMBinding.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
  * * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
  * 
- * ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class KeyRingIAMBinding extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class KeyRingIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingIAMBindingState): KeyRingIAMBinding {
-        return new KeyRingIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingIAMBindingState, opts?: pulumi.CustomResourceOptions): KeyRingIAMBinding {
+        return new KeyRingIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/keyRingIAMMember.ts
+++ b/sdk/nodejs/kms/keyRingIAMMember.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
  * * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
  * 
- * ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class KeyRingIAMMember extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class KeyRingIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingIAMMemberState): KeyRingIAMMember {
-        return new KeyRingIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingIAMMemberState, opts?: pulumi.CustomResourceOptions): KeyRingIAMMember {
+        return new KeyRingIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/keyRingIAMPolicy.ts
+++ b/sdk/nodejs/kms/keyRingIAMPolicy.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
  * * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
  * 
- * ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class KeyRingIAMPolicy extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class KeyRingIAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingIAMPolicyState): KeyRingIAMPolicy {
-        return new KeyRingIAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyRingIAMPolicyState, opts?: pulumi.CustomResourceOptions): KeyRingIAMPolicy {
+        return new KeyRingIAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/kms/registry.ts
+++ b/sdk/nodejs/kms/registry.ts
@@ -9,6 +9,42 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/iot/docs/) and
  * [API](https://cloud.google.com/iot/docs/reference/cloudiot/rest/v1/projects.locations.registries).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * import * as fs from "fs";
+ * 
+ * const google_pubsub_topic_default_devicestatus = new gcp.pubsub.Topic("default-devicestatus", {
+ *     name: "default-devicestatus",
+ * });
+ * const google_pubsub_topic_default_telemetry = new gcp.pubsub.Topic("default-telemetry", {
+ *     name: "default-telemetry",
+ * });
+ * const google_cloudiot_registry_default_registry = new gcp.kms.Registry("default-registry", {
+ *     credentials: [{
+ *         publicKeyCertificate: {
+ *             certificate: fs.readFileSync("rsa_cert.pem", "utf-8"),
+ *             format: "X509_CERTIFICATE_PEM",
+ *         },
+ *     }],
+ *     eventNotificationConfig: {
+ *         pubsub_topic_name: google_pubsub_topic_default_telemetry.id,
+ *     },
+ *     httpConfig: {
+ *         http_enabled_state: "HTTP_ENABLED",
+ *     },
+ *     mqttConfig: {
+ *         mqtt_enabled_state: "MQTT_ENABLED",
+ *     },
+ *     name: "default-registry",
+ *     stateNotificationConfig: {
+ *         pubsub_topic_name: google_pubsub_topic_default_devicestatus.id,
+ *     },
+ * });
+ * ```
  */
 export class Registry extends pulumi.CustomResource {
     /**
@@ -19,8 +55,8 @@ export class Registry extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegistryState): Registry {
-        return new Registry(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RegistryState, opts?: pulumi.CustomResourceOptions): Registry {
+        return new Registry(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/logging/billingAccountExclusion.ts
+++ b/sdk/nodejs/logging/billingAccountExclusion.ts
@@ -11,6 +11,20 @@ import * as utilities from "../utilities";
  * 
  * Note that you must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
  * granted to the credentials used with Terraform.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_logging_billing_account_exclusion_my_exclusion = new gcp.logging.BillingAccountExclusion("my-exclusion", {
+ *     billingAccount: "ABCDEF-012345-GHIJKL",
+ *     description: "Exclude GCE instance debug logs",
+ *     filter: "resource.type = gce_instance AND severity <= DEBUG",
+ *     name: "my-instance-debug-exclusion",
+ * });
+ * ```
  */
 export class BillingAccountExclusion extends pulumi.CustomResource {
     /**
@@ -21,8 +35,8 @@ export class BillingAccountExclusion extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BillingAccountExclusionState): BillingAccountExclusion {
-        return new BillingAccountExclusion(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BillingAccountExclusionState, opts?: pulumi.CustomResourceOptions): BillingAccountExclusion {
+        return new BillingAccountExclusion(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/logging/billingAccountSink.ts
+++ b/sdk/nodejs/logging/billingAccountSink.ts
@@ -9,10 +9,30 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/logging/docs/) and
  * [Exporting Logs in the API](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
  * 
- * ~> **Note** You must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
+ * > **Note** You must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
  * [granted on the billing account](https://cloud.google.com/billing/reference/rest/v1/billingAccounts/getIamPolicy) to
  * the credentials used with Terraform. [IAM roles granted on a billing account](https://cloud.google.com/billing/docs/how-to/billing-access) are separate from the
  * typical IAM roles granted on a project.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_log_bucket = new gcp.storage.Bucket("log-bucket", {
+ *     name: "billing-logging-bucket",
+ * });
+ * const google_logging_billing_account_sink_my_sink = new gcp.logging.BillingAccountSink("my-sink", {
+ *     billingAccount: "ABCDEF-012345-GHIJKL",
+ *     destination: google_storage_bucket_log_bucket.name.apply(__arg0 => `storage.googleapis.com/${__arg0}`),
+ *     name: "my-sink",
+ * });
+ * const google_project_iam_binding_log_writer = new gcp.projects.IAMBinding("log-writer", {
+ *     members: [google_logging_billing_account_sink_my_sink.writerIdentity],
+ *     role: "roles/storage.objectCreator",
+ * });
+ * ```
  */
 export class BillingAccountSink extends pulumi.CustomResource {
     /**
@@ -23,8 +43,8 @@ export class BillingAccountSink extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BillingAccountSinkState): BillingAccountSink {
-        return new BillingAccountSink(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BillingAccountSinkState, opts?: pulumi.CustomResourceOptions): BillingAccountSink {
+        return new BillingAccountSink(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/logging/folderExclusion.ts
+++ b/sdk/nodejs/logging/folderExclusion.ts
@@ -11,6 +11,24 @@ import * as utilities from "../utilities";
  * 
  * Note that you must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
  * granted to the credentials used with Terraform.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_my_folder = new gcp.organizations.Folder("my-folder", {
+ *     displayName: "My folder",
+ *     parent: "organizations/123456",
+ * });
+ * const google_logging_folder_exclusion_my_exclusion = new gcp.logging.FolderExclusion("my-exclusion", {
+ *     description: "Exclude GCE instance debug logs",
+ *     filter: "resource.type = gce_instance AND severity <= DEBUG",
+ *     folder: google_folder_my_folder.name,
+ *     name: "my-instance-debug-exclusion",
+ * });
+ * ```
  */
 export class FolderExclusion extends pulumi.CustomResource {
     /**
@@ -21,8 +39,8 @@ export class FolderExclusion extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FolderExclusionState): FolderExclusion {
-        return new FolderExclusion(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FolderExclusionState, opts?: pulumi.CustomResourceOptions): FolderExclusion {
+        return new FolderExclusion(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/logging/folderSink.ts
+++ b/sdk/nodejs/logging/folderSink.ts
@@ -11,6 +11,31 @@ import * as utilities from "../utilities";
  * 
  * Note that you must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
  * granted to the credentials used with terraform.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_my_folder = new gcp.organizations.Folder("my-folder", {
+ *     displayName: "My folder",
+ *     parent: "organizations/123456",
+ * });
+ * const google_storage_bucket_log_bucket = new gcp.storage.Bucket("log-bucket", {
+ *     name: "folder-logging-bucket",
+ * });
+ * const google_logging_folder_sink_my_sink = new gcp.logging.FolderSink("my-sink", {
+ *     destination: google_storage_bucket_log_bucket.name.apply(__arg0 => `storage.googleapis.com/${__arg0}`),
+ *     filter: "resource.type = gce_instance AND severity >= WARN",
+ *     folder: google_folder_my_folder.name,
+ *     name: "my-sink",
+ * });
+ * const google_project_iam_binding_log_writer = new gcp.projects.IAMBinding("log-writer", {
+ *     members: [google_logging_folder_sink_my_sink.writerIdentity],
+ *     role: "roles/storage.objectCreator",
+ * });
+ * ```
  */
 export class FolderSink extends pulumi.CustomResource {
     /**
@@ -21,8 +46,8 @@ export class FolderSink extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FolderSinkState): FolderSink {
-        return new FolderSink(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FolderSinkState, opts?: pulumi.CustomResourceOptions): FolderSink {
+        return new FolderSink(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/logging/organizationExclusion.ts
+++ b/sdk/nodejs/logging/organizationExclusion.ts
@@ -11,6 +11,20 @@ import * as utilities from "../utilities";
  * 
  * Note that you must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
  * granted to the credentials used with Terraform.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_logging_organization_exclusion_my_exclusion = new gcp.logging.OrganizationExclusion("my-exclusion", {
+ *     description: "Exclude GCE instance debug logs",
+ *     filter: "resource.type = gce_instance AND severity <= DEBUG",
+ *     name: "my-instance-debug-exclusion",
+ *     orgId: "123456789",
+ * });
+ * ```
  */
 export class OrganizationExclusion extends pulumi.CustomResource {
     /**
@@ -21,8 +35,8 @@ export class OrganizationExclusion extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationExclusionState): OrganizationExclusion {
-        return new OrganizationExclusion(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationExclusionState, opts?: pulumi.CustomResourceOptions): OrganizationExclusion {
+        return new OrganizationExclusion(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/logging/organizationSink.ts
+++ b/sdk/nodejs/logging/organizationSink.ts
@@ -11,6 +11,27 @@ import * as utilities from "../utilities";
  * 
  * Note that you must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
  * granted to the credentials used with terraform.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_log_bucket = new gcp.storage.Bucket("log-bucket", {
+ *     name: "organization-logging-bucket",
+ * });
+ * const google_logging_organization_sink_my_sink = new gcp.logging.OrganizationSink("my-sink", {
+ *     destination: google_storage_bucket_log_bucket.name.apply(__arg0 => `storage.googleapis.com/${__arg0}`),
+ *     filter: "resource.type = gce_instance AND severity >= WARN",
+ *     name: "my-sink",
+ *     orgId: "123456789",
+ * });
+ * const google_project_iam_binding_log_writer = new gcp.projects.IAMBinding("log-writer", {
+ *     members: [google_logging_organization_sink_my_sink.writerIdentity],
+ *     role: "roles/storage.objectCreator",
+ * });
+ * ```
  */
 export class OrganizationSink extends pulumi.CustomResource {
     /**
@@ -21,8 +42,8 @@ export class OrganizationSink extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationSinkState): OrganizationSink {
-        return new OrganizationSink(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationSinkState, opts?: pulumi.CustomResourceOptions): OrganizationSink {
+        return new OrganizationSink(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/logging/projectExclusion.ts
+++ b/sdk/nodejs/logging/projectExclusion.ts
@@ -11,6 +11,19 @@ import * as utilities from "../utilities";
  * 
  * Note that you must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
  * granted to the credentials used with Terraform.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_logging_project_exclusion_my_exclusion = new gcp.logging.ProjectExclusion("my-exclusion", {
+ *     description: "Exclude GCE instance debug logs",
+ *     filter: "resource.type = gce_instance AND severity <= DEBUG",
+ *     name: "my-instance-debug-exclusion",
+ * });
+ * ```
  */
 export class ProjectExclusion extends pulumi.CustomResource {
     /**
@@ -21,8 +34,8 @@ export class ProjectExclusion extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectExclusionState): ProjectExclusion {
-        return new ProjectExclusion(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectExclusionState, opts?: pulumi.CustomResourceOptions): ProjectExclusion {
+        return new ProjectExclusion(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/monitoring/alertPolicy.ts
+++ b/sdk/nodejs/monitoring/alertPolicy.ts
@@ -4,6 +4,43 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * A description of the conditions under which some aspect of your system is
+ * considered to be "unhealthy" and the ways to notify people or services
+ * about this state.
+ * 
+ * 
+ * To get more information about AlertPolicy, see:
+ * 
+ * * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/monitoring/alerts/)
+ * 
+ * ## Example Usage
+ * 
+ * ### Basic Usage
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_monitoring_alert_policy_basic = new gcp.monitoring.AlertPolicy("basic", {
+ *     combiner: "OR",
+ *     conditions: [{
+ *         conditionThreshold: {
+ *             aggregations: [{
+ *                 alignmentPeriod: "60s",
+ *                 perSeriesAligner: "ALIGN_RATE",
+ *             }],
+ *             comparison: "COMPARISON_GT",
+ *             duration: "60s",
+ *             filter: "metric.type=\"compute.googleapis.com/instance/disk/write_bytes_count\" AND resource.type=\"gce_instance\"",
+ *         },
+ *         displayName: "test condition",
+ *     }],
+ *     displayName: "Test Policy Basic",
+ * });
+ * ```
+ */
 export class AlertPolicy extends pulumi.CustomResource {
     /**
      * Get an existing AlertPolicy resource's state with the given name, ID, and optional extra
@@ -13,8 +50,8 @@ export class AlertPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AlertPolicyState): AlertPolicy {
-        return new AlertPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AlertPolicyState, opts?: pulumi.CustomResourceOptions): AlertPolicy {
+        return new AlertPolicy(name, <any>state, { ...opts, id: id });
     }
 
     public readonly combiner: pulumi.Output<string>;

--- a/sdk/nodejs/organizations/folder.ts
+++ b/sdk/nodejs/organizations/folder.ts
@@ -18,6 +18,22 @@ import * as utilities from "../utilities";
  * resource must have `roles/resourcemanager.folderCreator`. See the
  * [Access Control for Folders Using IAM](https://cloud.google.com/resource-manager/docs/access-control-folders)
  * doc for more information.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_department1 = new gcp.organizations.Folder("department1", {
+ *     displayName: "Department 1",
+ *     parent: "organizations/1234567",
+ * });
+ * const google_folder_team_abc = new gcp.organizations.Folder("team-abc", {
+ *     displayName: "Team ABC",
+ *     parent: google_folder_department1.name,
+ * });
+ * ```
  */
 export class Folder extends pulumi.CustomResource {
     /**
@@ -28,8 +44,8 @@ export class Folder extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FolderState): Folder {
-        return new Folder(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: FolderState, opts?: pulumi.CustomResourceOptions): Folder {
+        return new Folder(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/organizations/getActiveFolder.ts
+++ b/sdk/nodejs/organizations/getActiveFolder.ts
@@ -6,6 +6,18 @@ import * as utilities from "../utilities";
 
 /**
  * Get an active folder within GCP by `display_name` and `parent`.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_active_folder_department1 = pulumi.output(gcp.organizations.getActiveFolder({
+ *     displayName: "Department 1",
+ *     parent: "organizations/1234567",
+ * }));
+ * ```
  */
 export function getActiveFolder(args: GetActiveFolderArgs, opts?: pulumi.InvokeOptions): Promise<GetActiveFolderResult> {
     return pulumi.runtime.invoke("gcp:organizations/getActiveFolder:getActiveFolder", {

--- a/sdk/nodejs/organizations/getClientConfig.ts
+++ b/sdk/nodejs/organizations/getClientConfig.ts
@@ -6,6 +6,17 @@ import * as utilities from "../utilities";
 
 /**
  * Use this data source to access the configuration of the Google Cloud provider.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_client_config_current = pulumi.output(gcp.organizations.getClientConfig({}));
+ * 
+ * export const project = google_client_config_current.apply(__arg0 => __arg0.project);
+ * ```
  */
 export function getClientConfig(opts?: pulumi.InvokeOptions): Promise<GetClientConfigResult> {
     return pulumi.runtime.invoke("gcp:organizations/getClientConfig:getClientConfig", {

--- a/sdk/nodejs/organizations/getFolder.ts
+++ b/sdk/nodejs/organizations/getFolder.ts
@@ -8,6 +8,26 @@ import * as utilities from "../utilities";
  * Use this data source to get information about a Google Cloud Folder.
  * 
  * ```hcl
+ * # Get folder by id
+ * data "google_folder" "my_folder_1" {
+ *   folder = "folders/12345"
+ *   lookup_organization = true
+ * }
+ * 
+ * # Search by fields
+ * data "google_folder" "my_folder_2" {
+ *   folder = "folders/23456"
+ * }
+ * 
+ * output "my_folder_1_organization" {
+ *   value = "${data.google_folder.my_folder_1.organization}"
+ * }
+ * 
+ * output "my_folder_2_parent" {
+ *   value = "${data.google_folder.my_folder_2.parent}"
+ * }
+ * 
+ * ```
  */
 export function getFolder(args: GetFolderArgs, opts?: pulumi.InvokeOptions): Promise<GetFolderResult> {
     return pulumi.runtime.invoke("gcp:organizations/getFolder:getFolder", {

--- a/sdk/nodejs/organizations/getProject.ts
+++ b/sdk/nodejs/organizations/getProject.ts
@@ -8,6 +8,17 @@ import * as utilities from "../utilities";
  * Use this data source to get project details.
  * For more information see 
  * [API](https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_project = pulumi.output(gcp.organizations.getProject({}));
+ * 
+ * export const projectNumber = google_project_project.apply(__arg0 => __arg0.number);
+ * ```
  */
 export function getProject(args?: GetProjectArgs, opts?: pulumi.InvokeOptions): Promise<GetProjectResult> {
     args = args || {};

--- a/sdk/nodejs/organizations/getProjectServices.ts
+++ b/sdk/nodejs/organizations/getProjectServices.ts
@@ -9,6 +9,19 @@ import * as utilities from "../utilities";
  * 
  * For a list of services available, visit the
  * [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_services_project = pulumi.output(gcp.organizations.getProjectServices({
+ *     project: "your-project-id",
+ * }));
+ * 
+ * export const projectServices = google_project_services_project.apply(__arg0 => __arg0.services.join(","));
+ * ```
  */
 export function getProjectServices(args?: GetProjectServicesArgs, opts?: pulumi.InvokeOptions): Promise<GetProjectServicesResult> {
     args = args || {};

--- a/sdk/nodejs/organizations/iAMBinding.ts
+++ b/sdk/nodejs/organizations/iAMBinding.ts
@@ -8,9 +8,22 @@ import * as utilities from "../utilities";
  * Allows creation and management of a single binding within IAM policy for
  * an existing Google Cloud Platform Organization.
  * 
- * ~> **Note:** This resource __must not__ be used in conjunction with
+ * > **Note:** This resource __must not__ be used in conjunction with
  *    `google_organization_iam_member` for the __same role__ or they will fight over
  *    what your policy should be.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_organization_iam_binding_binding = new gcp.organizations.IAMBinding("binding", {
+ *     members: ["user:jane@example.com"],
+ *     orgId: "123456789",
+ *     role: "roles/browser",
+ * });
+ * ```
  */
 export class IAMBinding extends pulumi.CustomResource {
     /**
@@ -21,8 +34,8 @@ export class IAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState): IAMBinding {
-        return new IAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState, opts?: pulumi.CustomResourceOptions): IAMBinding {
+        return new IAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/organizations/iAMCustomRole.ts
+++ b/sdk/nodejs/organizations/iAMCustomRole.ts
@@ -10,12 +10,33 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/iam/reference/rest/v1/organizations.roles).
  * 
- * ~> **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
+ * > **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
  *  from this and how roles are propagated. 1) creating a role may involve undeleting and then updating a role with the
  *  same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
  *  after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is
  *  made available again. This means a deleted role that has been deleted for more than 7 days cannot be changed at all
  *  by Terraform, and new roles cannot share that name.
+ *  
+ * ## Example Usage
+ * 
+ * This snippet creates a customized IAM organization role.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_organization_iam_custom_role_my_custom_role = new gcp.organizations.IAMCustomRole("my-custom-role", {
+ *     description: "A description",
+ *     orgId: "123456789",
+ *     permissions: [
+ *         "iam.roles.list",
+ *         "iam.roles.create",
+ *         "iam.roles.delete",
+ *     ],
+ *     roleId: "myCustomRole",
+ *     title: "My Custom Role",
+ * });
+ * ```
  */
 export class IAMCustomRole extends pulumi.CustomResource {
     /**
@@ -26,8 +47,8 @@ export class IAMCustomRole extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMCustomRoleState): IAMCustomRole {
-        return new IAMCustomRole(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMCustomRoleState, opts?: pulumi.CustomResourceOptions): IAMCustomRole {
+        return new IAMCustomRole(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/organizations/iAMMember.ts
+++ b/sdk/nodejs/organizations/iAMMember.ts
@@ -8,9 +8,22 @@ import * as utilities from "../utilities";
  * Allows creation and management of a single member for a single binding within
  * the IAM policy for an existing Google Cloud Platform Organization.
  * 
- * ~> **Note:** This resource __must not__ be used in conjunction with
+ * > **Note:** This resource __must not__ be used in conjunction with
  *    `google_organization_iam_binding` for the __same role__ or they will fight over
  *    what your policy should be.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_organization_iam_member_binding = new gcp.organizations.IAMMember("binding", {
+ *     member: "user:jane@example.com",
+ *     orgId: "0123456789",
+ *     role: "roles/editor",
+ * });
+ * ```
  */
 export class IAMMember extends pulumi.CustomResource {
     /**
@@ -21,8 +34,8 @@ export class IAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState): IAMMember {
-        return new IAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState, opts?: pulumi.CustomResourceOptions): IAMMember {
+        return new IAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/organizations/iAMPolicy.ts
+++ b/sdk/nodejs/organizations/iAMPolicy.ts
@@ -7,7 +7,7 @@ import * as utilities from "../utilities";
 /**
  * Allows management of the entire IAM policy for an existing Google Cloud Platform Organization.
  * 
- * ~> **Warning:** New organizations have several default policies which will,
+ * > **Warning:** New organizations have several default policies which will,
  *    without extreme caution, be **overwritten** by use of this resource.
  *    The safest alternative is to use multiple `google_organization_iam_binding`
  *    resources.  It is easy to use this resource to remove your own access to
@@ -16,9 +16,27 @@ import * as utilities from "../utilities";
  *    the best way to be sure that you are not making dangerous changes is to start
  *    by importing your existing policy, and examining the diff very closely.
  * 
- * ~> **Note:** This resource __must not__ be used in conjunction with
+ * > **Note:** This resource __must not__ be used in conjunction with
  *    `google_organization_iam_member` or `google_organization_iam_binding`
  *    or they will fight over what your policy should be.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_iam_policy_admin = pulumi.output(gcp.organizations.getIAMPolicy({
+ *     bindings: [{
+ *         members: ["user:jane@example.com"],
+ *         role: "roles/editor",
+ *     }],
+ * }));
+ * const google_organization_iam_policy_policy = new gcp.organizations.IAMPolicy("policy", {
+ *     orgId: "123456789",
+ *     policyData: google_iam_policy_admin.apply(__arg0 => __arg0.policyData),
+ * });
+ * ```
  */
 export class IAMPolicy extends pulumi.CustomResource {
     /**
@@ -29,8 +47,8 @@ export class IAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState): IAMPolicy {
-        return new IAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState, opts?: pulumi.CustomResourceOptions): IAMPolicy {
+        return new IAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly etag: pulumi.Output<string>;

--- a/sdk/nodejs/organizations/policy.ts
+++ b/sdk/nodejs/organizations/policy.ts
@@ -9,6 +9,71 @@ import * as utilities from "../utilities";
  * [the official
  * documentation](https://cloud.google.com/resource-manager/docs/organization-policy/overview) and
  * [API](https://cloud.google.com/resource-manager/reference/rest/v1/organizations/setOrgPolicy).
+ * 
+ * ## Example Usage
+ * 
+ * To set policy with a [boolean constraint](https://cloud.google.com/resource-manager/docs/organization-policy/quickstart-boolean-constraints):
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_organization_policy_serial_port_policy = new gcp.organizations.Policy("serial_port_policy", {
+ *     booleanPolicy: {
+ *         enforced: true,
+ *     },
+ *     constraint: "compute.disableSerialPortAccess",
+ *     orgId: "123456789",
+ * });
+ * ```
+ * 
+ * To set a policy with a [list contraint](https://cloud.google.com/resource-manager/docs/organization-policy/quickstart-list-constraints):
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_organization_policy_services_policy = new gcp.organizations.Policy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     listPolicy: {
+ *         allow: {
+ *             all: true,
+ *         },
+ *     },
+ *     orgId: "123456789",
+ * });
+ * ```
+ * Or to deny some services, use the following instead:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_organization_policy_services_policy = new gcp.organizations.Policy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     listPolicy: {
+ *         deny: {
+ *             values: ["cloudresourcemanager.googleapis.com"],
+ *         },
+ *         suggestedValues: "compute.googleapis.com",
+ *     },
+ *     orgId: "123456789",
+ * });
+ * ```
+ * To restore the default organization policy, use the following instead:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_organization_policy_services_policy = new gcp.organizations.Policy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     orgId: "123456789",
+ *     restorePolicy: {
+ *         default: true,
+ *     },
+ * });
+ * ```
  */
 export class Policy extends pulumi.CustomResource {
     /**
@@ -19,8 +84,8 @@ export class Policy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: PolicyState): Policy {
-        return new Policy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: PolicyState, opts?: pulumi.CustomResourceOptions): Policy {
+        return new Policy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/organizations/project.ts
+++ b/sdk/nodejs/organizations/project.ts
@@ -29,9 +29,53 @@ import * as utilities from "../utilities";
  *   used just like always, keeping in mind that Terraform will attempt to undo any changes
  *   made outside Terraform.
  * 
- * ~> It's important to note that any project resources that were added to your Terraform config
+ * > It's important to note that any project resources that were added to your Terraform config
  * prior to 0.8.5 will continue to function as they always have, and will not be managed by
  * Terraform. Only newly added projects are affected.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_my_project = new gcp.organizations.Project("my_project", {
+ *     name: "My Project",
+ *     orgId: "1234567",
+ *     projectId: "your-project-id",
+ * });
+ * ```
+ * To create a project under a specific folder
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_department1 = new gcp.organizations.Folder("department1", {
+ *     displayName: "Department 1",
+ *     parent: "organizations/1234567",
+ * });
+ * const google_project_my_project_in_a_folder = new gcp.organizations.Project("my_project-in-a-folder", {
+ *     folderId: google_folder_department1.name,
+ *     name: "My Project",
+ *     projectId: "your-project-id",
+ * });
+ * ```
+ * To create a project with an App Engine app attached
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_my_app_engine_app = new gcp.organizations.Project("my-app-engine-app", {
+ *     appEngine: {
+ *         locationId: "us-central",
+ *     },
+ *     name: "App Engine Project",
+ *     orgId: "1234567",
+ *     projectId: "app-engine-project",
+ * });
+ * ```
  */
 export class Project extends pulumi.CustomResource {
     /**
@@ -42,8 +86,8 @@ export class Project extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectState): Project {
-        return new Project(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ProjectState, opts?: pulumi.CustomResourceOptions): Project {
+        return new Project(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/projects/iAMBinding.ts
+++ b/sdk/nodejs/projects/iAMBinding.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
  * * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
  * 
- * ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class IAMBinding extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class IAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState): IAMBinding {
-        return new IAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState, opts?: pulumi.CustomResourceOptions): IAMBinding {
+        return new IAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/projects/iAMCustomRole.ts
+++ b/sdk/nodejs/projects/iAMCustomRole.ts
@@ -10,12 +10,32 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/iam/reference/rest/v1/projects.roles).
  * 
- * ~> **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
+ * > **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
  *  from this and how roles are propagated. 1) creating a role may involve undeleting and then updating a role with the
  *  same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
  *  after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is
  *  made available again. This means a deleted role that has been deleted for more than 7 days cannot be changed at all
  *  by Terraform, and new roles cannot share that name.
+ * 
+ * ## Example Usage
+ * 
+ * This snippet creates a customized IAM role.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_iam_custom_role_my_custom_role = new gcp.projects.IAMCustomRole("my-custom-role", {
+ *     description: "A description",
+ *     permissions: [
+ *         "iam.roles.list",
+ *         "iam.roles.create",
+ *         "iam.roles.delete",
+ *     ],
+ *     roleId: "myCustomRole",
+ *     title: "My Custom Role",
+ * });
+ * ```
  */
 export class IAMCustomRole extends pulumi.CustomResource {
     /**
@@ -26,8 +46,8 @@ export class IAMCustomRole extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMCustomRoleState): IAMCustomRole {
-        return new IAMCustomRole(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMCustomRoleState, opts?: pulumi.CustomResourceOptions): IAMCustomRole {
+        return new IAMCustomRole(name, <any>state, { ...opts, id: id });
     }
 
     public readonly deleted: pulumi.Output<boolean | undefined>;

--- a/sdk/nodejs/projects/iAMMember.ts
+++ b/sdk/nodejs/projects/iAMMember.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
  * * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
  * 
- * ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class IAMMember extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class IAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState): IAMMember {
-        return new IAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState, opts?: pulumi.CustomResourceOptions): IAMMember {
+        return new IAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/projects/iAMPolicy.ts
+++ b/sdk/nodejs/projects/iAMPolicy.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
  * * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
  * 
- * ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class IAMPolicy extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class IAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState): IAMPolicy {
-        return new IAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState, opts?: pulumi.CustomResourceOptions): IAMPolicy {
+        return new IAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/projects/organizationPolicy.ts
+++ b/sdk/nodejs/projects/organizationPolicy.ts
@@ -9,6 +9,72 @@ import * as utilities from "../utilities";
  * [the official
  * documentation](https://cloud.google.com/resource-manager/docs/organization-policy/overview) and
  * [API](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setOrgPolicy).
+ * 
+ * ## Example Usage
+ * 
+ * To set policy with a [boolean constraint](https://cloud.google.com/resource-manager/docs/organization-policy/quickstart-boolean-constraints):
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_organization_policy_serial_port_policy = new gcp.projects.OrganizationPolicy("serial_port_policy", {
+ *     booleanPolicy: {
+ *         enforced: true,
+ *     },
+ *     constraint: "compute.disableSerialPortAccess",
+ *     project: "your-project-id",
+ * });
+ * ```
+ * 
+ * To set a policy with a [list contraint](https://cloud.google.com/resource-manager/docs/organization-policy/quickstart-list-constraints):
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_organization_policy_services_policy = new gcp.projects.OrganizationPolicy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     listPolicy: {
+ *         allow: {
+ *             all: true,
+ *         },
+ *     },
+ *     project: "your-project-id",
+ * });
+ * ```
+ * 
+ * Or to deny some services, use the following instead:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_organization_policy_services_policy = new gcp.projects.OrganizationPolicy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     listPolicy: {
+ *         deny: {
+ *             values: ["cloudresourcemanager.googleapis.com"],
+ *         },
+ *         suggestedValues: "compute.googleapis.com",
+ *     },
+ *     project: "your-project-id",
+ * });
+ * ```
+ * To restore the default project organization policy, use the following instead:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_organization_policy_services_policy = new gcp.projects.OrganizationPolicy("services_policy", {
+ *     constraint: "serviceuser.services",
+ *     project: "your-project-id",
+ *     restorePolicy: {
+ *         default: true,
+ *     },
+ * });
+ * ```
  */
 export class OrganizationPolicy extends pulumi.CustomResource {
     /**
@@ -19,8 +85,8 @@ export class OrganizationPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationPolicyState): OrganizationPolicy {
-        return new OrganizationPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: OrganizationPolicyState, opts?: pulumi.CustomResourceOptions): OrganizationPolicy {
+        return new OrganizationPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/projects/service.ts
+++ b/sdk/nodejs/projects/service.ts
@@ -10,8 +10,20 @@ import * as utilities from "../utilities";
  * For a list of services available, visit the
  * [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
  * 
- * ~> **Note:** This resource _must not_ be used in conjunction with
+ * > **Note:** This resource _must not_ be used in conjunction with
  *    `google_project_services` or they will fight over which services should be enabled.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_service_project = new gcp.projects.Service("project", {
+ *     project: "your-project-id",
+ *     service: "iam.googleapis.com",
+ * });
+ * ```
  */
 export class Service extends pulumi.CustomResource {
     /**
@@ -22,8 +34,8 @@ export class Service extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ServiceState): Service {
-        return new Service(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ServiceState, opts?: pulumi.CustomResourceOptions): Service {
+        return new Service(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/projects/services.ts
+++ b/sdk/nodejs/projects/services.ts
@@ -12,10 +12,25 @@ import * as utilities from "../utilities";
  * For a list of services available, visit the
  * [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
  * 
- * ~> **Note:** This resource attempts to be the authoritative source on *all* enabled APIs, which often
+ * > **Note:** This resource attempts to be the authoritative source on *all* enabled APIs, which often
  * 	leads to conflicts when certain actions enable other APIs. If you do not need to ensure that
  * 	*exclusively* a particular set of APIs are enabled, you should most likely use the
  * 	google_project_service resource, one resource per API.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_services_project = new gcp.projects.Services("project", {
+ *     project: "your-project-id",
+ *     services: [
+ *         "iam.googleapis.com",
+ *         "cloudresourcemanager.googleapis.com",
+ *     ],
+ * });
+ * ```
  */
 export class Services extends pulumi.CustomResource {
     /**
@@ -26,8 +41,8 @@ export class Services extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ServicesState): Services {
-        return new Services(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ServicesState, opts?: pulumi.CustomResourceOptions): Services {
+        return new Services(name, <any>state, { ...opts, id: id });
     }
 
     public readonly disableOnDestroy: pulumi.Output<boolean | undefined>;

--- a/sdk/nodejs/projects/usageExportBucket.ts
+++ b/sdk/nodejs/projects/usageExportBucket.ts
@@ -29,9 +29,53 @@ import * as utilities from "../utilities";
  *   used just like always, keeping in mind that Terraform will attempt to undo any changes
  *   made outside Terraform.
  * 
- * ~> It's important to note that any project resources that were added to your Terraform config
+ * > It's important to note that any project resources that were added to your Terraform config
  * prior to 0.8.5 will continue to function as they always have, and will not be managed by
  * Terraform. Only newly added projects are affected.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_my_project = new gcp.organizations.Project("my_project", {
+ *     name: "My Project",
+ *     orgId: "1234567",
+ *     projectId: "your-project-id",
+ * });
+ * ```
+ * To create a project under a specific folder
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_folder_department1 = new gcp.organizations.Folder("department1", {
+ *     displayName: "Department 1",
+ *     parent: "organizations/1234567",
+ * });
+ * const google_project_my_project_in_a_folder = new gcp.organizations.Project("my_project-in-a-folder", {
+ *     folderId: google_folder_department1.name,
+ *     name: "My Project",
+ *     projectId: "your-project-id",
+ * });
+ * ```
+ * To create a project with an App Engine app attached
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_my_app_engine_app = new gcp.organizations.Project("my-app-engine-app", {
+ *     appEngine: {
+ *         locationId: "us-central",
+ *     },
+ *     name: "App Engine Project",
+ *     orgId: "1234567",
+ *     projectId: "app-engine-project",
+ * });
+ * ```
  */
 export class UsageExportBucket extends pulumi.CustomResource {
     /**
@@ -42,8 +86,8 @@ export class UsageExportBucket extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: UsageExportBucketState): UsageExportBucket {
-        return new UsageExportBucket(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: UsageExportBucketState, opts?: pulumi.CustomResourceOptions): UsageExportBucket {
+        return new UsageExportBucket(name, <any>state, { ...opts, id: id });
     }
 
     public readonly bucketName: pulumi.Output<string>;

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -5,7 +5,10 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
- * The provider type for the google package
+ * The provider type for the google package. By default, resources use package-wide configuration
+ * settings, however an explicit `Provider` instance may be created and passed during resource
+ * construction to achieve fine-grained programmatic control over provider settings. See the
+ * [documentation](https://pulumi.io/reference/programming-model.html#providers) for more information.
  */
 export class Provider extends pulumi.ProviderResource {
 

--- a/sdk/nodejs/pubsub/subscription.ts
+++ b/sdk/nodejs/pubsub/subscription.ts
@@ -9,6 +9,43 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/pubsub/docs) and
  * [API](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_pubsub_topic_default_topic = new gcp.pubsub.Topic("default-topic", {
+ *     name: "default-topic",
+ * });
+ * const google_pubsub_subscription_default = new gcp.pubsub.Subscription("default", {
+ *     ackDeadlineSeconds: 20,
+ *     name: "default-subscription",
+ *     pushConfig: {
+ *         attributes: {
+ *             x-goog-version: "v1",
+ *         },
+ *         pushEndpoint: "https://example.com/push",
+ *     },
+ *     topic: google_pubsub_topic_default_topic.name,
+ * });
+ * ```
+ * If the subscription has a topic in a different project:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_pubsub_topic_topic_different_project = new gcp.pubsub.Topic("topic-different-project", {
+ *     name: "topic-different-project",
+ *     project: "another-project",
+ * });
+ * const google_pubsub_subscription_default = new gcp.pubsub.Subscription("default", {
+ *     name: "default-subscription",
+ *     topic: google_pubsub_topic_topic_different_project.id,
+ * });
+ * ```
  */
 export class Subscription extends pulumi.CustomResource {
     /**
@@ -19,8 +56,8 @@ export class Subscription extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionState): Subscription {
-        return new Subscription(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionState, opts?: pulumi.CustomResourceOptions): Subscription {
+        return new Subscription(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/pubsub/subscriptionIAMBinding.ts
+++ b/sdk/nodejs/pubsub/subscriptionIAMBinding.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
  * * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
  * 
- * ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class SubscriptionIAMBinding extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class SubscriptionIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionIAMBindingState): SubscriptionIAMBinding {
-        return new SubscriptionIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionIAMBindingState, opts?: pulumi.CustomResourceOptions): SubscriptionIAMBinding {
+        return new SubscriptionIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/pubsub/subscriptionIAMMember.ts
+++ b/sdk/nodejs/pubsub/subscriptionIAMMember.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
  * * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
  * 
- * ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class SubscriptionIAMMember extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class SubscriptionIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionIAMMemberState): SubscriptionIAMMember {
-        return new SubscriptionIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionIAMMemberState, opts?: pulumi.CustomResourceOptions): SubscriptionIAMMember {
+        return new SubscriptionIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/pubsub/subscriptionIAMPolicy.ts
+++ b/sdk/nodejs/pubsub/subscriptionIAMPolicy.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
  * * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
  * 
- * ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class SubscriptionIAMPolicy extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class SubscriptionIAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionIAMPolicyState): SubscriptionIAMPolicy {
-        return new SubscriptionIAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: SubscriptionIAMPolicyState, opts?: pulumi.CustomResourceOptions): SubscriptionIAMPolicy {
+        return new SubscriptionIAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/pubsub/topic.ts
+++ b/sdk/nodejs/pubsub/topic.ts
@@ -9,6 +9,17 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/pubsub/docs) and
  * [API](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_pubsub_topic_mytopic = new gcp.pubsub.Topic("mytopic", {
+ *     name: "default-topic",
+ * });
+ * ```
  */
 export class Topic extends pulumi.CustomResource {
     /**
@@ -19,8 +30,8 @@ export class Topic extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicState): Topic {
-        return new Topic(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicState, opts?: pulumi.CustomResourceOptions): Topic {
+        return new Topic(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/pubsub/topicIAMBinding.ts
+++ b/sdk/nodejs/pubsub/topicIAMBinding.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
  * * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
  * 
- * ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class TopicIAMBinding extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class TopicIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicIAMBindingState): TopicIAMBinding {
-        return new TopicIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicIAMBindingState, opts?: pulumi.CustomResourceOptions): TopicIAMBinding {
+        return new TopicIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/pubsub/topicIAMMember.ts
+++ b/sdk/nodejs/pubsub/topicIAMMember.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
  * * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
  * 
- * ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class TopicIAMMember extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class TopicIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicIAMMemberState): TopicIAMMember {
-        return new TopicIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicIAMMemberState, opts?: pulumi.CustomResourceOptions): TopicIAMMember {
+        return new TopicIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/pubsub/topicIAMPolicy.ts
+++ b/sdk/nodejs/pubsub/topicIAMPolicy.ts
@@ -11,9 +11,9 @@ import * as utilities from "../utilities";
  * * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
  * * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
  * 
- * ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class TopicIAMPolicy extends pulumi.CustomResource {
     /**
@@ -24,8 +24,8 @@ export class TopicIAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicIAMPolicyState): TopicIAMPolicy {
-        return new TopicIAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: TopicIAMPolicyState, opts?: pulumi.CustomResourceOptions): TopicIAMPolicy {
+        return new TopicIAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/redis/instance.ts
+++ b/sdk/nodejs/redis/instance.ts
@@ -4,6 +4,52 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * A Google Cloud Redis instance.
+ * 
+ * 
+ * To get more information about Instance, see:
+ * 
+ * * [API documentation](https://cloud.google.com/memorystore/docs/redis/reference/rest/)
+ * * How-to Guides
+ *     * [Official Documentation](https://cloud.google.com/memorystore/docs/redis/)
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_redis_instance_cache = new gcp.redis.Instance("cache", {
+ *     memorySizeGb: 1,
+ *     name: "memory-cache",
+ * });
+ * ```
+ * resource "google_redis_instance" "cache" {
+ *   name           = "ha-memory-cache"
+ *   tier           = "STANDARD_HA"
+ *   memory_size_gb = 1
+ * 
+ *   location_id             = "us-central1-a"
+ *   alternative_location_id = "us-central1-f"
+ * 
+ *   authorized_network = "${google_compute_network.auto-network.self_link}"
+ * 
+ *   redis_version     = "REDIS_3_2"
+ *   display_name      = "Terraform Test Instance"
+ *   reserved_ip_range = "192.168.0.0/29"
+ * 
+ *   labels {
+ *     my_key    = "my_val"
+ *     other_key = "other_val"
+ *   }
+ * }
+ * 
+ * resource "google_compute_network" "auto-network" {
+ *   name = "authorized-network"
+ * }
+ * 
+ */
 export class Instance extends pulumi.CustomResource {
     /**
      * Get an existing Instance resource's state with the given name, ID, and optional extra
@@ -13,8 +59,8 @@ export class Instance extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState): Instance {
-        return new Instance(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState, opts?: pulumi.CustomResourceOptions): Instance {
+        return new Instance(name, <any>state, { ...opts, id: id });
     }
 
     public readonly alternativeLocationId: pulumi.Output<string>;

--- a/sdk/nodejs/resourcemanager/lien.ts
+++ b/sdk/nodejs/resourcemanager/lien.ts
@@ -4,6 +4,29 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "../utilities";
 
+/**
+ * A Lien represents an encumbrance on the actions that can be performed on a resource.
+ * 
+ * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_project_project = new gcp.organizations.Project("project", {
+ *     name: "A very important project!",
+ *     projectId: "staging-project",
+ * });
+ * const google_resource_manager_lien_lien = new gcp.resourcemanager.Lien("lien", {
+ *     origin: "machine-readable-explanation",
+ *     parent: google_project_project.number.apply(__arg0 => `projects/${__arg0}`),
+ *     reason: "This project is an important environment",
+ *     restrictions: ["resourcemanager.projects.delete"],
+ * });
+ * ```
+ */
 export class Lien extends pulumi.CustomResource {
     /**
      * Get an existing Lien resource's state with the given name, ID, and optional extra
@@ -13,8 +36,8 @@ export class Lien extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: LienState): Lien {
-        return new Lien(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: LienState, opts?: pulumi.CustomResourceOptions): Lien {
+        return new Lien(name, <any>state, { ...opts, id: id });
     }
 
     public /*out*/ readonly createTime: pulumi.Output<string>;

--- a/sdk/nodejs/runtimeconfig/config.ts
+++ b/sdk/nodejs/runtimeconfig/config.ts
@@ -9,6 +9,20 @@ import * as utilities from "../utilities";
  * [official documentation](https://cloud.google.com/deployment-manager/runtime-configurator/),
  * or the
  * [JSON API](https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/).
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a RuntimeConfig resource.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_runtimeconfig_config_my_runtime_config = new gcp.runtimeconfig.Config("my-runtime-config", {
+ *     description: "Runtime configuration values for my service",
+ *     name: "my-service-runtime-config",
+ * });
+ * ```
  */
 export class Config extends pulumi.CustomResource {
     /**
@@ -19,8 +33,8 @@ export class Config extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ConfigState): Config {
-        return new Config(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ConfigState, opts?: pulumi.CustomResourceOptions): Config {
+        return new Config(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/runtimeconfig/variavble.ts
+++ b/sdk/nodejs/runtimeconfig/variavble.ts
@@ -9,6 +9,45 @@ import * as utilities from "../utilities";
  * [official documentation](https://cloud.google.com/deployment-manager/runtime-configurator/),
  * or the
  * [JSON API](https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/).
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a RuntimeConfig variable.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_runtimeconfig_config_my_runtime_config = new gcp.runtimeconfig.Config("my-runtime-config", {
+ *     description: "Runtime configuration values for my service",
+ *     name: "my-service-runtime-config",
+ * });
+ * const google_runtimeconfig_variable_environment = new gcp.runtimeconfig.Variavble("environment", {
+ *     name: "prod-variables/hostname",
+ *     parent: google_runtimeconfig_config_my_runtime_config.name,
+ *     text: "example.com",
+ * });
+ * ```
+ * You can also encode binary content using the `value` argument instead. The
+ * value must be base64 encoded.
+ * 
+ * Example of using the `value` argument.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * import * as fs from "fs";
+ * 
+ * const google_runtimeconfig_config_my_runtime_config = new gcp.runtimeconfig.Config("my-runtime-config", {
+ *     description: "Runtime configuration values for my service",
+ *     name: "my-service-runtime-config",
+ * });
+ * const google_runtimeconfig_variable_my_secret = new gcp.runtimeconfig.Variavble("my-secret", {
+ *     name: "secret",
+ *     parent: google_runtimeconfig_config_my_runtime_config.name,
+ *     value: Buffer.from(fs.readFileSync("my-encrypted-secret.dat", "utf-8")).toString("base64"),
+ * });
+ * ```
  */
 export class Variavble extends pulumi.CustomResource {
     /**
@@ -19,8 +58,8 @@ export class Variavble extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: VariavbleState): Variavble {
-        return new Variavble(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: VariavbleState, opts?: pulumi.CustomResourceOptions): Variavble {
+        return new Variavble(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/serviceAccount/account.ts
+++ b/sdk/nodejs/serviceAccount/account.ts
@@ -6,6 +6,21 @@ import * as utilities from "../utilities";
 
 /**
  * Allows management of a [Google Cloud Platform service account](https://cloud.google.com/compute/docs/access/service-accounts)
+ * 
+ * ## Example Usage
+ * 
+ * This snippet creates a service account, then gives it objectViewer
+ * permission in a project.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_service_account_object_viewer = new gcp.serviceAccount.Account("object_viewer", {
+ *     accountId: "object-viewer",
+ *     displayName: "Object viewer",
+ * });
+ * ```
  */
 export class Account extends pulumi.CustomResource {
     /**
@@ -16,8 +31,8 @@ export class Account extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AccountState): Account {
-        return new Account(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: AccountState, opts?: pulumi.CustomResourceOptions): Account {
+        return new Account(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/serviceAccount/getAccount.ts
+++ b/sdk/nodejs/serviceAccount/getAccount.ts
@@ -7,6 +7,17 @@ import * as utilities from "../utilities";
 /**
  * Get the service account from a project. For more information see
  * the official [API](https://cloud.google.com/compute/docs/access/service-accounts) documentation.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_service_account_object_viewer = pulumi.output(gcp.serviceAccount.getAccount({
+ *     accountId: "object-viewer",
+ * }));
+ * ```
  */
 export function getAccount(args: GetAccountArgs, opts?: pulumi.InvokeOptions): Promise<GetAccountResult> {
     return pulumi.runtime.invoke("gcp:serviceAccount/getAccount:getAccount", {

--- a/sdk/nodejs/serviceAccount/getAccountKey.ts
+++ b/sdk/nodejs/serviceAccount/getAccountKey.ts
@@ -7,6 +7,24 @@ import * as utilities from "../utilities";
 /**
  * Get service account public key. For more information, see [the official documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) and [API](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys/get).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_service_account_myaccount = new gcp.serviceAccount.Account("myaccount", {
+ *     accountId: "dev-foo-account",
+ * });
+ * const google_service_account_key_mykey = new gcp.serviceAccount.Key("mykey", {
+ *     serviceAccountId: google_service_account_myaccount.name,
+ * });
+ * const google_service_account_key_mykey = pulumi.output(gcp.serviceAccount.getAccountKey({
+ *     name: google_service_account_key_mykey.name,
+ *     publicKeyType: "TYPE_X509_PEM_FILE",
+ * }));
+ * ```
  */
 export function getAccountKey(args?: GetAccountKeyArgs, opts?: pulumi.InvokeOptions): Promise<GetAccountKeyResult> {
     args = args || {};

--- a/sdk/nodejs/serviceAccount/iAMBinding.ts
+++ b/sdk/nodejs/serviceAccount/iAMBinding.ts
@@ -13,9 +13,9 @@ import * as utilities from "../utilities";
  * * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
  * * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
  * 
- * ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class IAMBinding extends pulumi.CustomResource {
     /**
@@ -26,8 +26,8 @@ export class IAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState): IAMBinding {
-        return new IAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMBindingState, opts?: pulumi.CustomResourceOptions): IAMBinding {
+        return new IAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/serviceAccount/iAMMember.ts
+++ b/sdk/nodejs/serviceAccount/iAMMember.ts
@@ -13,9 +13,9 @@ import * as utilities from "../utilities";
  * * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
  * * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
  * 
- * ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class IAMMember extends pulumi.CustomResource {
     /**
@@ -26,8 +26,8 @@ export class IAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState): IAMMember {
-        return new IAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMMemberState, opts?: pulumi.CustomResourceOptions): IAMMember {
+        return new IAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/serviceAccount/iAMPolicy.ts
+++ b/sdk/nodejs/serviceAccount/iAMPolicy.ts
@@ -13,9 +13,9 @@ import * as utilities from "../utilities";
  * * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
  * * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
  * 
- * ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class IAMPolicy extends pulumi.CustomResource {
     /**
@@ -26,8 +26,8 @@ export class IAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState): IAMPolicy {
-        return new IAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: IAMPolicyState, opts?: pulumi.CustomResourceOptions): IAMPolicy {
+        return new IAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/serviceAccount/key.ts
+++ b/sdk/nodejs/serviceAccount/key.ts
@@ -7,6 +7,22 @@ import * as utilities from "../utilities";
 /**
  * Creates and manages service account key-pairs, which allow the user to establish identity of a service account outside of GCP. For more information, see [the official documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) and [API](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys).
  * 
+ * 
+ * ## Example Usage, creating a new Key Pair
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_service_account_myaccount = new gcp.serviceAccount.Account("myaccount", {
+ *     accountId: "myaccount",
+ *     displayName: "My Service Account",
+ * });
+ * const google_service_account_key_mykey = new gcp.serviceAccount.Key("mykey", {
+ *     publicKeyType: "TYPE_X509_PEM_FILE",
+ *     serviceAccountId: google_service_account_myaccount.name,
+ * });
+ * ```
  */
 export class Key extends pulumi.CustomResource {
     /**
@@ -17,8 +33,8 @@ export class Key extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyState): Key {
-        return new Key(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: KeyState, opts?: pulumi.CustomResourceOptions): Key {
+        return new Key(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/sourcerepo/repository.ts
+++ b/sdk/nodejs/sourcerepo/repository.ts
@@ -8,6 +8,19 @@ import * as utilities from "../utilities";
  * For more information, see [the official
  * documentation](https://cloud.google.com/source-repositories/) and
  * [API](https://cloud.google.com/source-repositories/docs/reference/rest/v1/projects.repos)
+ * 
+ * ## Example Usage
+ * 
+ * This example is the common case of creating a repository within Google Cloud Source Repositories:
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_sourcerepo_repository_frontend = new gcp.sourcerepo.Repository("frontend", {
+ *     name: "frontend",
+ * });
+ * ```
  */
 export class Repository extends pulumi.CustomResource {
     /**
@@ -18,8 +31,8 @@ export class Repository extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RepositoryState): Repository {
-        return new Repository(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RepositoryState, opts?: pulumi.CustomResourceOptions): Repository {
+        return new Repository(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/database.ts
+++ b/sdk/nodejs/spanner/database.ts
@@ -6,6 +6,28 @@ import * as utilities from "../utilities";
 
 /**
  * Creates a Google Spanner Database within a Spanner Instance. For more information, see the [official documentation](https://cloud.google.com/spanner/), or the [JSON API](https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases).
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a Spanner database.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_spanner_instance_main = new gcp.spanner.Instance("main", {
+ *     config: "regional-europe-west1",
+ *     displayName: "main-instance",
+ * });
+ * const google_spanner_database_db = new gcp.spanner.Database("db", {
+ *     ddls: [
+ *         "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+ *         "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
+ *     ],
+ *     instance: google_spanner_instance_main.name,
+ *     name: "main-instance",
+ * });
+ * ```
  */
 export class Database extends pulumi.CustomResource {
     /**
@@ -16,8 +38,8 @@ export class Database extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseState): Database {
-        return new Database(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseState, opts?: pulumi.CustomResourceOptions): Database {
+        return new Database(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/databaseIAMBinding.ts
+++ b/sdk/nodejs/spanner/databaseIAMBinding.ts
@@ -9,14 +9,14 @@ import * as utilities from "../utilities";
  * 
  * * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
  * 
- * ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+ * > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
  * 
  * * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
  * * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
  * 
- * ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class DatabaseIAMBinding extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class DatabaseIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseIAMBindingState): DatabaseIAMBinding {
-        return new DatabaseIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseIAMBindingState, opts?: pulumi.CustomResourceOptions): DatabaseIAMBinding {
+        return new DatabaseIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/databaseIAMMember.ts
+++ b/sdk/nodejs/spanner/databaseIAMMember.ts
@@ -9,14 +9,14 @@ import * as utilities from "../utilities";
  * 
  * * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
  * 
- * ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+ * > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
  * 
  * * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
  * * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
  * 
- * ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class DatabaseIAMMember extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class DatabaseIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseIAMMemberState): DatabaseIAMMember {
-        return new DatabaseIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseIAMMemberState, opts?: pulumi.CustomResourceOptions): DatabaseIAMMember {
+        return new DatabaseIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/databaseIAMPolicy.ts
+++ b/sdk/nodejs/spanner/databaseIAMPolicy.ts
@@ -9,14 +9,14 @@ import * as utilities from "../utilities";
  * 
  * * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
  * 
- * ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+ * > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
  * 
  * * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
  * * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
  * 
- * ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class DatabaseIAMPolicy extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class DatabaseIAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseIAMPolicyState): DatabaseIAMPolicy {
-        return new DatabaseIAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseIAMPolicyState, opts?: pulumi.CustomResourceOptions): DatabaseIAMPolicy {
+        return new DatabaseIAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/instance.ts
+++ b/sdk/nodejs/spanner/instance.ts
@@ -6,6 +6,22 @@ import * as utilities from "../utilities";
 
 /**
  * Creates and manages a Google Spanner Instance. For more information, see the [official documentation](https://cloud.google.com/spanner/), or the [JSON API](https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances).
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a Spanner instance.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_spanner_instance_main = new gcp.spanner.Instance("main", {
+ *     config: "regional-europe-west1",
+ *     displayName: "main-instance",
+ *     name: "main-instance",
+ *     numNodes: 1,
+ * });
+ * ```
  */
 export class Instance extends pulumi.CustomResource {
     /**
@@ -16,8 +32,8 @@ export class Instance extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState): Instance {
-        return new Instance(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceState, opts?: pulumi.CustomResourceOptions): Instance {
+        return new Instance(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/instanceIAMBinding.ts
+++ b/sdk/nodejs/spanner/instanceIAMBinding.ts
@@ -9,14 +9,14 @@ import * as utilities from "../utilities";
  * 
  * * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
  * 
- * ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+ * > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
  * 
  * * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
  * * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
  * 
- * ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class InstanceIAMBinding extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class InstanceIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceIAMBindingState): InstanceIAMBinding {
-        return new InstanceIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceIAMBindingState, opts?: pulumi.CustomResourceOptions): InstanceIAMBinding {
+        return new InstanceIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/instanceIAMMember.ts
+++ b/sdk/nodejs/spanner/instanceIAMMember.ts
@@ -9,14 +9,14 @@ import * as utilities from "../utilities";
  * 
  * * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
  * 
- * ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+ * > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
  * 
  * * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
  * * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
  * 
- * ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class InstanceIAMMember extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class InstanceIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceIAMMemberState): InstanceIAMMember {
-        return new InstanceIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceIAMMemberState, opts?: pulumi.CustomResourceOptions): InstanceIAMMember {
+        return new InstanceIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/spanner/instanceIAMPolicy.ts
+++ b/sdk/nodejs/spanner/instanceIAMPolicy.ts
@@ -9,14 +9,14 @@ import * as utilities from "../utilities";
  * 
  * * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
  * 
- * ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+ * > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
  * 
  * * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
  * * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
  * 
- * ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+ * > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
  * 
- * ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class InstanceIAMPolicy extends pulumi.CustomResource {
     /**
@@ -27,8 +27,8 @@ export class InstanceIAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceIAMPolicyState): InstanceIAMPolicy {
-        return new InstanceIAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: InstanceIAMPolicyState, opts?: pulumi.CustomResourceOptions): InstanceIAMPolicy {
+        return new InstanceIAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/sql/database.ts
+++ b/sdk/nodejs/sql/database.ts
@@ -8,6 +8,28 @@ import * as utilities from "../utilities";
  * Creates a new Google SQL Database on a Google SQL Database Instance. For more information, see
  * the [official documentation](https://cloud.google.com/sql/),
  * or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/databases).
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a SQL Database.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_sql_database_instance_master = new gcp.sql.DatabaseInstance("master", {
+ *     name: "master-instance",
+ *     settings: {
+ *         tier: "D0",
+ *     },
+ * });
+ * const google_sql_database_users = new gcp.sql.Database("users", {
+ *     charset: "latin1",
+ *     collation: "latin1_swedish_ci",
+ *     instance: google_sql_database_instance_master.name,
+ *     name: "users-db",
+ * });
+ * ```
  */
 export class Database extends pulumi.CustomResource {
     /**
@@ -18,8 +40,8 @@ export class Database extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseState): Database {
-        return new Database(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseState, opts?: pulumi.CustomResourceOptions): Database {
+        return new Database(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/sql/databaseInstance.ts
+++ b/sdk/nodejs/sql/databaseInstance.ts
@@ -8,7 +8,7 @@ import * as utilities from "../utilities";
  * Creates a new Google SQL Database Instance. For more information, see the [official documentation](https://cloud.google.com/sql/),
  * or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/instances).
  * 
- * ~> **NOTE on `google_sql_database_instance`:** - Second-generation instances include a
+ * > **NOTE on `google_sql_database_instance`:** - Second-generation instances include a
  * default 'root'@'%' user with no password. This user will be deleted by Terraform on
  * instance creation. You should use `google_sql_user` to define a custom user with
  * a restricted host and strong password.
@@ -22,8 +22,8 @@ export class DatabaseInstance extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseInstanceState): DatabaseInstance {
-        return new DatabaseInstance(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DatabaseInstanceState, opts?: pulumi.CustomResourceOptions): DatabaseInstance {
+        return new DatabaseInstance(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/sql/user.ts
+++ b/sdk/nodejs/sql/user.ts
@@ -7,9 +7,31 @@ import * as utilities from "../utilities";
 /**
  * Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
  * 
- * ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+ * > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html). Passwords will not be retrieved when running
  * "terraform import".
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a SQL User.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_sql_database_instance_master = new gcp.sql.DatabaseInstance("master", {
+ *     name: "master-instance",
+ *     settings: {
+ *         tier: "D0",
+ *     },
+ * });
+ * const google_sql_user_users = new gcp.sql.User("users", {
+ *     host: "me.com",
+ *     instance: google_sql_database_instance_master.name,
+ *     name: "me",
+ *     password: "changeme",
+ * });
+ * ```
  */
 export class User extends pulumi.CustomResource {
     /**
@@ -20,8 +42,8 @@ export class User extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: UserState): User {
-        return new User(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: UserState, opts?: pulumi.CustomResourceOptions): User {
+        return new User(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/bucket.ts
+++ b/sdk/nodejs/storage/bucket.ts
@@ -13,6 +13,24 @@ import * as utilities from "../utilities";
  * and
  * [API](https://cloud.google.com/storage/docs/json_api/v1/buckets).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a private bucket in standard storage, in the EU region.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_image_store = new gcp.storage.Bucket("image-store", {
+ *     location: "EU",
+ *     name: "image-store-bucket",
+ *     websites: [{
+ *         mainPageSuffix: "index.html",
+ *         notFoundPage: "404.html",
+ *     }],
+ * });
+ * ```
  */
 export class Bucket extends pulumi.CustomResource {
     /**
@@ -23,8 +41,8 @@ export class Bucket extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketState): Bucket {
-        return new Bucket(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketState, opts?: pulumi.CustomResourceOptions): Bucket {
+        return new Bucket(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/bucketACL.ts
+++ b/sdk/nodejs/storage/bucketACL.ts
@@ -9,6 +9,27 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
  * and 
  * [API](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls).
+ * 
+ * ## Example Usage
+ * 
+ * Example creating an ACL on a bucket with one owner, and one reader.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_image_store = new gcp.storage.Bucket("image-store", {
+ *     location: "EU",
+ *     name: "image-store-bucket",
+ * });
+ * const google_storage_bucket_acl_image_store_acl = new gcp.storage.BucketACL("image-store-acl", {
+ *     bucket: google_storage_bucket_image_store.name,
+ *     roleEntities: [
+ *         "OWNER:user-my.email@gmail.com",
+ *         "READER:group-mygroup",
+ *     ],
+ * });
+ * ```
  */
 export class BucketACL extends pulumi.CustomResource {
     /**
@@ -19,8 +40,8 @@ export class BucketACL extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketACLState): BucketACL {
-        return new BucketACL(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketACLState, opts?: pulumi.CustomResourceOptions): BucketACL {
+        return new BucketACL(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/bucketIAMBinding.ts
+++ b/sdk/nodejs/storage/bucketIAMBinding.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  * * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
  * 
  * 
- * ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class BucketIAMBinding extends pulumi.CustomResource {
     /**
@@ -23,8 +23,8 @@ export class BucketIAMBinding extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketIAMBindingState): BucketIAMBinding {
-        return new BucketIAMBinding(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketIAMBindingState, opts?: pulumi.CustomResourceOptions): BucketIAMBinding {
+        return new BucketIAMBinding(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/bucketIAMMember.ts
+++ b/sdk/nodejs/storage/bucketIAMMember.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  * * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
  * 
  * 
- * ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class BucketIAMMember extends pulumi.CustomResource {
     /**
@@ -23,8 +23,8 @@ export class BucketIAMMember extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketIAMMemberState): BucketIAMMember {
-        return new BucketIAMMember(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketIAMMemberState, opts?: pulumi.CustomResourceOptions): BucketIAMMember {
+        return new BucketIAMMember(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/bucketIAMPolicy.ts
+++ b/sdk/nodejs/storage/bucketIAMPolicy.ts
@@ -12,7 +12,7 @@ import * as utilities from "../utilities";
  * * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
  * 
  * 
- * ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+ * > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
  */
 export class BucketIAMPolicy extends pulumi.CustomResource {
     /**
@@ -23,8 +23,8 @@ export class BucketIAMPolicy extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketIAMPolicyState): BucketIAMPolicy {
-        return new BucketIAMPolicy(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketIAMPolicyState, opts?: pulumi.CustomResourceOptions): BucketIAMPolicy {
+        return new BucketIAMPolicy(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/bucketObject.ts
+++ b/sdk/nodejs/storage/bucketObject.ts
@@ -12,6 +12,21 @@ import * as utilities from "../utilities";
  * and 
  * [API](https://cloud.google.com/storage/docs/json_api/v1/objects).
  * 
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a public object in an existing `image-store` bucket.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_object_picture = new gcp.storage.BucketObject("picture", {
+ *     bucket: "image-store",
+ *     name: "butterfly01",
+ *     source: new pulumi.asset.FileArchive("/images/nature/garden-tiger-moth.jpg"),
+ * });
+ * ```
  */
 export class BucketObject extends pulumi.CustomResource {
     /**
@@ -22,8 +37,8 @@ export class BucketObject extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketObjectState): BucketObject {
-        return new BucketObject(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: BucketObjectState, opts?: pulumi.CustomResourceOptions): BucketObject {
+        return new BucketObject(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/defaultObjectACL.ts
+++ b/sdk/nodejs/storage/defaultObjectACL.ts
@@ -9,6 +9,27 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
  * and 
  * [API](https://cloud.google.com/storage/docs/json_api/v1/defaultObjectAccessControls).
+ * 
+ * ## Example Usage
+ * 
+ * Example creating a default object ACL on a bucket with one owner, and one reader.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_image_store = new gcp.storage.Bucket("image-store", {
+ *     location: "EU",
+ *     name: "image-store-bucket",
+ * });
+ * const google_storage_default_object_acl_image_store_default_acl = new gcp.storage.DefaultObjectACL("image-store-default-acl", {
+ *     bucket: google_storage_bucket_image_store.name,
+ *     roleEntities: [
+ *         "OWNER:user-my.email@gmail.com",
+ *         "READER:group-mygroup",
+ *     ],
+ * });
+ * ```
  */
 export class DefaultObjectACL extends pulumi.CustomResource {
     /**
@@ -19,8 +40,8 @@ export class DefaultObjectACL extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DefaultObjectACLState): DefaultObjectACL {
-        return new DefaultObjectACL(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: DefaultObjectACLState, opts?: pulumi.CustomResourceOptions): DefaultObjectACL {
+        return new DefaultObjectACL(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/notification.ts
+++ b/sdk/nodejs/storage/notification.ts
@@ -16,6 +16,38 @@ import * as utilities from "../utilities";
  * account's email address, use the `google_storage_project_service_account` datasource's `email_address` value, and see below
  * for an example of enabling notifications by granting the correct IAM permission. See
  * [the notifications documentation](https://cloud.google.com/storage/docs/gsutil/commands/notification) for more details.
+ * 
+ * ## Example Usage
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_project_service_account_gcs_account = pulumi.output(gcp.storage.getProjectServiceAccount({}));
+ * const google_pubsub_topic_topic = new gcp.pubsub.Topic("topic", {
+ *     name: "default_topic",
+ * });
+ * const google_storage_bucket_bucket = new gcp.storage.Bucket("bucket", {
+ *     name: "default_bucket",
+ * });
+ * const google_pubsub_topic_iam_binding_binding = new gcp.pubsub.TopicIAMBinding("binding", {
+ *     members: [google_storage_project_service_account_gcs_account.apply(__arg0 => `serviceAccount:${__arg0.emailAddress}`)],
+ *     role: "roles/pubsub.publisher",
+ *     topic: google_pubsub_topic_topic.name,
+ * });
+ * const google_storage_notification_notification = new gcp.storage.Notification("notification", {
+ *     bucket: google_storage_bucket_bucket.name,
+ *     customAttributes: {
+ *         new-attribute: "new-attribute-value",
+ *     },
+ *     eventTypes: [
+ *         "OBJECT_FINALIZE",
+ *         "OBJECT_METADATA_UPDATE",
+ *     ],
+ *     payloadFormat: "JSON_API_V1",
+ *     topic: google_pubsub_topic_topic.id,
+ * }, {dependsOn: [google_pubsub_topic_iam_binding_binding]});
+ * ```
  */
 export class Notification extends pulumi.CustomResource {
     /**
@@ -26,8 +58,8 @@ export class Notification extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NotificationState): Notification {
-        return new Notification(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: NotificationState, opts?: pulumi.CustomResourceOptions): Notification {
+        return new Notification(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/nodejs/storage/objectACL.ts
+++ b/sdk/nodejs/storage/objectACL.ts
@@ -9,6 +9,33 @@ import * as utilities from "../utilities";
  * [the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
  * and 
  * [API](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls).
+ * 
+ * ## Example Usage
+ * 
+ * Create an object ACL with one owner and one reader.
+ * 
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as gcp from "@pulumi/gcp";
+ * 
+ * const google_storage_bucket_image_store = new gcp.storage.Bucket("image-store", {
+ *     location: "EU",
+ *     name: "image-store-bucket",
+ * });
+ * const google_storage_bucket_object_image = new gcp.storage.BucketObject("image", {
+ *     bucket: google_storage_bucket_image_store.name,
+ *     name: "image1",
+ *     source: new pulumi.asset.FileArchive("image1.jpg"),
+ * });
+ * const google_storage_object_acl_image_store_acl = new gcp.storage.ObjectACL("image-store-acl", {
+ *     bucket: google_storage_bucket_image_store.name,
+ *     object: google_storage_bucket_object_image.name,
+ *     roleEntities: [
+ *         "OWNER:user-my.email@gmail.com",
+ *         "READER:group-mygroup",
+ *     ],
+ * });
+ * ```
  */
 export class ObjectACL extends pulumi.CustomResource {
     /**
@@ -19,8 +46,8 @@ export class ObjectACL extends pulumi.CustomResource {
      * @param id The _unique_ provider ID of the resource to lookup.
      * @param state Any extra arguments used during the lookup.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ObjectACLState): ObjectACL {
-        return new ObjectACL(name, <any>state, { id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: ObjectACLState, opts?: pulumi.CustomResourceOptions): ObjectACL {
+        return new ObjectACL(name, <any>state, { ...opts, id: id });
     }
 
     /**

--- a/sdk/python/pulumi_gcp/appengine/application.py
+++ b/sdk/python/pulumi_gcp/appengine/application.py
@@ -10,7 +10,7 @@ class Application(pulumi.CustomResource):
     """
     Allows creation and management of an App Engine application.
     
-    ~> App Engine applications cannot be deleted once they're created; you have to delete the
+    > App Engine applications cannot be deleted once they're created; you have to delete the
        entire project to delete the application. Terraform will report the application has been
        successfully deleted; this is a limitation of Terraform, and will go away in the future.
        Terraform is not able to delete App Engine applications.

--- a/sdk/python/pulumi_gcp/binaryauthorization/attestor.py
+++ b/sdk/python/pulumi_gcp/binaryauthorization/attestor.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Attestor(pulumi.CustomResource):
+    """
+    An attestor that attests to container image artifacts.
+    
+    > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+    
+    To get more information about Attestor, see:
+    
+    * [API documentation](https://cloud.google.com/binary-authorization/docs/reference/rest/)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/binary-authorization/)
+    """
     def __init__(__self__, __name__, __opts__=None, attestation_authority_note=None, description=None, name=None, project=None):
         """Create a Attestor resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/binaryauthorization/policy.py
+++ b/sdk/python/pulumi_gcp/binaryauthorization/policy.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Policy(pulumi.CustomResource):
+    """
+    A policy for container image binary authorization.
+    
+    > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+    
+    To get more information about Policy, see:
+    
+    * [API documentation](https://cloud.google.com/binary-authorization/docs/reference/rest/)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/binary-authorization/)
+    """
     def __init__(__self__, __name__, __opts__=None, admission_whitelist_patterns=None, cluster_admission_rules=None, default_admission_rule=None, description=None, project=None):
         """Create a Policy resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/address.py
+++ b/sdk/python/pulumi_gcp/compute/address.py
@@ -7,6 +7,29 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Address(pulumi.CustomResource):
+    """
+    Represents an Address resource.
+    
+    Each virtual machine instance has an ephemeral internal IP address and,
+    optionally, an external IP address. To communicate between instances on
+    the same network, you can use an instance's internal IP address. To
+    communicate with the Internet and instances outside of the same network,
+    you must specify the instance's external IP address.
+    
+    Internal IP addresses are ephemeral and only belong to an instance for
+    the lifetime of the instance; if the instance is deleted and recreated,
+    the instance is assigned a new internal IP address, either by Compute
+    Engine or by you. External IP addresses can be either ephemeral or
+    static.
+    
+    
+    To get more information about Address, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/beta/addresses)
+    * How-to Guides
+        * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/instances-and-network)
+        * [Reserving a Static Internal IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
+    """
     def __init__(__self__, __name__, __opts__=None, address=None, address_type=None, description=None, labels=None, name=None, network_tier=None, project=None, region=None, subnetwork=None):
         """Create a Address resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/autoscalar.py
+++ b/sdk/python/pulumi_gcp/compute/autoscalar.py
@@ -7,6 +7,20 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Autoscalar(pulumi.CustomResource):
+    """
+    Represents an Autoscaler resource.
+    
+    Autoscalers allow you to automatically scale virtual machine instances in
+    managed instance groups according to an autoscaling policy that you
+    define.
+    
+    
+    To get more information about Autoscaler, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers)
+    * How-to Guides
+        * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
+    """
     def __init__(__self__, __name__, __opts__=None, autoscaling_policy=None, description=None, name=None, project=None, target=None, zone=None):
         """Create a Autoscalar resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/backend_bucket.py
+++ b/sdk/python/pulumi_gcp/compute/backend_bucket.py
@@ -7,6 +7,22 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class BackendBucket(pulumi.CustomResource):
+    """
+    Backend buckets allow you to use Google Cloud Storage buckets with HTTP(S)
+    load balancing.
+    
+    An HTTP(S) load balancer can direct traffic to specified URLs to a
+    backend bucket rather than a backend service. It can send requests for
+    static content to a Cloud Storage bucket and requests for dynamic content
+    a virtual machine instance.
+    
+    
+    To get more information about BackendBucket, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/backendBuckets)
+    * How-to Guides
+        * [Using a Cloud Storage bucket as a load balancer backend](https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket)
+    """
     def __init__(__self__, __name__, __opts__=None, bucket_name=None, description=None, enable_cdn=None, name=None, project=None):
         """Create a BackendBucket resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/disk.py
+++ b/sdk/python/pulumi_gcp/compute/disk.py
@@ -7,6 +7,34 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Disk(pulumi.CustomResource):
+    """
+    Persistent disks are durable storage devices that function similarly to
+    the physical disks in a desktop or a server. Compute Engine manages the
+    hardware behind these devices to ensure data redundancy and optimize
+    performance for you. Persistent disks are available as either standard
+    hard disk drives (HDD) or solid-state drives (SSD).
+    
+    Persistent disks are located independently from your virtual machine
+    instances, so you can detach or move persistent disks to keep your data
+    even after you delete your instances. Persistent disk performance scales
+    automatically with size, so you can resize your existing persistent disks
+    or add more persistent disks to an instance to meet your performance and
+    storage space requirements.
+    
+    Add a persistent disk to your instance when you need reliable and
+    affordable storage with consistent performance characteristics.
+    
+    
+    To get more information about Disk, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/disks)
+    * How-to Guides
+        * [Adding a persistent disk](https://cloud.google.com/compute/docs/disks/add-persistent-disk)
+    
+    > **Warning:** All arguments including the disk encryption key will be stored in the raw
+    state as plain-text.
+    [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, disk_encryption_key=None, disk_encryption_key_raw=None, image=None, labels=None, name=None, project=None, size=None, snapshot=None, source_image_encryption_key=None, source_snapshot_encryption_key=None, type=None, zone=None):
         """Create a Disk resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/firewall.py
+++ b/sdk/python/pulumi_gcp/compute/firewall.py
@@ -7,6 +7,27 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Firewall(pulumi.CustomResource):
+    """
+    Each network has its own firewall controlling access to and from the
+    instances.
+    
+    All traffic to instances, even from other instances, is blocked by the
+    firewall unless firewall rules are created to allow it.
+    
+    The default network has automatically created firewall rules that are
+    shown in default firewall rules. No manually created network has
+    automatically created firewall rules except for a default "allow" rule for
+    outgoing traffic and a default "deny" for incoming traffic. For all
+    networks except the default network, you must create any firewall rules
+    you need.
+    
+    
+    To get more information about Firewall, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/firewalls)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/vpc/docs/firewalls)
+    """
     def __init__(__self__, __name__, __opts__=None, allows=None, denies=None, description=None, destination_ranges=None, direction=None, disabled=None, enable_logging=None, name=None, network=None, priority=None, project=None, source_ranges=None, source_service_accounts=None, source_tags=None, target_service_accounts=None, target_tags=None):
         """Create a Firewall resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/forwarding_rule.py
+++ b/sdk/python/pulumi_gcp/compute/forwarding_rule.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class ForwardingRule(pulumi.CustomResource):
+    """
+    A ForwardingRule resource. A ForwardingRule resource specifies which pool
+    of target virtual machines to forward a packet to if it matches the given
+    [IPAddress, IPProtocol, portRange] tuple.
+    
+    
+    To get more information about ForwardingRule, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/forwardingRule)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules)
+    """
     def __init__(__self__, __name__, __opts__=None, backend_service=None, description=None, ip_address=None, ip_protocol=None, ip_version=None, labels=None, load_balancing_scheme=None, name=None, network=None, network_tier=None, port_range=None, ports=None, project=None, region=None, service_label=None, subnetwork=None, target=None):
         """Create a ForwardingRule resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/global_address.py
+++ b/sdk/python/pulumi_gcp/compute/global_address.py
@@ -7,6 +7,17 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class GlobalAddress(pulumi.CustomResource):
+    """
+    Represents a Global Address resource. Global addresses are used for
+    HTTP(S) load balancing.
+    
+    
+    To get more information about GlobalAddress, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/globalAddresses)
+    * How-to Guides
+        * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address)
+    """
     def __init__(__self__, __name__, __opts__=None, address_type=None, description=None, ip_version=None, labels=None, name=None, network=None, prefix_length=None, project=None, purpose=None):
         """Create a GlobalAddress resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/health_check.py
+++ b/sdk/python/pulumi_gcp/compute/health_check.py
@@ -7,6 +7,26 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class HealthCheck(pulumi.CustomResource):
+    """
+    Health Checks determine whether instances are responsive and able to do work.
+    They are an important part of a comprehensive load balancing configuration,
+    as they enable monitoring instances behind load balancers.
+    
+    Health Checks poll instances at a specified interval. Instances that
+    do not respond successfully to some number of probes in a row are marked
+    as unhealthy. No new connections are sent to unhealthy instances,
+    though existing connections will continue. The health check will
+    continue to poll unhealthy instances. If an instance later responds
+    successfully to some number of consecutive probes, it is marked
+    healthy again and can receive new connections.
+    
+    
+    To get more information about HealthCheck, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/latest/healthChecks)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/load-balancing/docs/health-checks)
+    """
     def __init__(__self__, __name__, __opts__=None, check_interval_sec=None, description=None, healthy_threshold=None, http_health_check=None, https_health_check=None, name=None, project=None, ssl_health_check=None, tcp_health_check=None, timeout_sec=None, unhealthy_threshold=None):
         """Create a HealthCheck resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/http_health_check.py
+++ b/sdk/python/pulumi_gcp/compute/http_health_check.py
@@ -7,6 +7,24 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class HttpHealthCheck(pulumi.CustomResource):
+    """
+    An HttpHealthCheck resource. This resource defines a template for how
+    individual VMs should be checked for health, via HTTP.
+    
+    
+    > **Note:** google_compute_http_health_check is a legacy health check.
+    The newer [google_compute_health_check](https://www.terraform.io/docs/providers/google/r/compute_health_check.html)
+    should be preferred for all uses except
+    [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/)
+    which still require the legacy version.
+    
+    
+    To get more information about HttpHealthCheck, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/httpHealthChecks)
+    * How-to Guides
+        * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
+    """
     def __init__(__self__, __name__, __opts__=None, check_interval_sec=None, description=None, healthy_threshold=None, host=None, name=None, port=None, project=None, request_path=None, timeout_sec=None, unhealthy_threshold=None):
         """Create a HttpHealthCheck resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/https_health_check.py
+++ b/sdk/python/pulumi_gcp/compute/https_health_check.py
@@ -7,6 +7,24 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class HttpsHealthCheck(pulumi.CustomResource):
+    """
+    An HttpsHealthCheck resource. This resource defines a template for how
+    individual VMs should be checked for health, via HTTPS.
+    
+    
+    > **Note:** google_compute_https_health_check is a legacy health check.
+    The newer [google_compute_health_check](https://www.terraform.io/docs/providers/google/r/compute_health_check.html)
+    should be preferred for all uses except
+    [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/)
+    which still require the legacy version.
+    
+    
+    To get more information about HttpsHealthCheck, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/httpsHealthChecks)
+    * How-to Guides
+        * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
+    """
     def __init__(__self__, __name__, __opts__=None, check_interval_sec=None, description=None, healthy_threshold=None, host=None, name=None, port=None, project=None, request_path=None, timeout_sec=None, unhealthy_threshold=None):
         """Create a HttpsHealthCheck resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/instance_group_manager.py
+++ b/sdk/python/pulumi_gcp/compute/instance_group_manager.py
@@ -13,7 +13,7 @@ class InstanceGroupManager(pulumi.CustomResource):
     template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/manager)
     and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers)
     
-    ~> **Note:** Use [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
+    > **Note:** Use [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html) to create a regional (multi-zone) instance group manager.
     """
     def __init__(__self__, __name__, __opts__=None, auto_healing_policies=None, base_instance_name=None, description=None, instance_template=None, name=None, named_ports=None, project=None, rolling_update_policy=None, target_pools=None, target_size=None, update_strategy=None, versions=None, wait_for_instances=None, zone=None):
         """Create a InstanceGroupManager resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/compute/interconnect_attachment.py
+++ b/sdk/python/pulumi_gcp/compute/interconnect_attachment.py
@@ -7,6 +7,11 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class InterconnectAttachment(pulumi.CustomResource):
+    """
+    Represents an InterconnectAttachment (VLAN attachment) resource. For more
+    information, see Creating VLAN Attachments.
+    
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, interconnect=None, name=None, project=None, region=None, router=None):
         """Create a InterconnectAttachment resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/network_peering.py
+++ b/sdk/python/pulumi_gcp/compute/network_peering.py
@@ -13,9 +13,9 @@ class NetworkPeering(pulumi.CustomResource):
     and
     [API](https://cloud.google.com/compute/docs/reference/latest/networks).
     
-    ~> **Note:** Both network must create a peering with each other for the peering to be functional.
+    > **Note:** Both network must create a peering with each other for the peering to be functional.
     
-    ~> **Note:** Subnets IP ranges across peered VPC networks cannot overlap.
+    > **Note:** Subnets IP ranges across peered VPC networks cannot overlap.
     """
     def __init__(__self__, __name__, __opts__=None, auto_create_routes=None, name=None, network=None, peer_network=None):
         """Create a NetworkPeering resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/compute/project_metadata.py
+++ b/sdk/python/pulumi_gcp/compute/project_metadata.py
@@ -13,7 +13,7 @@ class ProjectMetadata(pulumi.CustomResource):
     and
     [API](https://cloud.google.com/compute/docs/reference/latest/projects/setCommonInstanceMetadata).
     
-    ~> **Note:**  If you want to manage only single key/value pairs within the project metadata
+    > **Note:**  If you want to manage only single key/value pairs within the project metadata
     rather than the entire set, then use
     google_compute_project_metadata_item.
     """

--- a/sdk/python/pulumi_gcp/compute/region_autoscaler.py
+++ b/sdk/python/pulumi_gcp/compute/region_autoscaler.py
@@ -7,6 +7,20 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class RegionAutoscaler(pulumi.CustomResource):
+    """
+    Represents an Autoscaler resource.
+    
+    Autoscalers allow you to automatically scale virtual machine instances in
+    managed instance groups according to an autoscaling policy that you
+    define.
+    
+    
+    To get more information about RegionAutoscaler, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionAutoscalers)
+    * How-to Guides
+        * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
+    """
     def __init__(__self__, __name__, __opts__=None, autoscaling_policy=None, description=None, name=None, project=None, region=None, target=None):
         """Create a RegionAutoscaler resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/region_backend_service.py
+++ b/sdk/python/pulumi_gcp/compute/region_backend_service.py
@@ -12,7 +12,7 @@ class RegionBackendService(pulumi.CustomResource):
     For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/internal/)
     and [API](https://cloud.google.com/compute/docs/reference/latest/regionBackendServices).
     
-    ~> **Note**: Region backend services can only be used when using internal load balancing. For external load balancing, use
+    > **Note**: Region backend services can only be used when using internal load balancing. For external load balancing, use
       `google_compute_backend_service` instead.
     """
     def __init__(__self__, __name__, __opts__=None, backends=None, connection_draining_timeout_sec=None, description=None, health_checks=None, name=None, project=None, protocol=None, region=None, session_affinity=None, timeout_sec=None):

--- a/sdk/python/pulumi_gcp/compute/region_disk.py
+++ b/sdk/python/pulumi_gcp/compute/region_disk.py
@@ -7,6 +7,34 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class RegionDisk(pulumi.CustomResource):
+    """
+    Persistent disks are durable storage devices that function similarly to
+    the physical disks in a desktop or a server. Compute Engine manages the
+    hardware behind these devices to ensure data redundancy and optimize
+    performance for you. Persistent disks are available as either standard
+    hard disk drives (HDD) or solid-state drives (SSD).
+    
+    Persistent disks are located independently from your virtual machine
+    instances, so you can detach or move persistent disks to keep your data
+    even after you delete your instances. Persistent disk performance scales
+    automatically with size, so you can resize your existing persistent disks
+    or add more persistent disks to an instance to meet your performance and
+    storage space requirements.
+    
+    Add a persistent disk to your instance when you need reliable and
+    affordable storage with consistent performance characteristics.
+    
+    
+    To get more information about RegionDisk, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/regionDisks)
+    * How-to Guides
+        * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
+    
+    > **Warning:** All arguments including the disk encryption key will be stored in the raw
+    state as plain-text.
+    [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, disk_encryption_key=None, labels=None, name=None, project=None, region=None, replica_zones=None, size=None, snapshot=None, source_snapshot_encryption_key=None, type=None):
         """Create a RegionDisk resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/region_instance_group_manager.py
+++ b/sdk/python/pulumi_gcp/compute/region_instance_group_manager.py
@@ -13,7 +13,7 @@ class RegionInstanceGroupManager(pulumi.CustomResource):
     template. For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups)
     and [API](https://cloud.google.com/compute/docs/reference/latest/regionInstanceGroupManagers)
     
-    ~> **Note:** Use [google_compute_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html) to create a single-zone instance group manager.
+    > **Note:** Use [google_compute_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_instance_group_manager.html) to create a single-zone instance group manager.
     """
     def __init__(__self__, __name__, __opts__=None, auto_healing_policies=None, base_instance_name=None, description=None, distribution_policy_zones=None, instance_template=None, name=None, named_ports=None, project=None, region=None, rolling_update_policy=None, target_pools=None, target_size=None, update_strategy=None, versions=None, wait_for_instances=None):
         """Create a RegionInstanceGroupManager resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/compute/route.py
+++ b/sdk/python/pulumi_gcp/compute/route.py
@@ -7,6 +7,36 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Route(pulumi.CustomResource):
+    """
+    Represents a Route resource.
+    
+    A route is a rule that specifies how certain packets should be handled by
+    the virtual network. Routes are associated with virtual machines by tag,
+    and the set of routes for a particular virtual machine is called its
+    routing table. For each packet leaving a virtual machine, the system
+    searches that virtual machine's routing table for a single best matching
+    route.
+    
+    Routes match packets by destination IP address, preferring smaller or more
+    specific ranges over larger ones. If there is a tie, the system selects
+    the route with the smallest priority value. If there is still a tie, it
+    uses the layer three and four packet headers to select just one of the
+    remaining matching routes. The packet is then forwarded as specified by
+    the next_hop field of the winning route -- either to another virtual
+    machine destination, a virtual machine gateway or a Compute
+    Engine-operated gateway. Packets that do not match any route in the
+    sending virtual machine's routing table will be dropped.
+    
+    A Route resource must have exactly one specification of either
+    nextHopGateway, nextHopInstance, nextHopIp, or nextHopVpnTunnel.
+    
+    
+    To get more information about Route, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routes)
+    * How-to Guides
+        * [Using Routes](https://cloud.google.com/vpc/docs/using-routes)
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, dest_range=None, name=None, network=None, next_hop_gateway=None, next_hop_instance=None, next_hop_instance_zone=None, next_hop_ip=None, next_hop_vpn_tunnel=None, priority=None, project=None, tags=None):
         """Create a Route resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/router.py
+++ b/sdk/python/pulumi_gcp/compute/router.py
@@ -7,6 +7,16 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Router(pulumi.CustomResource):
+    """
+    Represents a Router resource.
+    
+    
+    To get more information about Router, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routers)
+    * How-to Guides
+        * [Google Cloud Router](https://cloud.google.com/router/docs/)
+    """
     def __init__(__self__, __name__, __opts__=None, bgp=None, description=None, name=None, network=None, project=None, region=None):
         """Create a Router resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_certificate.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class SSLCertificate(pulumi.CustomResource):
+    """
+    An SslCertificate resource, used for HTTPS load balancing. This resource
+    provides a mechanism to upload an SSL key and certificate to
+    the load balancer to serve secure connections from the user.
+    
+    
+    To get more information about SslCertificate, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
+    """
     def __init__(__self__, __name__, __opts__=None, certificate=None, description=None, name=None, name_prefix=None, private_key=None, project=None):
         """Create a SSLCertificate resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/ssl_policy.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_policy.py
@@ -7,6 +7,17 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class SSLPolicy(pulumi.CustomResource):
+    """
+    Represents a SSL policy. SSL policies give you the ability to control the
+    features of SSL that your SSL proxy or HTTPS load balancer negotiates.
+    
+    
+    To get more information about SslPolicy, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies)
+    * How-to Guides
+        * [Using SSL Policies](https://cloud.google.com/compute/docs/load-balancing/ssl-policies)
+    """
     def __init__(__self__, __name__, __opts__=None, custom_features=None, description=None, min_tls_version=None, name=None, profile=None, project=None):
         """Create a SSLPolicy resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/subnetwork.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork.py
@@ -7,6 +7,38 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Subnetwork(pulumi.CustomResource):
+    """
+    A VPC network is a virtual version of the traditional physical networks
+    that exist within and between physical data centers. A VPC network
+    provides connectivity for your Compute Engine virtual machine (VM)
+    instances, Container Engine containers, App Engine Flex services, and
+    other network-related resources.
+    
+    Each GCP project contains one or more VPC networks. Each VPC network is a
+    global entity spanning all GCP regions. This global VPC network allows VM
+    instances and other resources to communicate with each other via internal,
+    private IP addresses.
+    
+    Each VPC network is subdivided into subnets, and each subnet is contained
+    within a single region. You can have more than one subnet in a region for
+    a given VPC network. Each subnet has a contiguous private RFC1918 IP
+    space. You create instances, containers, and the like in these subnets.
+    When you create an instance, you must create it in a subnet, and the
+    instance draws its internal IP address from that subnet.
+    
+    Virtual machine (VM) instances in a VPC network can communicate with
+    instances in all other subnets of the same VPC network, regardless of
+    region, using their RFC1918 private IP addresses. You can isolate portions
+    of the network, even entire subnets, using firewall rules.
+    
+    
+    To get more information about Subnetwork, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/subnetworks)
+    * How-to Guides
+        * [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
+        * [Cloud Networking](https://cloud.google.com/vpc/docs/using-vpc)
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, enable_flow_logs=None, ip_cidr_range=None, name=None, network=None, private_ip_google_access=None, project=None, region=None, secondary_ip_ranges=None):
         """Create a Subnetwork resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/subnetwork_iam_binding.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork_iam_binding.py
@@ -8,7 +8,7 @@ from .. import utilities, tables
 
 class SubnetworkIAMBinding(pulumi.CustomResource):
     """
-    ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+    > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
     
     Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -17,9 +17,9 @@ class SubnetworkIAMBinding(pulumi.CustomResource):
     * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
     * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
     
-    ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, members=None, project=None, region=None, role=None, subnetwork=None):
         """Create a SubnetworkIAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/compute/subnetwork_iam_member.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork_iam_member.py
@@ -8,7 +8,7 @@ from .. import utilities, tables
 
 class SubnetworkIAMMember(pulumi.CustomResource):
     """
-    ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+    > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
     
     Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -17,9 +17,9 @@ class SubnetworkIAMMember(pulumi.CustomResource):
     * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
     * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
     
-    ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, member=None, project=None, region=None, role=None, subnetwork=None):
         """Create a SubnetworkIAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/compute/subnetwork_iam_policy.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork_iam_policy.py
@@ -8,7 +8,7 @@ from .. import utilities, tables
 
 class SubnetworkIAMPolicy(pulumi.CustomResource):
     """
-    ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+    > **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
     See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
     
     Three different resources help you manage your IAM policy for GCE subnetwork. Each of these resources serves a different use case:
@@ -17,9 +17,9 @@ class SubnetworkIAMPolicy(pulumi.CustomResource):
     * `google_compute_subnetwork_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subnetwork are preserved.
     * `google_compute_subnetwork_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subnetwork are preserved.
     
-    ~> **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_compute_subnetwork_iam_policy` **cannot** be used in conjunction with `google_compute_subnetwork_iam_binding` and `google_compute_subnetwork_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_compute_subnetwork_iam_binding` resources **can be** used in conjunction with `google_compute_subnetwork_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, policy_data=None, project=None, region=None, subnetwork=None):
         """Create a SubnetworkIAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/compute/target_http_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_http_proxy.py
@@ -7,6 +7,17 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class TargetHttpProxy(pulumi.CustomResource):
+    """
+    Represents a TargetHttpProxy resource, which is used by one or more global
+    forwarding rule to route incoming HTTP requests to a URL map.
+    
+    
+    To get more information about TargetHttpProxy, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetHttpProxies)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, name=None, project=None, url_map=None):
         """Create a TargetHttpProxy resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/target_https_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_https_proxy.py
@@ -7,6 +7,17 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class TargetHttpsProxy(pulumi.CustomResource):
+    """
+    Represents a TargetHttpsProxy resource, which is used by one or more
+    global forwarding rule to route incoming HTTPS requests to a URL map.
+    
+    
+    To get more information about TargetHttpsProxy, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetHttpsProxies)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, name=None, project=None, quic_override=None, ssl_certificates=None, ssl_policy=None, url_map=None):
         """Create a TargetHttpsProxy resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/target_ssl_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_ssl_proxy.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class TargetSSLProxy(pulumi.CustomResource):
+    """
+    Represents a TargetSslProxy resource, which is used by one or more
+    global forwarding rule to route incoming SSL requests to a backend
+    service.
+    
+    
+    To get more information about TargetSslProxy, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetSslProxies)
+    * How-to Guides
+        * [Setting Up SSL proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/)
+    """
     def __init__(__self__, __name__, __opts__=None, backend_service=None, description=None, name=None, project=None, proxy_header=None, ssl_certificates=None, ssl_policy=None):
         """Create a TargetSSLProxy resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/target_tcp_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_tcp_proxy.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class TargetTCPProxy(pulumi.CustomResource):
+    """
+    Represents a TargetTcpProxy resource, which is used by one or more
+    global forwarding rule to route incoming TCP requests to a Backend
+    service.
+    
+    
+    To get more information about TargetTcpProxy, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/latest/targetTcpProxies)
+    * How-to Guides
+        * [Setting Up TCP proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy)
+    """
     def __init__(__self__, __name__, __opts__=None, backend_service=None, description=None, name=None, project=None, proxy_header=None):
         """Create a TargetTCPProxy resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/vpn_gateway.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_gateway.py
@@ -7,6 +7,15 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class VPNGateway(pulumi.CustomResource):
+    """
+    Represents a VPN gateway running in GCP. This virtual device is managed
+    by Google, but used only by you.
+    
+    
+    To get more information about VpnGateway, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways)
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, name=None, network=None, project=None, region=None):
         """Create a VPNGateway resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
@@ -7,6 +7,21 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class VPNTunnel(pulumi.CustomResource):
+    """
+    VPN tunnel resource.
+    
+    
+    To get more information about VpnTunnel, see:
+    
+    * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels)
+    * How-to Guides
+        * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
+        * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
+    
+    > **Warning:** All arguments including the shared secret will be stored in the raw
+    state as plain-text.
+    [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, ike_version=None, labels=None, local_traffic_selectors=None, name=None, peer_ip=None, project=None, region=None, remote_traffic_selectors=None, router=None, shared_secret=None, target_vpn_gateway=None):
         """Create a VPNTunnel resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/container/cluster.py
+++ b/sdk/python/pulumi_gcp/container/cluster.py
@@ -13,7 +13,7 @@ class Cluster(pulumi.CustomResource):
     and
     [API](https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters).
     
-    ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
     """
     def __init__(__self__, __name__, __opts__=None, additional_zones=None, addons_config=None, cluster_ipv4_cidr=None, description=None, enable_binary_authorization=None, enable_kubernetes_alpha=None, enable_legacy_abac=None, enable_tpu=None, initial_node_count=None, ip_allocation_policy=None, logging_service=None, maintenance_policy=None, master_auth=None, master_authorized_networks_config=None, master_ipv4_cidr_block=None, min_master_version=None, monitoring_service=None, name=None, network=None, network_policy=None, node_config=None, node_pools=None, node_version=None, pod_security_policy_config=None, private_cluster=None, project=None, region=None, remove_default_node_pool=None, resource_labels=None, subnetwork=None, zone=None):

--- a/sdk/python/pulumi_gcp/containeranalysis/note.py
+++ b/sdk/python/pulumi_gcp/containeranalysis/note.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Note(pulumi.CustomResource):
+    """
+    Provides a detailed description of a Note.
+    
+    > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+    
+    To get more information about Note, see:
+    
+    * [API documentation](https://cloud.google.com/container-analysis/api/reference/rest/)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/container-analysis/)
+    """
     def __init__(__self__, __name__, __opts__=None, attestation_authority=None, name=None, project=None):
         """Create a Note resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/dns/record_set.py
+++ b/sdk/python/pulumi_gcp/dns/record_set.py
@@ -11,7 +11,7 @@ class RecordSet(pulumi.CustomResource):
     Manages a set of DNS records within Google Cloud DNS. For more information see [the official documentation](https://cloud.google.com/dns/records/) and
     [API](https://cloud.google.com/dns/api/v1/resourceRecordSets).
     
-    ~> **Note:** The Google Cloud DNS API requires NS records be present at all
+    > **Note:** The Google Cloud DNS API requires NS records be present at all
     times. To accommodate this, when creating NS records, the default records
     Google automatically creates will be silently overwritten.  Also, when
     destroying NS records, Terraform will not actually remove NS records, but will

--- a/sdk/python/pulumi_gcp/filestore/instance.py
+++ b/sdk/python/pulumi_gcp/filestore/instance.py
@@ -7,6 +7,20 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Instance(pulumi.CustomResource):
+    """
+    A Google Cloud Filestore instance.
+    
+    > **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+    
+    To get more information about Instance, see:
+    
+    * [API documentation](https://cloud.google.com/filestore/docs/reference/rest/v1beta1/projects.locations.instances/create)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/filestore/docs/creating-instances)
+        * [Use with Kubernetes](https://cloud.google.com/filestore/docs/accessing-fileshares)
+        * [Copying Data In/Out](https://cloud.google.com/filestore/docs/copying-data)
+    """
     def __init__(__self__, __name__, __opts__=None, description=None, file_shares=None, labels=None, name=None, networks=None, project=None, tier=None, zone=None):
         """Create a Instance resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/folder/iam_binding.py
+++ b/sdk/python/pulumi_gcp/folder/iam_binding.py
@@ -11,7 +11,7 @@ class IAMBinding(pulumi.CustomResource):
     Allows creation and management of a single binding within IAM policy for
     an existing Google Cloud Platform folder.
     
-    ~> **Note:** This resource _must not_ be used in conjunction with
+    > **Note:** This resource _must not_ be used in conjunction with
        `google_folder_iam_policy` or they will fight over what your policy
        should be.
     """

--- a/sdk/python/pulumi_gcp/folder/iam_member.py
+++ b/sdk/python/pulumi_gcp/folder/iam_member.py
@@ -11,7 +11,7 @@ class IAMMember(pulumi.CustomResource):
     Allows creation and management of a single member for a single binding within
     the IAM policy for an existing Google Cloud Platform folder.
     
-    ~> **Note:** This resource _must not_ be used in conjunction with
+    > **Note:** This resource _must not_ be used in conjunction with
        `google_folder_iam_policy` or they will fight over what your policy
        should be. Similarly, roles controlled by `google_folder_iam_binding`
        should not be assigned to using `google_folder_iam_member`.

--- a/sdk/python/pulumi_gcp/kms/crypto_key.py
+++ b/sdk/python/pulumi_gcp/kms/crypto_key.py
@@ -16,7 +16,7 @@ class CryptoKey(pulumi.CustomResource):
     A CryptoKey is an interface to key material which can be used to encrypt and decrypt data. A CryptoKey belongs to a
     Google Cloud KMS KeyRing.
     
-    ~> Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a
+    > Note: CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a
     Terraform-managed CryptoKey will remove it from state and delete all
     CryptoKeyVersions, rendering the key unusable, but **will not delete the
     resource on the server**. When Terraform destroys these keys, any data

--- a/sdk/python/pulumi_gcp/kms/crypto_key_iam_member.py
+++ b/sdk/python/pulumi_gcp/kms/crypto_key_iam_member.py
@@ -11,7 +11,7 @@ class CryptoKeyIAMMember(pulumi.CustomResource):
     Allows creation and management of a single member for a single binding within
     the IAM policy for an existing Google Cloud KMS crypto key.
     
-    ~> **Note:** This resource _must not_ be used in conjunction with
+    > **Note:** This resource _must not_ be used in conjunction with
        `google_kms_crypto_key_iam_policy` or they will fight over what your policy
        should be. Similarly, roles controlled by `google_kms_crypto_key_iam_binding`
        should not be assigned to using `google_kms_crypto_key_iam_member`.

--- a/sdk/python/pulumi_gcp/kms/get_kms_secret.py
+++ b/sdk/python/pulumi_gcp/kms/get_kms_secret.py
@@ -32,7 +32,7 @@ async def get_kms_secret(ciphertext=None, crypto_key=None):
     For more information see
     [the official documentation](https://cloud.google.com/kms/docs/encrypt-decrypt).
     
-    ~> **NOTE**: Using this data provider will allow you to conceal secret data within your
+    > **NOTE**: Using this data provider will allow you to conceal secret data within your
     resource definitions, but it does not take care of protecting that data in the
     logging output, plan output, or state output.  Please take care to secure your secret
     data outside of resource definitions.

--- a/sdk/python/pulumi_gcp/kms/key_ring.py
+++ b/sdk/python/pulumi_gcp/kms/key_ring.py
@@ -16,7 +16,7 @@ class KeyRing(pulumi.CustomResource):
     A KeyRing is a grouping of CryptoKeys for organizational purposes. A KeyRing belongs to a Google Cloud Platform Project
     and resides in a specific location.
     
-    ~> Note: KeyRings cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyRing will remove it
+    > Note: KeyRings cannot be deleted from Google Cloud Platform. Destroying a Terraform-managed KeyRing will remove it
     from state but **will not delete the resource on the server**.
     """
     def __init__(__self__, __name__, __opts__=None, location=None, name=None, project=None):

--- a/sdk/python/pulumi_gcp/kms/key_ring_iam_binding.py
+++ b/sdk/python/pulumi_gcp/kms/key_ring_iam_binding.py
@@ -14,9 +14,9 @@ class KeyRingIAMBinding(pulumi.CustomResource):
     * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
     * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
     
-    ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, key_ring_id=None, members=None, role=None):
         """Create a KeyRingIAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/kms/key_ring_iam_member.py
+++ b/sdk/python/pulumi_gcp/kms/key_ring_iam_member.py
@@ -14,9 +14,9 @@ class KeyRingIAMMember(pulumi.CustomResource):
     * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
     * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
     
-    ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, key_ring_id=None, member=None, role=None):
         """Create a KeyRingIAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/kms/key_ring_iam_policy.py
+++ b/sdk/python/pulumi_gcp/kms/key_ring_iam_policy.py
@@ -14,9 +14,9 @@ class KeyRingIAMPolicy(pulumi.CustomResource):
     * `google_kms_key_ring_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the key ring are preserved.
     * `google_kms_key_ring_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the key ring are preserved.
     
-    ~> **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_kms_key_ring_iam_policy` **cannot** be used in conjunction with `google_kms_key_ring_iam_binding` and `google_kms_key_ring_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, key_ring_id=None, policy_data=None):
         """Create a KeyRingIAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/logging/billing_account_sink.py
+++ b/sdk/python/pulumi_gcp/logging/billing_account_sink.py
@@ -12,7 +12,7 @@ class BillingAccountSink(pulumi.CustomResource):
     [the official documentation](https://cloud.google.com/logging/docs/) and
     [Exporting Logs in the API](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
     
-    ~> **Note** You must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
+    > **Note** You must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
     [granted on the billing account](https://cloud.google.com/billing/reference/rest/v1/billingAccounts/getIamPolicy) to
     the credentials used with Terraform. [IAM roles granted on a billing account](https://cloud.google.com/billing/docs/how-to/billing-access) are separate from the
     typical IAM roles granted on a project.

--- a/sdk/python/pulumi_gcp/logging/project_sink.py
+++ b/sdk/python/pulumi_gcp/logging/project_sink.py
@@ -14,9 +14,9 @@ class ProjectSink(pulumi.CustomResource):
     and
     [API](https://cloud.google.com/logging/docs/reference/v2/rest/).
     
-    ~> **Note:** You must have [granted the "Logs Configuration Writer"](https://cloud.google.com/logging/docs/access-control) IAM role (`roles/logging.configWriter`) to the credentials used with terraform.
+    > **Note:** You must have [granted the "Logs Configuration Writer"](https://cloud.google.com/logging/docs/access-control) IAM role (`roles/logging.configWriter`) to the credentials used with terraform.
     
-    ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
+    > **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
     """
     def __init__(__self__, __name__, __opts__=None, destination=None, filter=None, name=None, project=None, unique_writer_identity=None):
         """Create a ProjectSink resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/monitoring/alert_policy.py
+++ b/sdk/python/pulumi_gcp/monitoring/alert_policy.py
@@ -7,6 +7,18 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class AlertPolicy(pulumi.CustomResource):
+    """
+    A description of the conditions under which some aspect of your system is
+    considered to be "unhealthy" and the ways to notify people or services
+    about this state.
+    
+    
+    To get more information about AlertPolicy, see:
+    
+    * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/monitoring/alerts/)
+    """
     def __init__(__self__, __name__, __opts__=None, combiner=None, conditions=None, display_name=None, enabled=None, labels=None, notification_channels=None, project=None):
         """Create a AlertPolicy resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/organizations/get_folder.py
+++ b/sdk/python/pulumi_gcp/organizations/get_folder.py
@@ -59,6 +59,26 @@ async def get_folder(folder=None, lookup_organization=None):
     Use this data source to get information about a Google Cloud Folder.
     
     ```hcl
+    # Get folder by id
+    data "google_folder" "my_folder_1" {
+      folder = "folders/12345"
+      lookup_organization = true
+    }
+    
+    # Search by fields
+    data "google_folder" "my_folder_2" {
+      folder = "folders/23456"
+    }
+    
+    output "my_folder_1_organization" {
+      value = "${data.google_folder.my_folder_1.organization}"
+    }
+    
+    output "my_folder_2_parent" {
+      value = "${data.google_folder.my_folder_2.parent}"
+    }
+    
+    ```
     """
     __args__ = dict()
 

--- a/sdk/python/pulumi_gcp/organizations/iam_binding.py
+++ b/sdk/python/pulumi_gcp/organizations/iam_binding.py
@@ -11,7 +11,7 @@ class IAMBinding(pulumi.CustomResource):
     Allows creation and management of a single binding within IAM policy for
     an existing Google Cloud Platform Organization.
     
-    ~> **Note:** This resource __must not__ be used in conjunction with
+    > **Note:** This resource __must not__ be used in conjunction with
        `google_organization_iam_member` for the __same role__ or they will fight over
        what your policy should be.
     """

--- a/sdk/python/pulumi_gcp/organizations/iam_custom_role.py
+++ b/sdk/python/pulumi_gcp/organizations/iam_custom_role.py
@@ -13,7 +13,7 @@ class IAMCustomRole(pulumi.CustomResource):
     and
     [API](https://cloud.google.com/iam/reference/rest/v1/organizations.roles).
     
-    ~> **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
+    > **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
      from this and how roles are propagated. 1) creating a role may involve undeleting and then updating a role with the
      same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
      after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is

--- a/sdk/python/pulumi_gcp/organizations/iam_member.py
+++ b/sdk/python/pulumi_gcp/organizations/iam_member.py
@@ -11,7 +11,7 @@ class IAMMember(pulumi.CustomResource):
     Allows creation and management of a single member for a single binding within
     the IAM policy for an existing Google Cloud Platform Organization.
     
-    ~> **Note:** This resource __must not__ be used in conjunction with
+    > **Note:** This resource __must not__ be used in conjunction with
        `google_organization_iam_binding` for the __same role__ or they will fight over
        what your policy should be.
     """

--- a/sdk/python/pulumi_gcp/organizations/iam_policy.py
+++ b/sdk/python/pulumi_gcp/organizations/iam_policy.py
@@ -10,7 +10,7 @@ class IAMPolicy(pulumi.CustomResource):
     """
     Allows management of the entire IAM policy for an existing Google Cloud Platform Organization.
     
-    ~> **Warning:** New organizations have several default policies which will,
+    > **Warning:** New organizations have several default policies which will,
        without extreme caution, be **overwritten** by use of this resource.
        The safest alternative is to use multiple `google_organization_iam_binding`
        resources.  It is easy to use this resource to remove your own access to
@@ -19,7 +19,7 @@ class IAMPolicy(pulumi.CustomResource):
        the best way to be sure that you are not making dangerous changes is to start
        by importing your existing policy, and examining the diff very closely.
     
-    ~> **Note:** This resource __must not__ be used in conjunction with
+    > **Note:** This resource __must not__ be used in conjunction with
        `google_organization_iam_member` or `google_organization_iam_binding`
        or they will fight over what your policy should be.
     """

--- a/sdk/python/pulumi_gcp/organizations/project.py
+++ b/sdk/python/pulumi_gcp/organizations/project.py
@@ -32,7 +32,7 @@ class Project(pulumi.CustomResource):
       used just like always, keeping in mind that Terraform will attempt to undo any changes
       made outside Terraform.
     
-    ~> It's important to note that any project resources that were added to your Terraform config
+    > It's important to note that any project resources that were added to your Terraform config
     prior to 0.8.5 will continue to function as they always have, and will not be managed by
     Terraform. Only newly added projects are affected.
     """

--- a/sdk/python/pulumi_gcp/projects/iam_binding.py
+++ b/sdk/python/pulumi_gcp/projects/iam_binding.py
@@ -14,9 +14,9 @@ class IAMBinding(pulumi.CustomResource):
     * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
     * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
     
-    ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, members=None, project=None, role=None):
         """Create a IAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/projects/iam_custom_role.py
+++ b/sdk/python/pulumi_gcp/projects/iam_custom_role.py
@@ -13,7 +13,7 @@ class IAMCustomRole(pulumi.CustomResource):
     and
     [API](https://cloud.google.com/iam/reference/rest/v1/projects.roles).
     
-    ~> **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
+    > **Warning:** Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise
      from this and how roles are propagated. 1) creating a role may involve undeleting and then updating a role with the
      same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
      after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is

--- a/sdk/python/pulumi_gcp/projects/iam_member.py
+++ b/sdk/python/pulumi_gcp/projects/iam_member.py
@@ -14,9 +14,9 @@ class IAMMember(pulumi.CustomResource):
     * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
     * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
     
-    ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, member=None, project=None, role=None):
         """Create a IAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/projects/iam_policy.py
+++ b/sdk/python/pulumi_gcp/projects/iam_policy.py
@@ -14,9 +14,9 @@ class IAMPolicy(pulumi.CustomResource):
     * `google_project_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
     * `google_project_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.
     
-    ~> **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_project_iam_policy` **cannot** be used in conjunction with `google_project_iam_binding` and `google_project_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_project_iam_binding` resources **can be** used in conjunction with `google_project_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, authoritative=None, disable_project=None, policy_data=None, project=None):
         """Create a IAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/projects/service.py
+++ b/sdk/python/pulumi_gcp/projects/service.py
@@ -13,7 +13,7 @@ class Service(pulumi.CustomResource):
     For a list of services available, visit the
     [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
     
-    ~> **Note:** This resource _must not_ be used in conjunction with
+    > **Note:** This resource _must not_ be used in conjunction with
        `google_project_services` or they will fight over which services should be enabled.
     """
     def __init__(__self__, __name__, __opts__=None, disable_on_destroy=None, project=None, service=None):

--- a/sdk/python/pulumi_gcp/projects/services.py
+++ b/sdk/python/pulumi_gcp/projects/services.py
@@ -15,7 +15,7 @@ class Services(pulumi.CustomResource):
     For a list of services available, visit the
     [API library page](https://console.cloud.google.com/apis/library) or run `gcloud services list`.
     
-    ~> **Note:** This resource attempts to be the authoritative source on *all* enabled APIs, which often
+    > **Note:** This resource attempts to be the authoritative source on *all* enabled APIs, which often
     	leads to conflicts when certain actions enable other APIs. If you do not need to ensure that
     	*exclusively* a particular set of APIs are enabled, you should most likely use the
     	google_project_service resource, one resource per API.

--- a/sdk/python/pulumi_gcp/projects/usage_export_bucket.py
+++ b/sdk/python/pulumi_gcp/projects/usage_export_bucket.py
@@ -32,7 +32,7 @@ class UsageExportBucket(pulumi.CustomResource):
       used just like always, keeping in mind that Terraform will attempt to undo any changes
       made outside Terraform.
     
-    ~> It's important to note that any project resources that were added to your Terraform config
+    > It's important to note that any project resources that were added to your Terraform config
     prior to 0.8.5 will continue to function as they always have, and will not be managed by
     Terraform. Only newly added projects are affected.
     """

--- a/sdk/python/pulumi_gcp/pubsub/subscription_iam_binding.py
+++ b/sdk/python/pulumi_gcp/pubsub/subscription_iam_binding.py
@@ -14,9 +14,9 @@ class SubscriptionIAMBinding(pulumi.CustomResource):
     * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
     * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
     
-    ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, members=None, project=None, role=None, subscription=None):
         """Create a SubscriptionIAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/pubsub/subscription_iam_member.py
+++ b/sdk/python/pulumi_gcp/pubsub/subscription_iam_member.py
@@ -14,9 +14,9 @@ class SubscriptionIAMMember(pulumi.CustomResource):
     * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
     * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
     
-    ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, member=None, project=None, role=None, subscription=None):
         """Create a SubscriptionIAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/pubsub/subscription_iam_policy.py
+++ b/sdk/python/pulumi_gcp/pubsub/subscription_iam_policy.py
@@ -14,9 +14,9 @@ class SubscriptionIAMPolicy(pulumi.CustomResource):
     * `google_pubsub_subscription_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the subscription are preserved.
     * `google_pubsub_subscription_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the subscription are preserved.
     
-    ~> **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_pubsub_subscription_iam_policy` **cannot** be used in conjunction with `google_pubsub_subscription_iam_binding` and `google_pubsub_subscription_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, policy_data=None, project=None, subscription=None):
         """Create a SubscriptionIAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/pubsub/topic_iam_binding.py
+++ b/sdk/python/pulumi_gcp/pubsub/topic_iam_binding.py
@@ -14,9 +14,9 @@ class TopicIAMBinding(pulumi.CustomResource):
     * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
     * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
     
-    ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, members=None, project=None, role=None, topic=None):
         """Create a TopicIAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/pubsub/topic_iam_member.py
+++ b/sdk/python/pulumi_gcp/pubsub/topic_iam_member.py
@@ -14,9 +14,9 @@ class TopicIAMMember(pulumi.CustomResource):
     * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
     * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
     
-    ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, member=None, project=None, role=None, topic=None):
         """Create a TopicIAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/pubsub/topic_iam_policy.py
+++ b/sdk/python/pulumi_gcp/pubsub/topic_iam_policy.py
@@ -14,9 +14,9 @@ class TopicIAMPolicy(pulumi.CustomResource):
     * `google_pubsub_topic_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the topic are preserved.
     * `google_pubsub_topic_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the topic are preserved.
     
-    ~> **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_pubsub_topic_iam_policy` **cannot** be used in conjunction with `google_pubsub_topic_iam_binding` and `google_pubsub_topic_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_pubsub_topic_iam_binding` resources **can be** used in conjunction with `google_pubsub_topic_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, policy_data=None, project=None, topic=None):
         """Create a TopicIAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/redis/instance.py
+++ b/sdk/python/pulumi_gcp/redis/instance.py
@@ -7,6 +7,16 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Instance(pulumi.CustomResource):
+    """
+    A Google Cloud Redis instance.
+    
+    
+    To get more information about Instance, see:
+    
+    * [API documentation](https://cloud.google.com/memorystore/docs/redis/reference/rest/)
+    * How-to Guides
+        * [Official Documentation](https://cloud.google.com/memorystore/docs/redis/)
+    """
     def __init__(__self__, __name__, __opts__=None, alternative_location_id=None, authorized_network=None, display_name=None, labels=None, location_id=None, memory_size_gb=None, name=None, project=None, redis_configs=None, redis_version=None, region=None, reserved_ip_range=None, tier=None):
         """Create a Instance resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/resourcemanager/lien.py
+++ b/sdk/python/pulumi_gcp/resourcemanager/lien.py
@@ -7,6 +7,11 @@ import pulumi.runtime
 from .. import utilities, tables
 
 class Lien(pulumi.CustomResource):
+    """
+    A Lien represents an encumbrance on the actions that can be performed on a resource.
+    
+    
+    """
     def __init__(__self__, __name__, __opts__=None, origin=None, parent=None, reason=None, restrictions=None):
         """Create a Lien resource with the given unique name, props, and options."""
         if not __name__:

--- a/sdk/python/pulumi_gcp/service_account/iam_binding.py
+++ b/sdk/python/pulumi_gcp/service_account/iam_binding.py
@@ -16,9 +16,9 @@ class IAMBinding(pulumi.CustomResource):
     * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
     * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
     
-    ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, members=None, role=None, service_account_id=None):
         """Create a IAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/service_account/iam_member.py
+++ b/sdk/python/pulumi_gcp/service_account/iam_member.py
@@ -16,9 +16,9 @@ class IAMMember(pulumi.CustomResource):
     * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
     * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
     
-    ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, member=None, role=None, service_account_id=None):
         """Create a IAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/service_account/iam_policy.py
+++ b/sdk/python/pulumi_gcp/service_account/iam_policy.py
@@ -16,9 +16,9 @@ class IAMPolicy(pulumi.CustomResource):
     * `google_service_account_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the service account are preserved.
     * `google_service_account_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the service account are preserved.
     
-    ~> **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_service_account_iam_policy` **cannot** be used in conjunction with `google_service_account_iam_binding` and `google_service_account_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, policy_data=None, service_account_id=None):
         """Create a IAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/spanner/database_iam_binding.py
+++ b/sdk/python/pulumi_gcp/spanner/database_iam_binding.py
@@ -12,14 +12,14 @@ class DatabaseIAMBinding(pulumi.CustomResource):
     
     * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
     
-    ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+    > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
     
     * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
     * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
     
-    ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, database=None, instance=None, members=None, project=None, role=None):
         """Create a DatabaseIAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/spanner/database_iam_member.py
+++ b/sdk/python/pulumi_gcp/spanner/database_iam_member.py
@@ -12,14 +12,14 @@ class DatabaseIAMMember(pulumi.CustomResource):
     
     * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
     
-    ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+    > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
     
     * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
     * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
     
-    ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, database=None, instance=None, member=None, project=None, role=None):
         """Create a DatabaseIAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/spanner/database_iam_policy.py
+++ b/sdk/python/pulumi_gcp/spanner/database_iam_policy.py
@@ -12,14 +12,14 @@ class DatabaseIAMPolicy(pulumi.CustomResource):
     
     * `google_spanner_database_iam_policy`: Authoritative. Sets the IAM policy for the database and replaces any existing policy already attached.
     
-    ~> **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+    > **Warning:** It's entirely possibly to lock yourself out of your database using `google_spanner_database_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
     
     * `google_spanner_database_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the database are preserved.
     * `google_spanner_database_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the database are preserved.
     
-    ~> **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_spanner_database_iam_policy` **cannot** be used in conjunction with `google_spanner_database_iam_binding` and `google_spanner_database_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, database=None, instance=None, policy_data=None, project=None):
         """Create a DatabaseIAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/spanner/instance_iam_binding.py
+++ b/sdk/python/pulumi_gcp/spanner/instance_iam_binding.py
@@ -12,14 +12,14 @@ class InstanceIAMBinding(pulumi.CustomResource):
     
     * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
     
-    ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+    > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
     
     * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
     * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
     
-    ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, instance=None, members=None, project=None, role=None):
         """Create a InstanceIAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/spanner/instance_iam_member.py
+++ b/sdk/python/pulumi_gcp/spanner/instance_iam_member.py
@@ -12,14 +12,14 @@ class InstanceIAMMember(pulumi.CustomResource):
     
     * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
     
-    ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+    > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
     
     * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
     * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
     
-    ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, instance=None, member=None, project=None, role=None):
         """Create a InstanceIAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/spanner/instance_iam_policy.py
+++ b/sdk/python/pulumi_gcp/spanner/instance_iam_policy.py
@@ -12,14 +12,14 @@ class InstanceIAMPolicy(pulumi.CustomResource):
     
     * `google_spanner_instance_iam_policy`: Authoritative. Sets the IAM policy for the instance and replaces any existing policy already attached.
     
-    ~> **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
+    > **Warning:** It's entirely possibly to lock yourself out of your instance using `google_spanner_instance_iam_policy`. Any permissions granted by default will be removed unless you include them in your config.
     
     * `google_spanner_instance_iam_binding`: Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the instance are preserved.
     * `google_spanner_instance_iam_member`: Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the instance are preserved.
     
-    ~> **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
+    > **Note:** `google_spanner_instance_iam_policy` **cannot** be used in conjunction with `google_spanner_instance_iam_binding` and `google_spanner_instance_iam_member` or they will fight over what your policy should be.
     
-    ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, instance=None, policy_data=None, project=None):
         """Create a InstanceIAMPolicy resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/sql/database_instance.py
+++ b/sdk/python/pulumi_gcp/sql/database_instance.py
@@ -11,7 +11,7 @@ class DatabaseInstance(pulumi.CustomResource):
     Creates a new Google SQL Database Instance. For more information, see the [official documentation](https://cloud.google.com/sql/),
     or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/instances).
     
-    ~> **NOTE on `google_sql_database_instance`:** - Second-generation instances include a
+    > **NOTE on `google_sql_database_instance`:** - Second-generation instances include a
     default 'root'@'%' user with no password. This user will be deleted by Terraform on
     instance creation. You should use `google_sql_user` to define a custom user with
     a restricted host and strong password.

--- a/sdk/python/pulumi_gcp/sql/user.py
+++ b/sdk/python/pulumi_gcp/sql/user.py
@@ -10,7 +10,7 @@ class User(pulumi.CustomResource):
     """
     Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
     
-    ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+    > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
     [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html). Passwords will not be retrieved when running
     "terraform import".
     """

--- a/sdk/python/pulumi_gcp/storage/bucket_iam_binding.py
+++ b/sdk/python/pulumi_gcp/storage/bucket_iam_binding.py
@@ -15,7 +15,7 @@ class BucketIAMBinding(pulumi.CustomResource):
     * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
     
     
-    ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, bucket=None, members=None, role=None):
         """Create a BucketIAMBinding resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/storage/bucket_iam_member.py
+++ b/sdk/python/pulumi_gcp/storage/bucket_iam_member.py
@@ -15,7 +15,7 @@ class BucketIAMMember(pulumi.CustomResource):
     * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
     
     
-    ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, bucket=None, member=None, role=None):
         """Create a BucketIAMMember resource with the given unique name, props, and options."""

--- a/sdk/python/pulumi_gcp/storage/bucket_iam_policy.py
+++ b/sdk/python/pulumi_gcp/storage/bucket_iam_policy.py
@@ -15,7 +15,7 @@ class BucketIAMPolicy(pulumi.CustomResource):
     * `google_storage_bucket_iam_policy`: Setting a policy removes all other permissions on the bucket, and if done incorrectly, there's a real chance you will lock yourself out of the bucket. If possible for your use case, using multiple google_storage_bucket_iam_binding resources will be much safer. See the usage example on how to work with policy correctly.
     
     
-    ~> **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
+    > **Note:** `google_storage_bucket_iam_binding` resources **can be** used in conjunction with `google_storage_bucket_iam_member` resources **only if** they do not grant privilege to the same role.
     """
     def __init__(__self__, __name__, __opts__=None, bucket=None, policy_data=None):
         """Create a BucketIAMPolicy resource with the given unique name, props, and options."""


### PR DESCRIPTION
This ingests the latest Terraform code-gen, bringing in the
ability to convert HCL examples to Pulumi in the API docs.

Notes on metrics:

* 242 docs sections ignored
* 19 code blocks failed to convert
* 160 code blocks successfully converted