### PR TITLE
Don't use a `/` in project name

### DIFF
--- a/examples/minimal/Pulumi.yaml
+++ b/examples/minimal/Pulumi.yaml
@@ -1,3 +1,3 @@
-name: gcp/minimal
+name: minimal-gcp
 runtime: nodejs
 description: An empty Pulumi Google Cloud Test Script.


### PR DESCRIPTION
We'd like to disallow this at some point, so let's stop having tests where we rely on this working.