### PR TITLE
Update pulumi-terraform for Python improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.16.9 (Unreleased)
 
+### Improvements
+
+- Module names have been corrected in the Python SDK.
+
+- `:param` documentation comments for parameters lacking documentation no longer appear in the Python SDK.
+
 ## 0.16.8 (Released February 11, 2019)
 
 ### Improvements

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -611,7 +611,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3cd2ee0fc4d4c21d8a6373ce710e73125ebd7512fa44faef76fad971644eb4d0"
+  digest = "1:3c76a905563ef19b7bdbe787e0ed94f62a623f547ba3d301b9d2d5e10c8fc248"
   name = "github.com/pulumi/pulumi"
   packages = [
     "pkg/apitype",
@@ -658,18 +658,18 @@
     "sdk/proto/go",
   ]
   pruneopts = ""
-  revision = "4229f85fdaabcfc7bc866379b271b730c2384b6c"
+  revision = "ce26bd871f42b9ff346058aa0760b1a0b30677ef"
 
 [[projects]]
   branch = "master"
-  digest = "1:ee977962b3fd8565483e1114262993016dcec9f170447a86b690b08ad5ab5bde"
+  digest = "1:9e48cffeb9b65db24f10f9271e27ed2987c037b07d7b7c0c3641bf13498bd09a"
   name = "github.com/pulumi/pulumi-terraform"
   packages = [
     "pkg/tfbridge",
     "pkg/tfgen",
   ]
   pruneopts = ""
-  revision = "50c3039457f71c1bbc62f0acd86e0f8ed72e2cea"
+  revision = "0b5b9753f915a7366dd177d9a3a106fbce2fa6de"
 
 [[projects]]
   branch = "master"
@@ -1092,12 +1092,13 @@
   version = "v4.3.0"
 
 [[projects]]
-  digest = "1:a72d911e18578e34367f4b849340501c7e6a2787a3a05651b3d53c6cb96990f4"
+  digest = "1:8b8c3a2fa9908caa5d9e1c8a7f57e527758522bbde64e2bafd59f86293c23da1"
   name = "gopkg.in/src-d/go-git.v4"
   packages = [
     ".",
     "config",
     "internal/revision",
+    "internal/url",
     "plumbing",
     "plumbing/cache",
     "plumbing/filemode",
@@ -1137,8 +1138,8 @@
     "utils/merkletrie/noder",
   ]
   pruneopts = ""
-  revision = "a1f6ef44dfed1253ef7f3bc049f66b15f8fc2ab2"
-  version = "v4.9.1"
+  revision = "db6c41c156481962abf9a55a324858674c25ab08"
+  version = "v4.10.0"
 
 [[projects]]
   digest = "1:ceec7e96590fb8168f36df4795fefe17051d4b0c2acc7ec4e260d8138c4dafac"

--- a/sdk/python/pulumi_gcp/__init__.py
+++ b/sdk/python/pulumi_gcp/__init__.py
@@ -3,7 +3,7 @@
 # *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 # Make subpackages available:
-__all__ = ['appengine', 'bigquery', 'bigtable', 'billing', 'binaryauthorization', 'cloudbuild', 'cloudfunctions', 'composer', 'compute', 'config', 'container', 'containeranalysis', 'dataflow', 'dataproc', 'dns', 'endpoints', 'filestore', 'folder', 'iam', 'kms', 'logging', 'monitoring', 'organizations', 'projects', 'pubsub', 'redis', 'resourcemanager', 'runtimeconfig', 'serviceAccount', 'sourcerepo', 'spanner', 'sql', 'storage']
+__all__ = ['appengine', 'bigquery', 'bigtable', 'billing', 'binaryauthorization', 'cloudbuild', 'cloudfunctions', 'composer', 'compute', 'config', 'container', 'containeranalysis', 'dataflow', 'dataproc', 'dns', 'endpoints', 'filestore', 'folder', 'iam', 'kms', 'logging', 'monitoring', 'organizations', 'projects', 'pubsub', 'redis', 'resourcemanager', 'runtimeconfig', 'service_account', 'sourcerepo', 'spanner', 'sql', 'storage']
 
 # Export this package's modules as members:
 from .provider import *

--- a/sdk/python/pulumi_gcp/appengine/application.py
+++ b/sdk/python/pulumi_gcp/appengine/application.py
@@ -66,7 +66,6 @@ class Application(pulumi.CustomResource):
         :param pulumi.Input[dict] feature_settings: A block of optional settings to configure specific App Engine features:
         :param pulumi.Input[str] location_id: The [location](https://cloud.google.com/appengine/docs/locations)
                to serve the app from.
-        :param pulumi.Input[str] project
         :param pulumi.Input[str] serving_status: The serving status of the app.
         """
         if __name__ is not None:

--- a/sdk/python/pulumi_gcp/binaryauthorization/attestor.py
+++ b/sdk/python/pulumi_gcp/binaryauthorization/attestor.py
@@ -28,10 +28,6 @@ class Attestor(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[dict] attestation_authority_note
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] project
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/binaryauthorization/policy.py
+++ b/sdk/python/pulumi_gcp/binaryauthorization/policy.py
@@ -29,11 +29,6 @@ class Policy(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] admission_whitelist_patterns
-        :param pulumi.Input[list] cluster_admission_rules
-        :param pulumi.Input[dict] default_admission_rule
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] project
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/cloudbuild/trigger.py
+++ b/sdk/python/pulumi_gcp/cloudbuild/trigger.py
@@ -76,7 +76,6 @@ class Trigger(pulumi.CustomResource):
                `cloudbuild.yaml` however it can be specified by the user.
         :param pulumi.Input[str] project: The ID of the project that the trigger will be created in.
                Defaults to the provider project configuration.
-        :param pulumi.Input[dict] substitutions
         :param pulumi.Input[dict] trigger_template: Location of the source in a Google
                Cloud Source Repository. Structure is documented below.
         """

--- a/sdk/python/pulumi_gcp/cloudfunctions/get_function.py
+++ b/sdk/python/pulumi_gcp/cloudfunctions/get_function.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetFunctionResult(object):
+class GetFunctionResult:
     """
     A collection of values returned by getFunction.
     """
@@ -104,7 +104,7 @@ class GetFunctionResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_function(name=None, project=None, region=None):
+async def get_function(name=None,project=None,region=None,opts=None):
     """
     Get information about a Google Cloud Function. For more information see
     the [official documentation](https://cloud.google.com/functions/docs/)
@@ -115,7 +115,7 @@ async def get_function(name=None, project=None, region=None):
     __args__['name'] = name
     __args__['project'] = project
     __args__['region'] = region
-    __ret__ = await pulumi.runtime.invoke('gcp:cloudfunctions/getFunction:getFunction', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:cloudfunctions/getFunction:getFunction', __args__, opts=opts)
 
     return GetFunctionResult(
         available_memory_mb=__ret__.get('availableMemoryMb'),

--- a/sdk/python/pulumi_gcp/composer/environment.py
+++ b/sdk/python/pulumi_gcp/composer/environment.py
@@ -45,12 +45,8 @@ class Environment(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[dict] config
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/address.py
+++ b/sdk/python/pulumi_gcp/compute/address.py
@@ -65,15 +65,8 @@ class Address(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address: The IP of the created resource.
-        :param pulumi.Input[str] address_type
-        :param pulumi.Input[str] description
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network_tier
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
-        :param pulumi.Input[str] subnetwork
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/attached_disk.py
+++ b/sdk/python/pulumi_gcp/compute/attached_disk.py
@@ -33,12 +33,6 @@ class AttachedDisk(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] device_name
-        :param pulumi.Input[str] disk
-        :param pulumi.Input[str] instance
-        :param pulumi.Input[str] mode
-        :param pulumi.Input[str] project
-        :param pulumi.Input[str] zone
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/autoscalar.py
+++ b/sdk/python/pulumi_gcp/compute/autoscalar.py
@@ -43,12 +43,6 @@ class Autoscalar(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[dict] autoscaling_policy
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] project
-        :param pulumi.Input[str] target
-        :param pulumi.Input[str] zone
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/backend_bucket.py
+++ b/sdk/python/pulumi_gcp/compute/backend_bucket.py
@@ -48,10 +48,6 @@ class BackendBucket(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] bucket_name
-        :param pulumi.Input[str] description
-        :param pulumi.Input[bool] enable_cdn
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         """

--- a/sdk/python/pulumi_gcp/compute/disk.py
+++ b/sdk/python/pulumi_gcp/compute/disk.py
@@ -75,20 +75,8 @@ class Disk(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[dict] disk_encryption_key
-        :param pulumi.Input[str] disk_encryption_key_raw
-        :param pulumi.Input[str] image
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[int] size
-        :param pulumi.Input[str] snapshot
-        :param pulumi.Input[dict] source_image_encryption_key
-        :param pulumi.Input[dict] source_snapshot_encryption_key
-        :param pulumi.Input[str] type
-        :param pulumi.Input[str] zone
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/firewall.py
+++ b/sdk/python/pulumi_gcp/compute/firewall.py
@@ -64,23 +64,8 @@ class Firewall(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] allows
-        :param pulumi.Input[list] denies
-        :param pulumi.Input[str] description
-        :param pulumi.Input[list] destination_ranges
-        :param pulumi.Input[str] direction
-        :param pulumi.Input[bool] disabled
-        :param pulumi.Input[bool] enable_logging
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network
-        :param pulumi.Input[int] priority
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[list] source_ranges
-        :param pulumi.Input[str] source_service_accounts
-        :param pulumi.Input[list] source_tags
-        :param pulumi.Input[str] target_service_accounts
-        :param pulumi.Input[list] target_tags
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/forwarding_rule.py
+++ b/sdk/python/pulumi_gcp/compute/forwarding_rule.py
@@ -58,24 +58,8 @@ class ForwardingRule(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] backend_service
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] ip_address
-        :param pulumi.Input[str] ip_protocol
-        :param pulumi.Input[str] ip_version
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] load_balancing_scheme
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network
-        :param pulumi.Input[str] network_tier
-        :param pulumi.Input[str] port_range
-        :param pulumi.Input[list] ports
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
-        :param pulumi.Input[str] service_label
-        :param pulumi.Input[str] subnetwork
-        :param pulumi.Input[str] target
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/get_address.py
+++ b/sdk/python/pulumi_gcp/compute/get_address.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetAddressResult(object):
+class GetAddressResult:
     """
     A collection of values returned by getAddress.
     """
@@ -44,7 +44,7 @@ class GetAddressResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_address(name=None, project=None, region=None):
+async def get_address(name=None,project=None,region=None,opts=None):
     """
     Get the IP address from a static address. For more information see
     the official [API](https://cloud.google.com/compute/docs/reference/latest/addresses/get) documentation.
@@ -54,7 +54,7 @@ async def get_address(name=None, project=None, region=None):
     __args__['name'] = name
     __args__['project'] = project
     __args__['region'] = region
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getAddress:getAddress', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getAddress:getAddress', __args__, opts=opts)
 
     return GetAddressResult(
         address=__ret__.get('address'),

--- a/sdk/python/pulumi_gcp/compute/get_backend_service.py
+++ b/sdk/python/pulumi_gcp/compute/get_backend_service.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetBackendServiceResult(object):
+class GetBackendServiceResult:
     """
     A collection of values returned by getBackendService.
     """
@@ -101,7 +101,7 @@ class GetBackendServiceResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_backend_service(name=None, project=None):
+async def get_backend_service(name=None,project=None,opts=None):
     """
     Provide acces to a Backend Service's attribute. For more information
     see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
@@ -111,7 +111,7 @@ async def get_backend_service(name=None, project=None):
 
     __args__['name'] = name
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getBackendService:getBackendService', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getBackendService:getBackendService', __args__, opts=opts)
 
     return GetBackendServiceResult(
         backends=__ret__.get('backends'),

--- a/sdk/python/pulumi_gcp/compute/get_default_service_account.py
+++ b/sdk/python/pulumi_gcp/compute/get_default_service_account.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetDefaultServiceAccountResult(object):
+class GetDefaultServiceAccountResult:
     """
     A collection of values returned by getDefaultServiceAccount.
     """
@@ -29,14 +29,14 @@ class GetDefaultServiceAccountResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_default_service_account(project=None):
+async def get_default_service_account(project=None,opts=None):
     """
     Use this data source to retrieve default service account for this project
     """
     __args__ = dict()
 
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getDefaultServiceAccount:getDefaultServiceAccount', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getDefaultServiceAccount:getDefaultServiceAccount', __args__, opts=opts)
 
     return GetDefaultServiceAccountResult(
         email=__ret__.get('email'),

--- a/sdk/python/pulumi_gcp/compute/get_forwarding_rule.py
+++ b/sdk/python/pulumi_gcp/compute/get_forwarding_rule.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetForwardingRuleResult(object):
+class GetForwardingRuleResult:
     """
     A collection of values returned by getForwardingRule.
     """
@@ -95,7 +95,7 @@ class GetForwardingRuleResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_forwarding_rule(name=None, project=None, region=None):
+async def get_forwarding_rule(name=None,project=None,region=None,opts=None):
     """
     Get a forwarding rule within GCE from its name.
     """
@@ -104,7 +104,7 @@ async def get_forwarding_rule(name=None, project=None, region=None):
     __args__['name'] = name
     __args__['project'] = project
     __args__['region'] = region
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getForwardingRule:getForwardingRule', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getForwardingRule:getForwardingRule', __args__, opts=opts)
 
     return GetForwardingRuleResult(
         backend_service=__ret__.get('backendService'),

--- a/sdk/python/pulumi_gcp/compute/get_global_address.py
+++ b/sdk/python/pulumi_gcp/compute/get_global_address.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetGlobalAddressResult(object):
+class GetGlobalAddressResult:
     """
     A collection of values returned by getGlobalAddress.
     """
@@ -41,7 +41,7 @@ class GetGlobalAddressResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_global_address(name=None, project=None):
+async def get_global_address(name=None,project=None,opts=None):
     """
     Get the IP address from a static address reserved for a Global Forwarding Rule which are only used for HTTP load balancing. For more information see
     the official [API](https://cloud.google.com/compute/docs/reference/latest/globalAddresses) documentation.
@@ -50,7 +50,7 @@ async def get_global_address(name=None, project=None):
 
     __args__['name'] = name
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getGlobalAddress:getGlobalAddress', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getGlobalAddress:getGlobalAddress', __args__, opts=opts)
 
     return GetGlobalAddressResult(
         address=__ret__.get('address'),

--- a/sdk/python/pulumi_gcp/compute/get_image.py
+++ b/sdk/python/pulumi_gcp/compute/get_image.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetImageResult(object):
+class GetImageResult:
     """
     A collection of values returned by getImage.
     """
@@ -129,7 +129,7 @@ class GetImageResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_image(family=None, name=None, project=None):
+async def get_image(family=None,name=None,project=None,opts=None):
     """
     Get information about a Google Compute Image. Check that your service account has the `compute.imageUser` role if you want to share [custom images](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) from another project. If you want to use [public images][pubimg], do not forget to specify the dedicated project. For more information see
     [the official documentation](https://cloud.google.com/compute/docs/images) and its [API](https://cloud.google.com/compute/docs/reference/latest/images).
@@ -139,7 +139,7 @@ async def get_image(family=None, name=None, project=None):
     __args__['family'] = family
     __args__['name'] = name
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getImage:getImage', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getImage:getImage', __args__, opts=opts)
 
     return GetImageResult(
         archive_size_bytes=__ret__.get('archiveSizeBytes'),

--- a/sdk/python/pulumi_gcp/compute/get_instance.py
+++ b/sdk/python/pulumi_gcp/compute/get_instance.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetInstanceResult(object):
+class GetInstanceResult:
     """
     A collection of values returned by getInstance.
     """
@@ -164,7 +164,7 @@ class GetInstanceResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_instance(name=None, project=None, zone=None):
+async def get_instance(name=None,project=None,zone=None,opts=None):
     """
     Get information about a VM instance resource within GCE. For more information see
     [the official documentation](https://cloud.google.com/compute/docs/instances)
@@ -176,7 +176,7 @@ async def get_instance(name=None, project=None, zone=None):
     __args__['name'] = name
     __args__['project'] = project
     __args__['zone'] = zone
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getInstance:getInstance', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getInstance:getInstance', __args__, opts=opts)
 
     return GetInstanceResult(
         allow_stopping_for_update=__ret__.get('allowStoppingForUpdate'),

--- a/sdk/python/pulumi_gcp/compute/get_instance_group.py
+++ b/sdk/python/pulumi_gcp/compute/get_instance_group.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetInstanceGroupResult(object):
+class GetInstanceGroupResult:
     """
     A collection of values returned by getInstanceGroup.
     """
@@ -62,7 +62,7 @@ class GetInstanceGroupResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_instance_group(name=None, project=None, self_link=None, zone=None):
+async def get_instance_group(name=None,project=None,self_link=None,zone=None,opts=None):
     """
     Get a Compute Instance Group within GCE.
     For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)
@@ -74,7 +74,7 @@ async def get_instance_group(name=None, project=None, self_link=None, zone=None)
     __args__['project'] = project
     __args__['selfLink'] = self_link
     __args__['zone'] = zone
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getInstanceGroup:getInstanceGroup', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getInstanceGroup:getInstanceGroup', __args__, opts=opts)
 
     return GetInstanceGroupResult(
         description=__ret__.get('description'),

--- a/sdk/python/pulumi_gcp/compute/get_lbip_ranges.py
+++ b/sdk/python/pulumi_gcp/compute/get_lbip_ranges.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetLBIPRangesResult(object):
+class GetLBIPRangesResult:
     """
     A collection of values returned by getLBIPRanges.
     """
@@ -32,7 +32,7 @@ class GetLBIPRangesResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_lbip_ranges():
+async def get_lbip_ranges(opts=None):
     """
     Use this data source to access IP ranges in your firewall rules.
     
@@ -40,7 +40,7 @@ async def get_lbip_ranges():
     """
     __args__ = dict()
 
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getLBIPRanges:getLBIPRanges', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getLBIPRanges:getLBIPRanges', __args__, opts=opts)
 
     return GetLBIPRangesResult(
         http_ssl_tcp_internals=__ret__.get('httpSslTcpInternals'),

--- a/sdk/python/pulumi_gcp/compute/get_netblock_ip_ranges.py
+++ b/sdk/python/pulumi_gcp/compute/get_netblock_ip_ranges.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetNetblockIPRangesResult(object):
+class GetNetblockIPRangesResult:
     """
     A collection of values returned by getNetblockIPRanges.
     """
@@ -38,7 +38,7 @@ class GetNetblockIPRangesResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_netblock_ip_ranges():
+async def get_netblock_ip_ranges(opts=None):
     """
     Use this data source to get the IP ranges from the sender policy framework (SPF) record of \_cloud-netblocks.googleusercontent
     
@@ -46,7 +46,7 @@ async def get_netblock_ip_ranges():
     """
     __args__ = dict()
 
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getNetblockIPRanges:getNetblockIPRanges', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getNetblockIPRanges:getNetblockIPRanges', __args__, opts=opts)
 
     return GetNetblockIPRangesResult(
         cidr_blocks=__ret__.get('cidrBlocks'),

--- a/sdk/python/pulumi_gcp/compute/get_network.py
+++ b/sdk/python/pulumi_gcp/compute/get_network.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetNetworkResult(object):
+class GetNetworkResult:
     """
     A collection of values returned by getNetwork.
     """
@@ -44,7 +44,7 @@ class GetNetworkResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_network(name=None, project=None):
+async def get_network(name=None,project=None,opts=None):
     """
     Get a network within GCE from its name.
     """
@@ -52,7 +52,7 @@ async def get_network(name=None, project=None):
 
     __args__['name'] = name
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getNetwork:getNetwork', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getNetwork:getNetwork', __args__, opts=opts)
 
     return GetNetworkResult(
         description=__ret__.get('description'),

--- a/sdk/python/pulumi_gcp/compute/get_region_instance_group.py
+++ b/sdk/python/pulumi_gcp/compute/get_region_instance_group.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetRegionInstanceGroupResult(object):
+class GetRegionInstanceGroupResult:
     """
     A collection of values returned by getRegionInstanceGroup.
     """
@@ -47,7 +47,7 @@ class GetRegionInstanceGroupResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_region_instance_group(name=None, project=None, region=None, self_link=None):
+async def get_region_instance_group(name=None,project=None,region=None,self_link=None,opts=None):
     """
     Get a Compute Region Instance Group within GCE.
     For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/latest/regionInstanceGroups).
@@ -61,7 +61,7 @@ async def get_region_instance_group(name=None, project=None, region=None, self_l
     __args__['project'] = project
     __args__['region'] = region
     __args__['selfLink'] = self_link
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getRegionInstanceGroup:getRegionInstanceGroup', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getRegionInstanceGroup:getRegionInstanceGroup', __args__, opts=opts)
 
     return GetRegionInstanceGroupResult(
         instances=__ret__.get('instances'),

--- a/sdk/python/pulumi_gcp/compute/get_regions.py
+++ b/sdk/python/pulumi_gcp/compute/get_regions.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetRegionsResult(object):
+class GetRegionsResult:
     """
     A collection of values returned by getRegions.
     """
@@ -29,7 +29,7 @@ class GetRegionsResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_regions(project=None, status=None):
+async def get_regions(project=None,status=None,opts=None):
     """
     Provides access to available Google Compute regions for a given project.
     See more about [regions and regions](https://cloud.google.com/compute/docs/regions-zones/) in the upstream docs.
@@ -38,7 +38,7 @@ async def get_regions(project=None, status=None):
 
     __args__['project'] = project
     __args__['status'] = status
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getRegions:getRegions', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getRegions:getRegions', __args__, opts=opts)
 
     return GetRegionsResult(
         names=__ret__.get('names'),

--- a/sdk/python/pulumi_gcp/compute/get_ssl_policy.py
+++ b/sdk/python/pulumi_gcp/compute/get_ssl_policy.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetSSLPolicyResult(object):
+class GetSSLPolicyResult:
     """
     A collection of values returned by getSSLPolicy.
     """
@@ -67,7 +67,7 @@ class GetSSLPolicyResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_ssl_policy(name=None, project=None):
+async def get_ssl_policy(name=None,project=None,opts=None):
     """
     Gets an SSL Policy within GCE from its name, for use with Target HTTPS and Target SSL Proxies.
         For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies).
@@ -76,7 +76,7 @@ async def get_ssl_policy(name=None, project=None):
 
     __args__['name'] = name
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getSSLPolicy:getSSLPolicy', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getSSLPolicy:getSSLPolicy', __args__, opts=opts)
 
     return GetSSLPolicyResult(
         creation_timestamp=__ret__.get('creationTimestamp'),

--- a/sdk/python/pulumi_gcp/compute/get_subnetwork.py
+++ b/sdk/python/pulumi_gcp/compute/get_subnetwork.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetSubnetworkResult(object):
+class GetSubnetworkResult:
     """
     A collection of values returned by getSubnetwork.
     """
@@ -73,7 +73,7 @@ class GetSubnetworkResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_subnetwork(name=None, project=None, region=None):
+async def get_subnetwork(name=None,project=None,region=None,opts=None):
     """
     Get a subnetwork within GCE from its name and region.
     """
@@ -82,7 +82,7 @@ async def get_subnetwork(name=None, project=None, region=None):
     __args__['name'] = name
     __args__['project'] = project
     __args__['region'] = region
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getSubnetwork:getSubnetwork', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getSubnetwork:getSubnetwork', __args__, opts=opts)
 
     return GetSubnetworkResult(
         description=__ret__.get('description'),

--- a/sdk/python/pulumi_gcp/compute/get_vpn_gateway.py
+++ b/sdk/python/pulumi_gcp/compute/get_vpn_gateway.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetVPNGatewayResult(object):
+class GetVPNGatewayResult:
     """
     A collection of values returned by getVPNGateway.
     """
@@ -47,7 +47,7 @@ class GetVPNGatewayResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_vpn_gateway(name=None, project=None, region=None):
+async def get_vpn_gateway(name=None,project=None,region=None,opts=None):
     """
     Get a VPN gateway within GCE from its name.
     """
@@ -56,7 +56,7 @@ async def get_vpn_gateway(name=None, project=None, region=None):
     __args__['name'] = name
     __args__['project'] = project
     __args__['region'] = region
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getVPNGateway:getVPNGateway', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getVPNGateway:getVPNGateway', __args__, opts=opts)
 
     return GetVPNGatewayResult(
         description=__ret__.get('description'),

--- a/sdk/python/pulumi_gcp/compute/get_zones.py
+++ b/sdk/python/pulumi_gcp/compute/get_zones.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetZonesResult(object):
+class GetZonesResult:
     """
     A collection of values returned by getZones.
     """
@@ -29,7 +29,7 @@ class GetZonesResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_zones(project=None, region=None, status=None):
+async def get_zones(project=None,region=None,status=None,opts=None):
     """
     Provides access to available Google Compute zones in a region for a given project.
     See more about [regions and zones](https://cloud.google.com/compute/docs/regions-zones/regions-zones) in the upstream docs.
@@ -39,7 +39,7 @@ async def get_zones(project=None, region=None, status=None):
     __args__['project'] = project
     __args__['region'] = region
     __args__['status'] = status
-    __ret__ = await pulumi.runtime.invoke('gcp:compute/getZones:getZones', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:compute/getZones:getZones', __args__, opts=opts)
 
     return GetZonesResult(
         names=__ret__.get('names'),

--- a/sdk/python/pulumi_gcp/compute/global_address.py
+++ b/sdk/python/pulumi_gcp/compute/global_address.py
@@ -49,16 +49,8 @@ class GlobalAddress(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] address_type
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] ip_version
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network
-        :param pulumi.Input[int] prefix_length
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] purpose
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/health_check.py
+++ b/sdk/python/pulumi_gcp/compute/health_check.py
@@ -59,18 +59,8 @@ class HealthCheck(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[int] check_interval_sec
-        :param pulumi.Input[str] description
-        :param pulumi.Input[int] healthy_threshold
-        :param pulumi.Input[dict] http_health_check
-        :param pulumi.Input[dict] https_health_check
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[dict] ssl_health_check
-        :param pulumi.Input[dict] tcp_health_check
-        :param pulumi.Input[int] timeout_sec
-        :param pulumi.Input[int] unhealthy_threshold
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/http_health_check.py
+++ b/sdk/python/pulumi_gcp/compute/http_health_check.py
@@ -55,17 +55,8 @@ class HttpHealthCheck(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[int] check_interval_sec
-        :param pulumi.Input[str] description
-        :param pulumi.Input[int] healthy_threshold
-        :param pulumi.Input[str] host
-        :param pulumi.Input[str] name
-        :param pulumi.Input[int] port
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] request_path
-        :param pulumi.Input[int] timeout_sec
-        :param pulumi.Input[int] unhealthy_threshold
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/https_health_check.py
+++ b/sdk/python/pulumi_gcp/compute/https_health_check.py
@@ -55,17 +55,8 @@ class HttpsHealthCheck(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[int] check_interval_sec
-        :param pulumi.Input[str] description
-        :param pulumi.Input[int] healthy_threshold
-        :param pulumi.Input[str] host
-        :param pulumi.Input[str] name
-        :param pulumi.Input[int] port
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] request_path
-        :param pulumi.Input[int] timeout_sec
-        :param pulumi.Input[int] unhealthy_threshold
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/instance_from_template.py
+++ b/sdk/python/pulumi_gcp/compute/instance_from_template.py
@@ -61,28 +61,10 @@ class InstanceFromTemplate(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[bool] allow_stopping_for_update
-        :param pulumi.Input[list] attached_disks
-        :param pulumi.Input[dict] boot_disk
-        :param pulumi.Input[bool] can_ip_forward
-        :param pulumi.Input[bool] deletion_protection
-        :param pulumi.Input[str] description
-        :param pulumi.Input[list] guest_accelerators
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] machine_type
-        :param pulumi.Input[dict] metadata
-        :param pulumi.Input[str] metadata_startup_script
-        :param pulumi.Input[str] min_cpu_platform
         :param pulumi.Input[str] name: A unique name for the resource, required by GCE.
                Changing this forces a new resource to be created.
-        :param pulumi.Input[list] network_interfaces
-        :param pulumi.Input[str] project
-        :param pulumi.Input[dict] scheduling
-        :param pulumi.Input[list] scratch_disks
-        :param pulumi.Input[dict] service_account
         :param pulumi.Input[str] source_instance_template: Name or self link of an instance
                template to create the instance based on.
-        :param pulumi.Input[list] tags
         :param pulumi.Input[str] zone: The zone that the machine should be created in. If not
                set, the provider zone is used.
         """

--- a/sdk/python/pulumi_gcp/compute/interconnect_attachment.py
+++ b/sdk/python/pulumi_gcp/compute/interconnect_attachment.py
@@ -35,13 +35,8 @@ class InterconnectAttachment(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] interconnect
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
-        :param pulumi.Input[str] router
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/region_autoscaler.py
+++ b/sdk/python/pulumi_gcp/compute/region_autoscaler.py
@@ -43,12 +43,6 @@ class RegionAutoscaler(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[dict] autoscaling_policy
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] project
-        :param pulumi.Input[str] region
-        :param pulumi.Input[str] target
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/region_disk.py
+++ b/sdk/python/pulumi_gcp/compute/region_disk.py
@@ -71,18 +71,8 @@ class RegionDisk(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[dict] disk_encryption_key
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
-        :param pulumi.Input[list] replica_zones
-        :param pulumi.Input[int] size
-        :param pulumi.Input[str] snapshot
-        :param pulumi.Input[dict] source_snapshot_encryption_key
-        :param pulumi.Input[str] type
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/route.py
+++ b/sdk/python/pulumi_gcp/compute/route.py
@@ -75,22 +75,12 @@ class Route(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] dest_range
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network
-        :param pulumi.Input[str] next_hop_gateway
-        :param pulumi.Input[str] next_hop_instance
         :param pulumi.Input[str] next_hop_instance_zone: (Optional when `next_hop_instance` is
                specified)  The zone of the instance specified in
                `next_hop_instance`.  Omit if `next_hop_instance` is specified as
                a URL.
-        :param pulumi.Input[str] next_hop_ip
-        :param pulumi.Input[str] next_hop_vpn_tunnel
-        :param pulumi.Input[int] priority
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[list] tags
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/router.py
+++ b/sdk/python/pulumi_gcp/compute/router.py
@@ -43,13 +43,8 @@ class Router(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[dict] bgp
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/router_nat.py
+++ b/sdk/python/pulumi_gcp/compute/router_nat.py
@@ -28,19 +28,6 @@ class RouterNat(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[int] icmp_idle_timeout_sec
-        :param pulumi.Input[int] min_ports_per_vm
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] nat_ip_allocate_option
-        :param pulumi.Input[list] nat_ips
-        :param pulumi.Input[str] project
-        :param pulumi.Input[str] region
-        :param pulumi.Input[str] router
-        :param pulumi.Input[str] source_subnetwork_ip_ranges_to_nat
-        :param pulumi.Input[list] subnetworks
-        :param pulumi.Input[int] tcp_established_idle_timeout_sec
-        :param pulumi.Input[int] tcp_transitory_idle_timeout_sec
-        :param pulumi.Input[int] udp_idle_timeout_sec
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/snapshot.py
+++ b/sdk/python/pulumi_gcp/compute/snapshot.py
@@ -60,17 +60,8 @@ class Snapshot(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[dict] snapshot_encryption_key
-        :param pulumi.Input[str] snapshot_encryption_key_raw
-        :param pulumi.Input[str] source_disk
-        :param pulumi.Input[dict] source_disk_encryption_key
-        :param pulumi.Input[str] source_disk_encryption_key_raw
-        :param pulumi.Input[str] zone
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_certificate.py
@@ -50,12 +50,8 @@ class SSLCertificate(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] certificate
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] name_prefix: Creates a unique name beginning with the
                specified prefix. Conflicts with `name`.
-        :param pulumi.Input[str] private_key
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         """

--- a/sdk/python/pulumi_gcp/compute/ssl_policy.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_policy.py
@@ -46,11 +46,6 @@ class SSLPolicy(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] custom_features
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] min_tls_version
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] profile
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         """

--- a/sdk/python/pulumi_gcp/compute/subnetwork.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork.py
@@ -70,16 +70,8 @@ class Subnetwork(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[bool] enable_flow_logs
-        :param pulumi.Input[str] ip_cidr_range
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network
-        :param pulumi.Input[bool] private_ip_google_access
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
-        :param pulumi.Input[list] secondary_ip_ranges
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/subnetwork_iam_binding.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork_iam_binding.py
@@ -51,7 +51,6 @@ class SubnetworkIAMBinding(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] region: The region of the subnetwork. If

--- a/sdk/python/pulumi_gcp/compute/subnetwork_iam_member.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork_iam_member.py
@@ -51,7 +51,6 @@ class SubnetworkIAMMember(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] region: The region of the subnetwork. If

--- a/sdk/python/pulumi_gcp/compute/target_http_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_http_proxy.py
@@ -43,11 +43,8 @@ class TargetHttpProxy(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] url_map
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/target_https_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_https_proxy.py
@@ -46,14 +46,8 @@ class TargetHttpsProxy(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] quic_override
-        :param pulumi.Input[list] ssl_certificates
-        :param pulumi.Input[str] ssl_policy
-        :param pulumi.Input[str] url_map
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/target_ssl_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_ssl_proxy.py
@@ -47,14 +47,8 @@ class TargetSSLProxy(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] backend_service
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] proxy_header
-        :param pulumi.Input[str] ssl_certificates
-        :param pulumi.Input[str] ssl_policy
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/target_tcp_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_tcp_proxy.py
@@ -45,12 +45,8 @@ class TargetTCPProxy(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] backend_service
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] proxy_header
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/vpn_gateway.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_gateway.py
@@ -41,12 +41,8 @@ class VPNGateway(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] network
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
@@ -57,19 +57,8 @@ class VPNTunnel(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[int] ike_version
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[list] local_traffic_selectors
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] peer_ip
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
-        :param pulumi.Input[list] remote_traffic_selectors
-        :param pulumi.Input[str] router
-        :param pulumi.Input[str] shared_secret
-        :param pulumi.Input[str] target_vpn_gateway
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/container/cluster.py
+++ b/sdk/python/pulumi_gcp/container/cluster.py
@@ -325,7 +325,6 @@ class Cluster(pulumi.CustomResource):
                See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
-        :param pulumi.Input[str] region
         :param pulumi.Input[bool] remove_default_node_pool: If true, deletes the default node pool upon cluster creation.
         :param pulumi.Input[dict] resource_labels: The GCE resource labels (a map of key/value pairs) to be applied to the cluster.
         :param pulumi.Input[str] subnetwork: The name or self_link of the Google Compute Engine subnetwork in

--- a/sdk/python/pulumi_gcp/container/get_cluster.py
+++ b/sdk/python/pulumi_gcp/container/get_cluster.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetClusterResult(object):
+class GetClusterResult:
     """
     A collection of values returned by getCluster.
     """
@@ -116,7 +116,7 @@ class GetClusterResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_cluster(name=None, project=None, region=None, zone=None):
+async def get_cluster(name=None,project=None,region=None,zone=None,opts=None):
     """
     Get info about a cluster within GKE from its name and zone.
     """
@@ -126,7 +126,7 @@ async def get_cluster(name=None, project=None, region=None, zone=None):
     __args__['project'] = project
     __args__['region'] = region
     __args__['zone'] = zone
-    __ret__ = await pulumi.runtime.invoke('gcp:container/getCluster:getCluster', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:container/getCluster:getCluster', __args__, opts=opts)
 
     return GetClusterResult(
         additional_zones=__ret__.get('additionalZones'),

--- a/sdk/python/pulumi_gcp/container/get_engine_versions.py
+++ b/sdk/python/pulumi_gcp/container/get_engine_versions.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetEngineVersionsResult(object):
+class GetEngineVersionsResult:
     """
     A collection of values returned by getEngineVersions.
     """
@@ -50,7 +50,7 @@ class GetEngineVersionsResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_engine_versions(project=None, region=None, zone=None):
+async def get_engine_versions(project=None,region=None,zone=None,opts=None):
     """
     Provides access to available Google Container Engine versions in a zone or region for a given project.
     """
@@ -59,7 +59,7 @@ async def get_engine_versions(project=None, region=None, zone=None):
     __args__['project'] = project
     __args__['region'] = region
     __args__['zone'] = zone
-    __ret__ = await pulumi.runtime.invoke('gcp:container/getEngineVersions:getEngineVersions', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:container/getEngineVersions:getEngineVersions', __args__, opts=opts)
 
     return GetEngineVersionsResult(
         default_cluster_version=__ret__.get('defaultClusterVersion'),

--- a/sdk/python/pulumi_gcp/container/get_registry_image.py
+++ b/sdk/python/pulumi_gcp/container/get_registry_image.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetRegistryImageResult(object):
+class GetRegistryImageResult:
     """
     A collection of values returned by getRegistryImage.
     """
@@ -26,7 +26,7 @@ class GetRegistryImageResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_registry_image(digest=None, name=None, project=None, region=None, tag=None):
+async def get_registry_image(digest=None,name=None,project=None,region=None,tag=None,opts=None):
     """
     This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project.
     
@@ -39,7 +39,7 @@ async def get_registry_image(digest=None, name=None, project=None, region=None, 
     __args__['project'] = project
     __args__['region'] = region
     __args__['tag'] = tag
-    __ret__ = await pulumi.runtime.invoke('gcp:container/getRegistryImage:getRegistryImage', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:container/getRegistryImage:getRegistryImage', __args__, opts=opts)
 
     return GetRegistryImageResult(
         image_url=__ret__.get('imageUrl'),

--- a/sdk/python/pulumi_gcp/container/get_registry_repository.py
+++ b/sdk/python/pulumi_gcp/container/get_registry_repository.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetRegistryRepositoryResult(object):
+class GetRegistryRepositoryResult:
     """
     A collection of values returned by getRegistryRepository.
     """
@@ -26,7 +26,7 @@ class GetRegistryRepositoryResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_registry_repository(project=None, region=None):
+async def get_registry_repository(project=None,region=None,opts=None):
     """
     This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project.
     
@@ -36,7 +36,7 @@ async def get_registry_repository(project=None, region=None):
 
     __args__['project'] = project
     __args__['region'] = region
-    __ret__ = await pulumi.runtime.invoke('gcp:container/getRegistryRepository:getRegistryRepository', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:container/getRegistryRepository:getRegistryRepository', __args__, opts=opts)
 
     return GetRegistryRepositoryResult(
         project=__ret__.get('project'),

--- a/sdk/python/pulumi_gcp/containeranalysis/note.py
+++ b/sdk/python/pulumi_gcp/containeranalysis/note.py
@@ -33,9 +33,6 @@ class Note(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[dict] attestation_authority
-        :param pulumi.Input[str] name
-        :param pulumi.Input[str] project
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/dataflow/job.py
+++ b/sdk/python/pulumi_gcp/dataflow/job.py
@@ -68,7 +68,6 @@ class Job(pulumi.CustomResource):
         :param pulumi.Input[str] on_delete: One of "drain" or "cancel".  Specifies behavior of deletion during `terraform destroy`.  See above note.
         :param pulumi.Input[dict] parameters: Key/Value pairs to be passed to the Dataflow job (as used in the template).
         :param pulumi.Input[str] project: The project in which the resource belongs. If it is not provided, the provider project is used.
-        :param pulumi.Input[str] region
         :param pulumi.Input[str] temp_gcs_location: A writeable location on GCS for the Dataflow job to dump its temporary data.
         :param pulumi.Input[str] template_gcs_path: The GCS path to the Dataflow job template.
         :param pulumi.Input[str] zone: The zone in which the created job should run. If it is not provided, the provider zone is used.

--- a/sdk/python/pulumi_gcp/dataproc/job.py
+++ b/sdk/python/pulumi_gcp/dataproc/job.py
@@ -59,20 +59,11 @@ class Job(pulumi.CustomResource):
         :param pulumi.Input[bool] force_delete: By default, you can only delete inactive jobs within
                Dataproc. Setting this to true, and calling destroy, will ensure that the
                job is first cancelled before issuing the delete.
-        :param pulumi.Input[dict] hadoop_config
-        :param pulumi.Input[dict] hive_config
         :param pulumi.Input[dict] labels: The list of labels (key/value pairs) to add to the job.
-        :param pulumi.Input[dict] pig_config
-        :param pulumi.Input[dict] placement
         :param pulumi.Input[str] project: The project in which the `cluster` can be found and jobs
                subsequently run against. If it is not provided, the provider project is used.
-        :param pulumi.Input[dict] pyspark_config
-        :param pulumi.Input[dict] reference
         :param pulumi.Input[str] region: The Cloud Dataproc region. This essentially determines which clusters are available
                for this job to be submitted to. If not specified, defaults to `global`.
-        :param pulumi.Input[dict] scheduling
-        :param pulumi.Input[dict] spark_config
-        :param pulumi.Input[dict] sparksql_config
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/dns/get_managed_zone.py
+++ b/sdk/python/pulumi_gcp/dns/get_managed_zone.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetManagedZoneResult(object):
+class GetManagedZoneResult:
     """
     A collection of values returned by getManagedZone.
     """
@@ -40,7 +40,7 @@ class GetManagedZoneResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_managed_zone(name=None, project=None):
+async def get_managed_zone(name=None,project=None,opts=None):
     """
     Provides access to a zone's attributes within Google Cloud DNS.
     For more information see
@@ -52,7 +52,7 @@ async def get_managed_zone(name=None, project=None):
 
     __args__['name'] = name
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:dns/getManagedZone:getManagedZone', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:dns/getManagedZone:getManagedZone', __args__, opts=opts)
 
     return GetManagedZoneResult(
         description=__ret__.get('description'),

--- a/sdk/python/pulumi_gcp/endpoints/service.py
+++ b/sdk/python/pulumi_gcp/endpoints/service.py
@@ -25,12 +25,6 @@ class Service(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] grpc_config
-        :param pulumi.Input[str] openapi_config
-        :param pulumi.Input[str] project
-        :param pulumi.Input[str] protoc_output
-        :param pulumi.Input[str] protoc_output_base64
-        :param pulumi.Input[str] service_name
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/filestore/instance.py
+++ b/sdk/python/pulumi_gcp/filestore/instance.py
@@ -42,14 +42,6 @@ class Instance(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[dict] file_shares
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] name
-        :param pulumi.Input[list] networks
-        :param pulumi.Input[str] project
-        :param pulumi.Input[str] tier
-        :param pulumi.Input[str] zone
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/iam/get_rule.py
+++ b/sdk/python/pulumi_gcp/iam/get_rule.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetRuleResult(object):
+class GetRuleResult:
     """
     A collection of values returned by getRule.
     """
@@ -38,14 +38,14 @@ class GetRuleResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_rule(name=None):
+async def get_rule(name=None,opts=None):
     """
     Use this data source to get information about a Google IAM Role.
     """
     __args__ = dict()
 
     __args__['name'] = name
-    __ret__ = await pulumi.runtime.invoke('gcp:iam/getRule:getRule', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:iam/getRule:getRule', __args__, opts=opts)
 
     return GetRuleResult(
         included_permissions=__ret__.get('includedPermissions'),

--- a/sdk/python/pulumi_gcp/kms/get_kms_secret.py
+++ b/sdk/python/pulumi_gcp/kms/get_kms_secret.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetKMSSecretResult(object):
+class GetKMSSecretResult:
     """
     A collection of values returned by getKMSSecret.
     """
@@ -26,7 +26,7 @@ class GetKMSSecretResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_kms_secret(ciphertext=None, crypto_key=None):
+async def get_kms_secret(ciphertext=None,crypto_key=None,opts=None):
     """
     This data source allows you to use data encrypted with Google Cloud KMS
     within your resource definitions.
@@ -43,7 +43,7 @@ async def get_kms_secret(ciphertext=None, crypto_key=None):
 
     __args__['ciphertext'] = ciphertext
     __args__['cryptoKey'] = crypto_key
-    __ret__ = await pulumi.runtime.invoke('gcp:kms/getKMSSecret:getKMSSecret', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:kms/getKMSSecret:getKMSSecret', __args__, opts=opts)
 
     return GetKMSSecretResult(
         plaintext=__ret__.get('plaintext'),

--- a/sdk/python/pulumi_gcp/kms/key_ring_iam_binding.py
+++ b/sdk/python/pulumi_gcp/kms/key_ring_iam_binding.py
@@ -45,7 +45,6 @@ class KeyRingIAMBinding(pulumi.CustomResource):
                `{project_id}/{location_name}/{key_ring_name}` or
                `{location_name}/{key_ring_name}`. In the second form, the provider's
                project setting will be used as a fallback.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] role: The role that should be applied. Only one
                `google_kms_key_ring_iam_binding` can be used per role. Note that custom roles must be of the format
                `[projects|organizations]/{parent-name}/roles/{role-name}`.

--- a/sdk/python/pulumi_gcp/kms/key_ring_iam_member.py
+++ b/sdk/python/pulumi_gcp/kms/key_ring_iam_member.py
@@ -45,7 +45,6 @@ class KeyRingIAMMember(pulumi.CustomResource):
                `{project_id}/{location_name}/{key_ring_name}` or
                `{location_name}/{key_ring_name}`. In the second form, the provider's
                project setting will be used as a fallback.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] role: The role that should be applied. Only one
                `google_kms_key_ring_iam_binding` can be used per role. Note that custom roles must be of the format
                `[projects|organizations]/{parent-name}/roles/{role-name}`.

--- a/sdk/python/pulumi_gcp/monitoring/alert_policy.py
+++ b/sdk/python/pulumi_gcp/monitoring/alert_policy.py
@@ -33,13 +33,6 @@ class AlertPolicy(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] combiner
-        :param pulumi.Input[list] conditions
-        :param pulumi.Input[str] display_name
-        :param pulumi.Input[bool] enabled
-        :param pulumi.Input[list] labels
-        :param pulumi.Input[list] notification_channels
-        :param pulumi.Input[str] project
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/monitoring/group.py
+++ b/sdk/python/pulumi_gcp/monitoring/group.py
@@ -41,10 +41,6 @@ class Group(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] display_name
-        :param pulumi.Input[str] filter
-        :param pulumi.Input[bool] is_cluster
-        :param pulumi.Input[str] parent_name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         """

--- a/sdk/python/pulumi_gcp/monitoring/notification_channel.py
+++ b/sdk/python/pulumi_gcp/monitoring/notification_channel.py
@@ -44,14 +44,8 @@ class NotificationChannel(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] description
-        :param pulumi.Input[str] display_name
-        :param pulumi.Input[bool] enabled
-        :param pulumi.Input[dict] labels
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[str] type
-        :param pulumi.Input[dict] user_labels
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
+++ b/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
@@ -45,19 +45,8 @@ class UptimeCheckConfig(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] content_matchers
-        :param pulumi.Input[str] display_name
-        :param pulumi.Input[dict] http_check
-        :param pulumi.Input[list] internal_checkers
-        :param pulumi.Input[bool] is_internal
-        :param pulumi.Input[dict] monitored_resource
-        :param pulumi.Input[str] period
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[dict] resource_group
-        :param pulumi.Input[list] selected_regions
-        :param pulumi.Input[dict] tcp_check
-        :param pulumi.Input[str] timeout
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/organizations/get_active_folder.py
+++ b/sdk/python/pulumi_gcp/organizations/get_active_folder.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetActiveFolderResult(object):
+class GetActiveFolderResult:
     """
     A collection of values returned by getActiveFolder.
     """
@@ -26,7 +26,7 @@ class GetActiveFolderResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_active_folder(display_name=None, parent=None):
+async def get_active_folder(display_name=None,parent=None,opts=None):
     """
     Get an active folder within GCP by `display_name` and `parent`.
     """
@@ -34,7 +34,7 @@ async def get_active_folder(display_name=None, parent=None):
 
     __args__['displayName'] = display_name
     __args__['parent'] = parent
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getActiveFolder:getActiveFolder', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getActiveFolder:getActiveFolder', __args__, opts=opts)
 
     return GetActiveFolderResult(
         name=__ret__.get('name'),

--- a/sdk/python/pulumi_gcp/organizations/get_billing_account.py
+++ b/sdk/python/pulumi_gcp/organizations/get_billing_account.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetBillingAccountResult(object):
+class GetBillingAccountResult:
     """
     A collection of values returned by getBillingAccount.
     """
@@ -38,7 +38,7 @@ class GetBillingAccountResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_billing_account(billing_account=None, display_name=None, open=None):
+async def get_billing_account(billing_account=None,display_name=None,open=None,opts=None):
     """
     Use this data source to get information about a Google Billing Account.
     """
@@ -47,7 +47,7 @@ async def get_billing_account(billing_account=None, display_name=None, open=None
     __args__['billingAccount'] = billing_account
     __args__['displayName'] = display_name
     __args__['open'] = open
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getBillingAccount:getBillingAccount', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getBillingAccount:getBillingAccount', __args__, opts=opts)
 
     return GetBillingAccountResult(
         display_name=__ret__.get('displayName'),

--- a/sdk/python/pulumi_gcp/organizations/get_client_config.py
+++ b/sdk/python/pulumi_gcp/organizations/get_client_config.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetClientConfigResult(object):
+class GetClientConfigResult:
     """
     A collection of values returned by getClientConfig.
     """
@@ -38,13 +38,13 @@ class GetClientConfigResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_client_config():
+async def get_client_config(opts=None):
     """
     Use this data source to access the configuration of the Google Cloud provider.
     """
     __args__ = dict()
 
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getClientConfig:getClientConfig', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getClientConfig:getClientConfig', __args__, opts=opts)
 
     return GetClientConfigResult(
         access_token=__ret__.get('accessToken'),

--- a/sdk/python/pulumi_gcp/organizations/get_folder.py
+++ b/sdk/python/pulumi_gcp/organizations/get_folder.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetFolderResult(object):
+class GetFolderResult:
     """
     A collection of values returned by getFolder.
     """
@@ -56,7 +56,7 @@ class GetFolderResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_folder(folder=None, lookup_organization=None):
+async def get_folder(folder=None,lookup_organization=None,opts=None):
     """
     Use this data source to get information about a Google Cloud Folder.
     """
@@ -64,7 +64,7 @@ async def get_folder(folder=None, lookup_organization=None):
 
     __args__['folder'] = folder
     __args__['lookupOrganization'] = lookup_organization
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getFolder:getFolder', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getFolder:getFolder', __args__, opts=opts)
 
     return GetFolderResult(
         create_time=__ret__.get('createTime'),

--- a/sdk/python/pulumi_gcp/organizations/get_iam_policy.py
+++ b/sdk/python/pulumi_gcp/organizations/get_iam_policy.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetIAMPolicyResult(object):
+class GetIAMPolicyResult:
     """
     A collection of values returned by getIAMPolicy.
     """
@@ -27,7 +27,7 @@ class GetIAMPolicyResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_iam_policy(bindings=None):
+async def get_iam_policy(bindings=None,opts=None):
     """
     Generates an IAM policy document that may be referenced by and applied to
     other Google Cloud Platform resources, such as the `google_project` resource.
@@ -44,7 +44,7 @@ async def get_iam_policy(bindings=None):
     __args__ = dict()
 
     __args__['bindings'] = bindings
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getIAMPolicy:getIAMPolicy', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getIAMPolicy:getIAMPolicy', __args__, opts=opts)
 
     return GetIAMPolicyResult(
         policy_data=__ret__.get('policyData'),

--- a/sdk/python/pulumi_gcp/organizations/get_organization.py
+++ b/sdk/python/pulumi_gcp/organizations/get_organization.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetOrganizationResult(object):
+class GetOrganizationResult:
     """
     A collection of values returned by getOrganization.
     """
@@ -47,7 +47,7 @@ class GetOrganizationResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_organization(domain=None, organization=None):
+async def get_organization(domain=None,organization=None,opts=None):
     """
     Use this data source to get information about a Google Cloud Organization.
     """
@@ -55,7 +55,7 @@ async def get_organization(domain=None, organization=None):
 
     __args__['domain'] = domain
     __args__['organization'] = organization
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getOrganization:getOrganization', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getOrganization:getOrganization', __args__, opts=opts)
 
     return GetOrganizationResult(
         create_time=__ret__.get('createTime'),

--- a/sdk/python/pulumi_gcp/organizations/get_project.py
+++ b/sdk/python/pulumi_gcp/organizations/get_project.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetProjectResult(object):
+class GetProjectResult:
     """
     A collection of values returned by getProject.
     """
@@ -53,7 +53,7 @@ class GetProjectResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_project(project_id=None):
+async def get_project(project_id=None,opts=None):
     """
     Use this data source to get project details.
     For more information see 
@@ -62,7 +62,7 @@ async def get_project(project_id=None):
     __args__ = dict()
 
     __args__['projectId'] = project_id
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getProject:getProject', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getProject:getProject', __args__, opts=opts)
 
     return GetProjectResult(
         app_engines=__ret__.get('appEngines'),

--- a/sdk/python/pulumi_gcp/organizations/get_project_services.py
+++ b/sdk/python/pulumi_gcp/organizations/get_project_services.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetProjectServicesResult(object):
+class GetProjectServicesResult:
     """
     A collection of values returned by getProjectServices.
     """
@@ -26,7 +26,7 @@ class GetProjectServicesResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_project_services(project=None):
+async def get_project_services(project=None,opts=None):
     """
     Use this data source to get details on the enabled project services.
     
@@ -36,7 +36,7 @@ async def get_project_services(project=None):
     __args__ = dict()
 
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getProjectServices:getProjectServices', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:organizations/getProjectServices:getProjectServices', __args__, opts=opts)
 
     return GetProjectServicesResult(
         disable_on_destroy=__ret__.get('disableOnDestroy'),

--- a/sdk/python/pulumi_gcp/projects/iam_binding.py
+++ b/sdk/python/pulumi_gcp/projects/iam_binding.py
@@ -39,7 +39,6 @@ class IAMBinding(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] project: The project ID. If not specified, uses the
                ID of the project configured with the provider.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/projects/iam_custom_role.py
+++ b/sdk/python/pulumi_gcp/projects/iam_custom_role.py
@@ -53,7 +53,6 @@ class IAMCustomRole(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[bool] deleted
         :param pulumi.Input[str] description: A human-readable description for the role.
         :param pulumi.Input[list] permissions: The names of the permissions this role grants when bound in an IAM policy. At least one permission must be specified.
         :param pulumi.Input[str] project: The project that the service account will be created in.

--- a/sdk/python/pulumi_gcp/projects/iam_member.py
+++ b/sdk/python/pulumi_gcp/projects/iam_member.py
@@ -39,7 +39,6 @@ class IAMMember(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] project: The project ID. If not specified, uses the
                ID of the project configured with the provider.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/projects/services.py
+++ b/sdk/python/pulumi_gcp/projects/services.py
@@ -37,7 +37,6 @@ class Services(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[bool] disable_on_destroy
         :param pulumi.Input[str] project: The project ID.
                Changing this forces Terraform to attempt to disable all previously managed
                API services in the previous project.

--- a/sdk/python/pulumi_gcp/projects/usage_export_bucket.py
+++ b/sdk/python/pulumi_gcp/projects/usage_export_bucket.py
@@ -44,9 +44,6 @@ class UsageExportBucket(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] bucket_name
-        :param pulumi.Input[str] prefix
-        :param pulumi.Input[str] project
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/provider.py
+++ b/sdk/python/pulumi_gcp/provider.py
@@ -18,10 +18,6 @@ class Provider(pulumi.ProviderResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] credentials
-        :param pulumi.Input[str] project
-        :param pulumi.Input[str] region
-        :param pulumi.Input[str] zone
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/pubsub/subscription_iam_binding.py
+++ b/sdk/python/pulumi_gcp/pubsub/subscription_iam_binding.py
@@ -43,7 +43,6 @@ class SubscriptionIAMBinding(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] project: The project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/pubsub/subscription_iam_member.py
+++ b/sdk/python/pulumi_gcp/pubsub/subscription_iam_member.py
@@ -43,7 +43,6 @@ class SubscriptionIAMMember(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] project: The project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/pubsub/topic_iam_binding.py
+++ b/sdk/python/pulumi_gcp/pubsub/topic_iam_binding.py
@@ -43,7 +43,6 @@ class TopicIAMBinding(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] project: The project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/pubsub/topic_iam_member.py
+++ b/sdk/python/pulumi_gcp/pubsub/topic_iam_member.py
@@ -43,7 +43,6 @@ class TopicIAMMember(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] project: The project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/redis/instance.py
+++ b/sdk/python/pulumi_gcp/redis/instance.py
@@ -49,20 +49,8 @@ class Instance(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] alternative_location_id
-        :param pulumi.Input[str] authorized_network
-        :param pulumi.Input[str] display_name
-        :param pulumi.Input[dict] labels
-        :param pulumi.Input[str] location_id
-        :param pulumi.Input[int] memory_size_gb
-        :param pulumi.Input[str] name
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
-        :param pulumi.Input[dict] redis_configs
-        :param pulumi.Input[str] redis_version
-        :param pulumi.Input[str] region
-        :param pulumi.Input[str] reserved_ip_range
-        :param pulumi.Input[str] tier
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/resourcemanager/lien.py
+++ b/sdk/python/pulumi_gcp/resourcemanager/lien.py
@@ -21,10 +21,6 @@ class Lien(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] origin
-        :param pulumi.Input[str] parent
-        :param pulumi.Input[str] reason
-        :param pulumi.Input[list] restrictions
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/runtimeconfig/variavble.py
+++ b/sdk/python/pulumi_gcp/runtimeconfig/variavble.py
@@ -47,8 +47,6 @@ class Variavble(pulumi.CustomResource):
                variable.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
-        :param pulumi.Input[str] text
-        :param pulumi.Input[str] value
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/service_account/get_account.py
+++ b/sdk/python/pulumi_gcp/service_account/get_account.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetAccountResult(object):
+class GetAccountResult:
     """
     A collection of values returned by getAccount.
     """
@@ -46,7 +46,7 @@ class GetAccountResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_account(account_id=None, project=None):
+async def get_account(account_id=None,project=None,opts=None):
     """
     Get the service account from a project. For more information see
     the official [API](https://cloud.google.com/compute/docs/access/service-accounts) documentation.
@@ -55,7 +55,7 @@ async def get_account(account_id=None, project=None):
 
     __args__['accountId'] = account_id
     __args__['project'] = project
-    __ret__ = await pulumi.runtime.invoke('gcp:serviceAccount/getAccount:getAccount', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:serviceAccount/getAccount:getAccount', __args__, opts=opts)
 
     return GetAccountResult(
         display_name=__ret__.get('displayName'),

--- a/sdk/python/pulumi_gcp/service_account/get_account_key.py
+++ b/sdk/python/pulumi_gcp/service_account/get_account_key.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetAccountKeyResult(object):
+class GetAccountKeyResult:
     """
     A collection of values returned by getAccountKey.
     """
@@ -32,7 +32,7 @@ class GetAccountKeyResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_account_key(name=None, project=None, public_key_type=None, service_account_id=None):
+async def get_account_key(name=None,project=None,public_key_type=None,service_account_id=None,opts=None):
     """
     Get service account public key. For more information, see [the official documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) and [API](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys/get).
     """
@@ -42,7 +42,7 @@ async def get_account_key(name=None, project=None, public_key_type=None, service
     __args__['project'] = project
     __args__['publicKeyType'] = public_key_type
     __args__['serviceAccountId'] = service_account_id
-    __ret__ = await pulumi.runtime.invoke('gcp:serviceAccount/getAccountKey:getAccountKey', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:serviceAccount/getAccountKey:getAccountKey', __args__, opts=opts)
 
     return GetAccountKeyResult(
         key_algorithm=__ret__.get('keyAlgorithm'),

--- a/sdk/python/pulumi_gcp/service_account/iam_binding.py
+++ b/sdk/python/pulumi_gcp/service_account/iam_binding.py
@@ -40,7 +40,6 @@ class IAMBinding(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] role: The role that should be applied. Only one
                `google_service_account_iam_binding` can be used per role. Note that custom roles must be of the format
                `[projects|organizations]/{parent-name}/roles/{role-name}`.

--- a/sdk/python/pulumi_gcp/service_account/iam_member.py
+++ b/sdk/python/pulumi_gcp/service_account/iam_member.py
@@ -40,7 +40,6 @@ class IAMMember(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] role: The role that should be applied. Only one
                `google_service_account_iam_binding` can be used per role. Note that custom roles must be of the format
                `[projects|organizations]/{parent-name}/roles/{role-name}`.

--- a/sdk/python/pulumi_gcp/spanner/database_iam_binding.py
+++ b/sdk/python/pulumi_gcp/spanner/database_iam_binding.py
@@ -52,7 +52,6 @@ class DatabaseIAMBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] database: The name of the Spanner database.
         :param pulumi.Input[str] instance: The name of the Spanner instance the database belongs to.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/spanner/database_iam_member.py
+++ b/sdk/python/pulumi_gcp/spanner/database_iam_member.py
@@ -52,7 +52,6 @@ class DatabaseIAMMember(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] database: The name of the Spanner database.
         :param pulumi.Input[str] instance: The name of the Spanner instance the database belongs to.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/spanner/instance_iam_binding.py
+++ b/sdk/python/pulumi_gcp/spanner/instance_iam_binding.py
@@ -47,7 +47,6 @@ class InstanceIAMBinding(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] instance: The name of the instance.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/spanner/instance_iam_member.py
+++ b/sdk/python/pulumi_gcp/spanner/instance_iam_member.py
@@ -47,7 +47,6 @@ class InstanceIAMMember(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] instance: The name of the instance.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs. If it
                is not provided, the provider project is used.
         :param pulumi.Input[str] role: The role that should be applied. Only one

--- a/sdk/python/pulumi_gcp/storage/bucket_iam_binding.py
+++ b/sdk/python/pulumi_gcp/storage/bucket_iam_binding.py
@@ -37,7 +37,6 @@ class BucketIAMBinding(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] bucket: The name of the bucket it applies to.
-        :param pulumi.Input[list] members
         :param pulumi.Input[str] role: The role that should be applied. Note that custom roles must be of the format
                `[projects|organizations]/{parent-name}/roles/{role-name}`.
         """

--- a/sdk/python/pulumi_gcp/storage/bucket_iam_member.py
+++ b/sdk/python/pulumi_gcp/storage/bucket_iam_member.py
@@ -37,7 +37,6 @@ class BucketIAMMember(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] bucket: The name of the bucket it applies to.
-        :param pulumi.Input[str] member
         :param pulumi.Input[str] role: The role that should be applied. Note that custom roles must be of the format
                `[projects|organizations]/{parent-name}/roles/{role-name}`.
         """

--- a/sdk/python/pulumi_gcp/storage/bucket_iam_policy.py
+++ b/sdk/python/pulumi_gcp/storage/bucket_iam_policy.py
@@ -32,7 +32,6 @@ class BucketIAMPolicy(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] bucket: The name of the bucket it applies to.
-        :param pulumi.Input[str] policy_data
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/storage/bucket_object.py
+++ b/sdk/python/pulumi_gcp/storage/bucket_object.py
@@ -83,7 +83,6 @@ class BucketObject(pulumi.CustomResource):
         :param pulumi.Input[str] content_encoding: [Content-Encoding](https://tools.ietf.org/html/rfc7231#section-3.1.2.2) of the object data.
         :param pulumi.Input[str] content_language: [Content-Language](https://tools.ietf.org/html/rfc7231#section-3.1.3.2) of the object data.
         :param pulumi.Input[str] content_type: [Content-Type](https://tools.ietf.org/html/rfc7231#section-3.1.1.5) of the object data. Defaults to "application/octet-stream" or "text/plain; charset=utf-8".
-        :param pulumi.Input[str] detect_md5hash
         :param pulumi.Input[str] name: The name of the object.
         :param pulumi.Input[pulumi.Archive] source: A path to the data you want to upload. Must be defined
                if `content` is not.

--- a/sdk/python/pulumi_gcp/storage/default_object_access_control.py
+++ b/sdk/python/pulumi_gcp/storage/default_object_access_control.py
@@ -49,10 +49,6 @@ class DefaultObjectAccessControl(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] bucket
-        :param pulumi.Input[str] entity
-        :param pulumi.Input[str] object
-        :param pulumi.Input[str] role
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)

--- a/sdk/python/pulumi_gcp/storage/get_object_signed_url.py
+++ b/sdk/python/pulumi_gcp/storage/get_object_signed_url.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetObjectSignedUrlResult(object):
+class GetObjectSignedUrlResult:
     """
     A collection of values returned by getObjectSignedUrl.
     """
@@ -26,7 +26,7 @@ class GetObjectSignedUrlResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_object_signed_url(bucket=None, content_md5=None, content_type=None, credentials=None, duration=None, extension_headers=None, http_method=None, path=None):
+async def get_object_signed_url(bucket=None,content_md5=None,content_type=None,credentials=None,duration=None,extension_headers=None,http_method=None,path=None,opts=None):
     """
     The Google Cloud storage signed URL data source generates a signed URL for a given storage object. Signed URLs provide a way to give time-limited read or write access to anyone in possession of the URL, regardless of whether they have a Google account.
     
@@ -42,7 +42,7 @@ async def get_object_signed_url(bucket=None, content_md5=None, content_type=None
     __args__['extensionHeaders'] = extension_headers
     __args__['httpMethod'] = http_method
     __args__['path'] = path
-    __ret__ = await pulumi.runtime.invoke('gcp:storage/getObjectSignedUrl:getObjectSignedUrl', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:storage/getObjectSignedUrl:getObjectSignedUrl', __args__, opts=opts)
 
     return GetObjectSignedUrlResult(
         signed_url=__ret__.get('signedUrl'),

--- a/sdk/python/pulumi_gcp/storage/get_project_service_account.py
+++ b/sdk/python/pulumi_gcp/storage/get_project_service_account.py
@@ -8,7 +8,7 @@ import pulumi
 import pulumi.runtime
 from .. import utilities, tables
 
-class GetProjectServiceAccountResult(object):
+class GetProjectServiceAccountResult:
     """
     A collection of values returned by getProjectServiceAccount.
     """
@@ -30,7 +30,7 @@ class GetProjectServiceAccountResult(object):
         id is the provider-assigned unique ID for this managed resource.
         """
 
-async def get_project_service_account(project=None, user_project=None):
+async def get_project_service_account(project=None,user_project=None,opts=None):
     """
     Get the email address of a project's unique Google Cloud Storage service account.
     
@@ -44,7 +44,7 @@ async def get_project_service_account(project=None, user_project=None):
 
     __args__['project'] = project
     __args__['userProject'] = user_project
-    __ret__ = await pulumi.runtime.invoke('gcp:storage/getProjectServiceAccount:getProjectServiceAccount', __args__)
+    __ret__ = await pulumi.runtime.invoke('gcp:storage/getProjectServiceAccount:getProjectServiceAccount', __args__, opts=opts)
 
     return GetProjectServiceAccountResult(
         email_address=__ret__.get('emailAddress'),

--- a/sdk/python/pulumi_gcp/storage/object_access_control.py
+++ b/sdk/python/pulumi_gcp/storage/object_access_control.py
@@ -48,10 +48,6 @@ class ObjectAccessControl(pulumi.CustomResource):
         
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[str] bucket
-        :param pulumi.Input[str] entity
-        :param pulumi.Input[str] object
-        :param pulumi.Input[str] role
         """
         if __name__ is not None:
             warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)


### PR DESCRIPTION
This pulls in a variety of bug fixes for Python generation from pulumi-terraform. We remain pinned to 1.20.0 of the actual upstream provider, however, until the versioning work to allow us to upgrade to 2.0.0 is in place.