### PR TITLE
Add ability to override a managed by description

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -81,6 +81,9 @@ func gcpResource(mod string, res string) tokens.Type {
 	return gcpType(mod+"/"+fn, res)
 }
 
+// managedByPulumi is a default used for some managed resources, in the absence of something more meaningful.
+var managedByPulumi = &tfbridge.DefaultInfo{Value: "Managed by Pulumi"}
+
 // Provider returns additional overlaid schema and metadata associated with the gcp package.
 func Provider() tfbridge.ProviderInfo {
 	p := google.Provider().(*schema.Provider)
@@ -480,7 +483,14 @@ func Provider() tfbridge.ProviderInfo {
 			"google_dataproc_job":     {Tok: gcpResource(gcpDataProc, "Job")},
 
 			// DNS resources
-			"google_dns_managed_zone": {Tok: gcpResource(gcpDNS, "ManagedZone")},
+			"google_dns_managed_zone": {
+				Tok: gcpResource(gcpDNS, "ManagedZone"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"description": {
+						Default: managedByPulumi,
+					},
+				},
+			},
 			"google_dns_policy":       {Tok: gcpResource(gcpDNS, "Policy")},
 			"google_dns_record_set":   {Tok: gcpResource(gcpDNS, "RecordSet")},
 

--- a/sdk/go/gcp/dns/managedZone.go
+++ b/sdk/go/gcp/dns/managedZone.go
@@ -35,8 +35,8 @@ func NewManagedZone(ctx *pulumi.Context,
 		return nil, errors.New("missing required argument 'DnsName'")
 	}
 	inputs := make(map[string]interface{})
+	inputs["description"] = "Managed by Pulumi"
 	if args == nil {
-		inputs["description"] = nil
 		inputs["dnsName"] = nil
 		inputs["forwardingConfig"] = nil
 		inputs["labels"] = nil

--- a/sdk/nodejs/dns/managedZone.ts
+++ b/sdk/nodejs/dns/managedZone.ts
@@ -96,7 +96,7 @@ export class ManagedZone extends pulumi.CustomResource {
         return new ManagedZone(name, <any>state, { ...opts, id: id });
     }
 
-    public readonly description: pulumi.Output<string | undefined>;
+    public readonly description: pulumi.Output<string>;
     public readonly dnsName: pulumi.Output<string>;
     public readonly forwardingConfig: pulumi.Output<{ targetNameServers?: { ipv4Address?: string }[] } | undefined>;
     public readonly labels: pulumi.Output<{[key: string]: string} | undefined>;
@@ -136,7 +136,7 @@ export class ManagedZone extends pulumi.CustomResource {
             if (!args || args.dnsName === undefined) {
                 throw new Error("Missing required property 'dnsName'");
             }
-            inputs["description"] = args ? args.description : undefined;
+            inputs["description"] = (args ? args.description : undefined) || "Managed by Pulumi";
             inputs["dnsName"] = args ? args.dnsName : undefined;
             inputs["forwardingConfig"] = args ? args.forwardingConfig : undefined;
             inputs["labels"] = args ? args.labels : undefined;

--- a/sdk/python/pulumi_gcp/dns/managed_zone.py
+++ b/sdk/python/pulumi_gcp/dns/managed_zone.py
@@ -61,6 +61,8 @@ class ManagedZone(pulumi.CustomResource):
 
         __props__ = dict()
 
+        if description is None:
+            description = 'Managed by Pulumi'
         __props__['description'] = description
 
         if dns_name is None:


### PR DESCRIPTION
Fixes: #93

This introduces the work to allow a resource to override a "Managed
by Terraform" description