### PR TITLE
Strip "Open in Cloud Shell" buttons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform v0.12.0-alpha4.0.20190401213546-16778fea9219
 	github.com/pkg/errors v0.8.0
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190410175858-788550dffb09
+	github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190423021607-1090d14a55ea
 	github.com/stretchr/testify v1.3.0
 	github.com/terraform-providers/terraform-provider-google-beta v0.0.0-20190326192708-8ee58e6dda3c
 )

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,8 @@ github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0 h1:NqGT9rxjyADqq2
 github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0/go.mod h1:RIy1gmz8Vyy7H5w2ffHJ23aZHCOggF2zk2c+KD1GMtY=
 github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190410175858-788550dffb09 h1:IK1V6YgNWMh4yMMJYCDyouLoNHWYJmuIjmz5aXpQl5s=
 github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190410175858-788550dffb09/go.mod h1:bJ2tsYQlSMzMCEDb2kP1rDHaadG3O7JUnBUYH/yx2Io=
+github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190423021607-1090d14a55ea h1:xdHI09APNIRyWkx7O18UysbqILI6sDWdhKYCV81rjFY=
+github.com/pulumi/pulumi-terraform v0.14.1-dev.0.20190423021607-1090d14a55ea/go.mod h1:bJ2tsYQlSMzMCEDb2kP1rDHaadG3O7JUnBUYH/yx2Io=
 github.com/pulumi/pulumi-terraform v0.15.1 h1:y+Xh+lhj+fiPnHzfJb7ajkUuRH+vvwCy7bi304AAJig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 h1:J2RvHxEMIzMV6XbaZIj9s5G4lG3hhqWxS7Cl1Jii44c=

--- a/sdk/go/gcp/appengine/firewallRule.go
+++ b/sdk/go/gcp/appengine/firewallRule.go
@@ -17,12 +17,6 @@ import (
 // * [API documentation](https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.firewall.ingressRules)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/appengine/docs/standard/python/creating-firewalls#creating_firewall_rules)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=app_engine_firewall_rule_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type FirewallRule struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/cloudbuild/trigger.go
+++ b/sdk/go/gcp/cloudbuild/trigger.go
@@ -15,12 +15,6 @@ import (
 // * [API documentation](https://cloud.google.com/cloud-build/docs/api/reference/rest/)
 // * How-to Guides
 //     * [Automating builds using build triggers](https://cloud.google.com/cloud-build/docs/running-builds/automate-builds)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=cloudbuild_trigger_filename&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Trigger struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/cloudscheduler/job.go
+++ b/sdk/go/gcp/cloudscheduler/job.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/scheduler/docs/reference/rest/)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/scheduler/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=scheduler_job_pubsub&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Job struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/address.go
+++ b/sdk/go/gcp/compute/address.go
@@ -28,12 +28,6 @@ import (
 // * How-to Guides
 //     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/instances-and-network)
 //     * [Reserving a Static Internal IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=address_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Address struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/autoscalar.go
+++ b/sdk/go/gcp/compute/autoscalar.go
@@ -20,12 +20,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers)
 // * How-to Guides
 //     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=autoscaler_beta&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Autoscalar struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/backendBucket.go
+++ b/sdk/go/gcp/compute/backendBucket.go
@@ -22,12 +22,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/backendBuckets)
 // * How-to Guides
 //     * [Using a Cloud Storage bucket as a load balancer backend](https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=backend_bucket_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type BackendBucket struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/disk.go
+++ b/sdk/go/gcp/compute/disk.go
@@ -33,12 +33,6 @@ import (
 // > **Warning:** All arguments including the disk encryption key will be stored in the raw
 // state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Disk struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/firewall.go
+++ b/sdk/go/gcp/compute/firewall.go
@@ -27,12 +27,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/firewalls)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/vpc/docs/firewalls)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=firewall_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Firewall struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/forwardingRule.go
+++ b/sdk/go/gcp/compute/forwardingRule.go
@@ -17,12 +17,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/forwardingRule)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=forwarding_rule_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type ForwardingRule struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/globalAddress.go
+++ b/sdk/go/gcp/compute/globalAddress.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/globalAddresses)
 // * How-to Guides
 //     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=global_address_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type GlobalAddress struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/healthCheck.go
+++ b/sdk/go/gcp/compute/healthCheck.go
@@ -25,12 +25,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/load-balancing/docs/health-checks)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type HealthCheck struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/httpHealthCheck.go
+++ b/sdk/go/gcp/compute/httpHealthCheck.go
@@ -23,12 +23,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/httpHealthChecks)
 // * How-to Guides
 //     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=http_health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type HttpHealthCheck struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/httpsHealthCheck.go
+++ b/sdk/go/gcp/compute/httpsHealthCheck.go
@@ -23,12 +23,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/httpsHealthChecks)
 // * How-to Guides
 //     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=https_health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type HttpsHealthCheck struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/image.go
+++ b/sdk/go/gcp/compute/image.go
@@ -30,12 +30,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/images)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/compute/docs/images)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=image_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Image struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/mangedSslCertificate.go
+++ b/sdk/go/gcp/compute/mangedSslCertificate.go
@@ -35,12 +35,6 @@ import (
 // certificates may entail some downtime while the certificate provisions.
 // 
 // In conclusion: Be extremely cautious.
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=managed_ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type MangedSslCertificate struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/network.go
+++ b/sdk/go/gcp/compute/network.go
@@ -15,12 +15,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/networks)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/vpc/docs/vpc)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=network_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Network struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/regionAutoscaler.go
+++ b/sdk/go/gcp/compute/regionAutoscaler.go
@@ -20,12 +20,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionAutoscalers)
 // * How-to Guides
 //     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_autoscaler_beta&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type RegionAutoscaler struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/regionDisk.go
+++ b/sdk/go/gcp/compute/regionDisk.go
@@ -34,12 +34,6 @@ import (
 // > **Warning:** All arguments including the disk encryption key will be stored in the raw
 // state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type RegionDisk struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/route.go
+++ b/sdk/go/gcp/compute/route.go
@@ -36,12 +36,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routes)
 // * How-to Guides
 //     * [Using Routes](https://cloud.google.com/vpc/docs/using-routes)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=route_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Route struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/router.go
+++ b/sdk/go/gcp/compute/router.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/routers)
 // * How-to Guides
 //     * [Google Cloud Router](https://cloud.google.com/router/docs/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=router_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Router struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/sSLCertificate.go
+++ b/sdk/go/gcp/compute/sSLCertificate.go
@@ -18,12 +18,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type SSLCertificate struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/sSLPolicy.go
+++ b/sdk/go/gcp/compute/sSLPolicy.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies)
 // * How-to Guides
 //     * [Using SSL Policies](https://cloud.google.com/compute/docs/load-balancing/ssl-policies)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type SSLPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/snapshot.go
+++ b/sdk/go/gcp/compute/snapshot.go
@@ -27,12 +27,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/snapshots)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=snapshot_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Snapshot struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/subnetwork.go
+++ b/sdk/go/gcp/compute/subnetwork.go
@@ -38,12 +38,6 @@ import (
 // * How-to Guides
 //     * [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
 //     * [Cloud Networking](https://cloud.google.com/vpc/docs/using-vpc)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=subnetwork_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Subnetwork struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetHttpProxy.go
+++ b/sdk/go/gcp/compute/targetHttpProxy.go
@@ -17,12 +17,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/targetHttpProxies)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_http_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type TargetHttpProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetHttpsProxy.go
+++ b/sdk/go/gcp/compute/targetHttpsProxy.go
@@ -17,12 +17,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/targetHttpsProxies)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_https_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type TargetHttpsProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetSSLProxy.go
+++ b/sdk/go/gcp/compute/targetSSLProxy.go
@@ -18,12 +18,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/targetSslProxies)
 // * How-to Guides
 //     * [Setting Up SSL proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_ssl_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type TargetSSLProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/targetTCPProxy.go
+++ b/sdk/go/gcp/compute/targetTCPProxy.go
@@ -18,12 +18,6 @@ import (
 // * [API documentation](https://cloud.google.com/compute/docs/reference/v1/targetTcpProxies)
 // * How-to Guides
 //     * [Setting Up TCP proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_tcp_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type TargetTCPProxy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/uRLMap.go
+++ b/sdk/go/gcp/compute/uRLMap.go
@@ -10,14 +10,6 @@ import (
 
 // UrlMaps are used to route requests to a backend service based on rules
 // that you define for the host and path of an incoming URL.
-// 
-// 
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=url_map_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type URLMap struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/vPNGateway.go
+++ b/sdk/go/gcp/compute/vPNGateway.go
@@ -15,12 +15,6 @@ import (
 // To get more information about VpnGateway, see:
 // 
 // * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_vpn_gateway_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type VPNGateway struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/compute/vPNTunnel.go
+++ b/sdk/go/gcp/compute/vPNTunnel.go
@@ -21,12 +21,6 @@ import (
 // > **Warning:** All arguments including the shared secret will be stored in the raw
 // state as plain-text.
 // [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=vpn_tunnel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type VPNTunnel struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/containeranalysis/note.go
+++ b/sdk/go/gcp/containeranalysis/note.go
@@ -18,12 +18,6 @@ import (
 // * [API documentation](https://cloud.google.com/container-analysis/api/reference/rest/)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/container-analysis/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=container_analysis_note_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Note struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/dns/managedZone.go
+++ b/sdk/go/gcp/dns/managedZone.go
@@ -18,12 +18,6 @@ import (
 // * [API documentation](https://cloud.google.com/dns/api/v1/managedZones)
 // * How-to Guides
 //     * [Managing Zones](https://cloud.google.com/dns/zones/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dns_managed_zone_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type ManagedZone struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/dns/policy.go
+++ b/sdk/go/gcp/dns/policy.go
@@ -18,12 +18,6 @@ import (
 // * [API documentation](https://cloud.google.com/dns/docs/reference/v1beta2/policies)
 // * How-to Guides
 //     * [Using DNS server policies](https://cloud.google.com/dns/zones/#using-dns-server-policies)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dns_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Policy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/filestore/instance.go
+++ b/sdk/go/gcp/filestore/instance.go
@@ -20,12 +20,6 @@ import (
 //     * [Official Documentation](https://cloud.google.com/filestore/docs/creating-instances)
 //     * [Use with Kubernetes](https://cloud.google.com/filestore/docs/accessing-fileshares)
 //     * [Copying Data In/Out](https://cloud.google.com/filestore/docs/copying-data)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=filestore_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Instance struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/monitoring/alertPolicy.go
+++ b/sdk/go/gcp/monitoring/alertPolicy.go
@@ -18,12 +18,6 @@ import (
 // * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/monitoring/alerts/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=monitoring_alert_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type AlertPolicy struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/monitoring/group.go
+++ b/sdk/go/gcp/monitoring/group.go
@@ -19,12 +19,6 @@ import (
 // * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.groups)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/monitoring/groups/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=monitoring_group_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Group struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/monitoring/notificationChannel.go
+++ b/sdk/go/gcp/monitoring/notificationChannel.go
@@ -19,12 +19,6 @@ import (
 // * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.notificationChannels)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/monitoring/api/v3/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=notification_channel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type NotificationChannel struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/monitoring/uptimeCheckConfig.go
+++ b/sdk/go/gcp/monitoring/uptimeCheckConfig.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.uptimeCheckConfigs)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=uptime_check_config_http&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type UptimeCheckConfig struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/pubsub/topic.go
+++ b/sdk/go/gcp/pubsub/topic.go
@@ -15,12 +15,6 @@ import (
 // * [API documentation](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics)
 // * How-to Guides
 //     * [Managing Topics](https://cloud.google.com/pubsub/docs/admin#managing_topics)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=pubsub_topic_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Topic struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/redis/instance.go
+++ b/sdk/go/gcp/redis/instance.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/memorystore/docs/redis/reference/rest/)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/memorystore/docs/redis/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=redis_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Instance struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/sourcerepo/repository.go
+++ b/sdk/go/gcp/sourcerepo/repository.go
@@ -15,12 +15,6 @@ import (
 // * [API documentation](https://cloud.google.com/source-repositories/docs/reference/rest/v1/projects.repos)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/source-repositories/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=sourcerepo_repository_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Repository struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/database.go
+++ b/sdk/go/gcp/spanner/database.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/spanner/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=spanner_database_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Database struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/spanner/instance.go
+++ b/sdk/go/gcp/spanner/instance.go
@@ -17,12 +17,6 @@ import (
 // * [API documentation](https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/spanner/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=spanner_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Instance struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/storage/defaultObjectAccessControl.go
+++ b/sdk/go/gcp/storage/defaultObjectAccessControl.go
@@ -28,12 +28,6 @@ import (
 // * [API documentation](https://cloud.google.com/storage/docs/json_api/v1/defaultObjectAccessControls)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/storage/docs/access-control/create-manage-lists)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_default_object_access_control_public&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type DefaultObjectAccessControl struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/storage/objectAccessControl.go
+++ b/sdk/go/gcp/storage/objectAccessControl.go
@@ -27,12 +27,6 @@ import (
 // * [API documentation](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/storage/docs/access-control/create-manage-lists)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_object_access_control_public_object&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type ObjectAccessControl struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/go/gcp/tpu/node.go
+++ b/sdk/go/gcp/tpu/node.go
@@ -16,12 +16,6 @@ import (
 // * [API documentation](https://cloud.google.com/tpu/docs/reference/rest/)
 // * How-to Guides
 //     * [Official Documentation](https://cloud.google.com/tpu/docs/)
-// 
-// <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-//   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=tpu_node_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-//     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-//   </a>
-// </div>
 type Node struct {
 	s *pulumi.ResourceState
 }

--- a/sdk/nodejs/appengine/firewallRule.ts
+++ b/sdk/nodejs/appengine/firewallRule.ts
@@ -15,11 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/appengine/docs/standard/python/creating-firewalls#creating_firewall_rules)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=app_engine_firewall_rule_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - App Engine Firewall Rule Basic
  * 
  * 

--- a/sdk/nodejs/cloudbuild/trigger.ts
+++ b/sdk/nodejs/cloudbuild/trigger.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Automating builds using build triggers](https://cloud.google.com/cloud-build/docs/running-builds/automate-builds)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=cloudbuild_trigger_filename&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Cloudbuild Trigger Filename
  * 
  * 

--- a/sdk/nodejs/cloudscheduler/job.ts
+++ b/sdk/nodejs/cloudscheduler/job.ts
@@ -15,11 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/scheduler/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=scheduler_job_pubsub&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Scheduler Job Pubsub
  * 
  * 
@@ -37,11 +32,6 @@ import * as utilities from "../utilities";
  *     schedule: "*&#47;2 * * * *",
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=scheduler_job_http&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Scheduler Job Http
  * 
  * 
@@ -59,11 +49,6 @@ import * as utilities from "../utilities";
  *     timeZone: "America/New_York",
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=scheduler_job_app_engine&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Scheduler Job App Engine
  * 
  * 

--- a/sdk/nodejs/compute/address.ts
+++ b/sdk/nodejs/compute/address.ts
@@ -27,11 +27,6 @@ import * as utilities from "../utilities";
  *     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/instances-and-network)
  *     * [Reserving a Static Internal IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=address_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Address Basic
  * 
  * 
@@ -41,11 +36,6 @@ import * as utilities from "../utilities";
  * 
  * const ipAddress = new gcp.compute.Address("ip_address", {});
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=address_with_subnetwork&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Address With Subnetwork
  * 
  * 
@@ -66,11 +56,6 @@ import * as utilities from "../utilities";
  *     subnetwork: defaultSubnetwork.selfLink,
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=instance_with_ip&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Instance With Ip
  * 
  * 

--- a/sdk/nodejs/compute/autoscalar.ts
+++ b/sdk/nodejs/compute/autoscalar.ts
@@ -18,11 +18,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=autoscaler_beta&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Autoscaler Basic
  * 
  * 

--- a/sdk/nodejs/compute/backendBucket.ts
+++ b/sdk/nodejs/compute/backendBucket.ts
@@ -20,11 +20,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using a Cloud Storage bucket as a load balancer backend](https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=backend_bucket_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Backend Bucket Basic
  * 
  * 

--- a/sdk/nodejs/compute/disk.ts
+++ b/sdk/nodejs/compute/disk.ts
@@ -32,11 +32,6 @@ import * as utilities from "../utilities";
  * state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Disk Basic
  * 
  * 

--- a/sdk/nodejs/compute/firewall.ts
+++ b/sdk/nodejs/compute/firewall.ts
@@ -25,11 +25,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/vpc/docs/firewalls)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=firewall_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Firewall Basic
  * 
  * 

--- a/sdk/nodejs/compute/forwardingRule.ts
+++ b/sdk/nodejs/compute/forwardingRule.ts
@@ -16,11 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=forwarding_rule_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Forwarding Rule Basic
  * 
  * 

--- a/sdk/nodejs/compute/globalAddress.ts
+++ b/sdk/nodejs/compute/globalAddress.ts
@@ -15,11 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=global_address_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Global Address Basic
  * 
  * 

--- a/sdk/nodejs/compute/healthCheck.ts
+++ b/sdk/nodejs/compute/healthCheck.ts
@@ -24,11 +24,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/health-checks)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Health Check Basic
  * 
  * 

--- a/sdk/nodejs/compute/httpHealthCheck.ts
+++ b/sdk/nodejs/compute/httpHealthCheck.ts
@@ -22,11 +22,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=http_health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Http Health Check Basic
  * 
  * 

--- a/sdk/nodejs/compute/httpsHealthCheck.ts
+++ b/sdk/nodejs/compute/httpsHealthCheck.ts
@@ -22,11 +22,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=https_health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Https Health Check Basic
  * 
  * 

--- a/sdk/nodejs/compute/image.ts
+++ b/sdk/nodejs/compute/image.ts
@@ -29,11 +29,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/images)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=image_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Image Basic
  * 
  * 

--- a/sdk/nodejs/compute/mangedSslCertificate.ts
+++ b/sdk/nodejs/compute/mangedSslCertificate.ts
@@ -33,12 +33,6 @@ import * as utilities from "../utilities";
  * certificates may entail some downtime while the certificate provisions.
  * 
  * In conclusion: Be extremely cautious.
- * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=managed_ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  */
 export class MangedSslCertificate extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/compute/network.ts
+++ b/sdk/nodejs/compute/network.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/vpc/docs/vpc)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=network_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Network Basic
  * 
  * 

--- a/sdk/nodejs/compute/regionAutoscaler.ts
+++ b/sdk/nodejs/compute/regionAutoscaler.ts
@@ -18,11 +18,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_autoscaler_beta&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Region Autoscaler Basic
  * 
  * 

--- a/sdk/nodejs/compute/regionDisk.ts
+++ b/sdk/nodejs/compute/regionDisk.ts
@@ -32,11 +32,6 @@ import * as utilities from "../utilities";
  * state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Region Disk Basic
  * 
  * 

--- a/sdk/nodejs/compute/route.ts
+++ b/sdk/nodejs/compute/route.ts
@@ -34,11 +34,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using Routes](https://cloud.google.com/vpc/docs/using-routes)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=route_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Route Basic
  * 
  * 

--- a/sdk/nodejs/compute/router.ts
+++ b/sdk/nodejs/compute/router.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Google Cloud Router](https://cloud.google.com/router/docs/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=router_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Router Basic
  * 
  * 

--- a/sdk/nodejs/compute/sSLCertificate.ts
+++ b/sdk/nodejs/compute/sSLCertificate.ts
@@ -16,11 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Ssl Certificate Basic
  * 
  * 
@@ -36,11 +31,6 @@ import * as utilities from "../utilities";
  *     privateKey: fs.readFileSync("path/to/private.key", "utf-8"),
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_certificate_random_provider&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Ssl Certificate Random Provider
  * 
  * 
@@ -71,11 +61,6 @@ import * as utilities from "../utilities";
  *     privateKey: fs.readFileSync("path/to/private.key", "utf-8"),
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_certificate_target_https_proxies&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Ssl Certificate Target Https Proxies
  * 
  * 

--- a/sdk/nodejs/compute/sSLPolicy.ts
+++ b/sdk/nodejs/compute/sSLPolicy.ts
@@ -15,11 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using SSL Policies](https://cloud.google.com/compute/docs/load-balancing/ssl-policies)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Ssl Policy Basic
  * 
  * 

--- a/sdk/nodejs/compute/snapshot.ts
+++ b/sdk/nodejs/compute/snapshot.ts
@@ -25,11 +25,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=snapshot_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Snapshot Basic
  * 
  * 

--- a/sdk/nodejs/compute/subnetwork.ts
+++ b/sdk/nodejs/compute/subnetwork.ts
@@ -36,11 +36,6 @@ import * as utilities from "../utilities";
  *     * [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
  *     * [Cloud Networking](https://cloud.google.com/vpc/docs/using-vpc)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=subnetwork_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Subnetwork Basic
  * 
  * 

--- a/sdk/nodejs/compute/targetHttpProxy.ts
+++ b/sdk/nodejs/compute/targetHttpProxy.ts
@@ -15,11 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_http_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Target Http Proxy Basic
  * 
  * 

--- a/sdk/nodejs/compute/targetHttpsProxy.ts
+++ b/sdk/nodejs/compute/targetHttpsProxy.ts
@@ -15,11 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_https_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Target Https Proxy Basic
  * 
  * 

--- a/sdk/nodejs/compute/targetSSLProxy.ts
+++ b/sdk/nodejs/compute/targetSSLProxy.ts
@@ -16,11 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Setting Up SSL proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_ssl_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Target Ssl Proxy Basic
  * 
  * 

--- a/sdk/nodejs/compute/targetTCPProxy.ts
+++ b/sdk/nodejs/compute/targetTCPProxy.ts
@@ -16,11 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Setting Up TCP proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_tcp_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Target Tcp Proxy Basic
  * 
  * 

--- a/sdk/nodejs/compute/uRLMap.ts
+++ b/sdk/nodejs/compute/uRLMap.ts
@@ -10,11 +10,6 @@ import * as utilities from "../utilities";
  * 
  * 
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=url_map_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Url Map Basic
  * 
  * 

--- a/sdk/nodejs/compute/vPNGateway.ts
+++ b/sdk/nodejs/compute/vPNGateway.ts
@@ -13,11 +13,6 @@ import * as utilities from "../utilities";
  * 
  * * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_vpn_gateway_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Target Vpn Gateway Basic
  * 
  * 

--- a/sdk/nodejs/compute/vPNTunnel.ts
+++ b/sdk/nodejs/compute/vPNTunnel.ts
@@ -19,11 +19,6 @@ import * as utilities from "../utilities";
  * state as plain-text.
  * [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=vpn_tunnel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Vpn Tunnel Basic
  * 
  * 
@@ -65,11 +60,6 @@ import * as utilities from "../utilities";
  *     priority: 1000,
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=vpn_tunnel_beta&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  */
 export class VPNTunnel extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/containeranalysis/note.ts
+++ b/sdk/nodejs/containeranalysis/note.ts
@@ -15,12 +15,6 @@ import * as utilities from "../utilities";
  * * [API documentation](https://cloud.google.com/container-analysis/api/reference/rest/)
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/container-analysis/)
- * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=container_analysis_note_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  */
 export class Note extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/dns/managedZone.ts
+++ b/sdk/nodejs/dns/managedZone.ts
@@ -16,11 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Managing Zones](https://cloud.google.com/dns/zones/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dns_managed_zone_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Dns Managed Zone Basic
  * 
  * 

--- a/sdk/nodejs/dns/policy.ts
+++ b/sdk/nodejs/dns/policy.ts
@@ -16,12 +16,6 @@ import * as utilities from "../utilities";
  * * [API documentation](https://cloud.google.com/dns/docs/reference/v1beta2/policies)
  * * How-to Guides
  *     * [Using DNS server policies](https://cloud.google.com/dns/zones/#using-dns-server-policies)
- * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dns_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  */
 export class Policy extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/filestore/instance.ts
+++ b/sdk/nodejs/filestore/instance.ts
@@ -17,12 +17,6 @@ import * as utilities from "../utilities";
  *     * [Official Documentation](https://cloud.google.com/filestore/docs/creating-instances)
  *     * [Use with Kubernetes](https://cloud.google.com/filestore/docs/accessing-fileshares)
  *     * [Copying Data In/Out](https://cloud.google.com/filestore/docs/copying-data)
- * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=filestore_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  */
 export class Instance extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/monitoring/alertPolicy.ts
+++ b/sdk/nodejs/monitoring/alertPolicy.ts
@@ -16,11 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/alerts/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=monitoring_alert_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Monitoring Alert Policy Basic
  * 
  * 

--- a/sdk/nodejs/monitoring/group.ts
+++ b/sdk/nodejs/monitoring/group.ts
@@ -17,11 +17,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/groups/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=monitoring_group_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Monitoring Group Basic
  * 
  * 
@@ -34,11 +29,6 @@ import * as utilities from "../utilities";
  *     filter: "resource.metadata.region=\"europe-west2\"",
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=monitoring_group_subgroup&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Monitoring Group Subgroup
  * 
  * 

--- a/sdk/nodejs/monitoring/notificationChannel.ts
+++ b/sdk/nodejs/monitoring/notificationChannel.ts
@@ -17,11 +17,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/api/v3/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=notification_channel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Notification Channel Basic
  * 
  * 

--- a/sdk/nodejs/monitoring/uptimeCheckConfig.ts
+++ b/sdk/nodejs/monitoring/uptimeCheckConfig.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=uptime_check_config_http&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Uptime Check Config Http
  * 
  * 
@@ -45,11 +40,6 @@ import * as utilities from "../utilities";
  *     timeout: "60s",
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=uptime_check_tcp&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Uptime Check Tcp
  * 
  * 

--- a/sdk/nodejs/pubsub/subscription.ts
+++ b/sdk/nodejs/pubsub/subscription.ts
@@ -37,11 +37,6 @@ import * as utilities from "../utilities";
  *     topic: exampleTopic.name,
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=pubsub_subscription_pull&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Pubsub Subscription Pull
  * 
  * 

--- a/sdk/nodejs/pubsub/topic.ts
+++ b/sdk/nodejs/pubsub/topic.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Managing Topics](https://cloud.google.com/pubsub/docs/admin#managing_topics)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=pubsub_topic_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Pubsub Topic Basic
  * 
  * 

--- a/sdk/nodejs/redis/instance.ts
+++ b/sdk/nodejs/redis/instance.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/memorystore/docs/redis/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=redis_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Redis Instance Basic
  * 
  * 
@@ -30,11 +25,6 @@ import * as utilities from "../utilities";
  *     memorySizeGb: 1,
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=redis_instance_full&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Redis Instance Full
  * 
  * 

--- a/sdk/nodejs/sourcerepo/repository.ts
+++ b/sdk/nodejs/sourcerepo/repository.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/source-repositories/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=sourcerepo_repository_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Sourcerepo Repository Basic
  * 
  * 

--- a/sdk/nodejs/spanner/database.ts
+++ b/sdk/nodejs/spanner/database.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/spanner/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=spanner_database_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Spanner Database Basic
  * 
  * 

--- a/sdk/nodejs/spanner/instance.ts
+++ b/sdk/nodejs/spanner/instance.ts
@@ -15,11 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/spanner/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=spanner_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Spanner Instance Basic
  * 
  * 

--- a/sdk/nodejs/storage/defaultObjectAccessControl.ts
+++ b/sdk/nodejs/storage/defaultObjectAccessControl.ts
@@ -26,11 +26,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/storage/docs/access-control/create-manage-lists)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_default_object_access_control_public&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Storage Default Object Access Control Public
  * 
  * 

--- a/sdk/nodejs/storage/objectAccessControl.ts
+++ b/sdk/nodejs/storage/objectAccessControl.ts
@@ -25,11 +25,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/storage/docs/access-control/create-manage-lists)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_object_access_control_public_object&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Storage Object Access Control Public Object
  * 
  * 

--- a/sdk/nodejs/tpu/node.ts
+++ b/sdk/nodejs/tpu/node.ts
@@ -14,11 +14,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/tpu/docs/)
  * 
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=tpu_node_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Tpu Node Basic
  * 
  * 
@@ -33,11 +28,6 @@ import * as utilities from "../utilities";
  *     zone: "us-central1-b",
  * });
  * ```
- * <div class = "oics-button" style="float: right; margin: 0 0 -15px">
- *   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=tpu_node_full&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
- *     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
- *   </a>
- * </div>
  * ## Example Usage - Tpu Node Full
  * 
  * 

--- a/sdk/python/pulumi_gcp/appengine/firewall_rule.py
+++ b/sdk/python/pulumi_gcp/appengine/firewall_rule.py
@@ -30,12 +30,6 @@ class FirewallRule(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/appengine/docs/standard/python/creating-firewalls#creating_firewall_rules)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=app_engine_firewall_rule_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/cloudbuild/trigger.py
+++ b/sdk/python/pulumi_gcp/cloudbuild/trigger.py
@@ -35,12 +35,6 @@ class Trigger(pulumi.CustomResource):
         * How-to Guides
             * [Automating builds using build triggers](https://cloud.google.com/cloud-build/docs/running-builds/automate-builds)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=cloudbuild_trigger_filename&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/cloudscheduler/job.py
+++ b/sdk/python/pulumi_gcp/cloudscheduler/job.py
@@ -35,12 +35,6 @@ class Job(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/scheduler/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=scheduler_job_pubsub&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/address.py
+++ b/sdk/python/pulumi_gcp/compute/address.py
@@ -56,12 +56,6 @@ class Address(pulumi.CustomResource):
             * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/instances-and-network)
             * [Reserving a Static Internal IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=address_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address: The IP of the created resource.

--- a/sdk/python/pulumi_gcp/compute/autoscalar.py
+++ b/sdk/python/pulumi_gcp/compute/autoscalar.py
@@ -35,12 +35,6 @@ class Autoscalar(pulumi.CustomResource):
         * How-to Guides
             * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=autoscaler_beta&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """

--- a/sdk/python/pulumi_gcp/compute/backend_bucket.py
+++ b/sdk/python/pulumi_gcp/compute/backend_bucket.py
@@ -40,12 +40,6 @@ class BackendBucket(pulumi.CustomResource):
         * How-to Guides
             * [Using a Cloud Storage bucket as a load balancer backend](https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=backend_bucket_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/disk.py
+++ b/sdk/python/pulumi_gcp/compute/disk.py
@@ -66,12 +66,6 @@ class Disk(pulumi.CustomResource):
         state as plain-text.
         [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/firewall.py
+++ b/sdk/python/pulumi_gcp/compute/firewall.py
@@ -56,12 +56,6 @@ class Firewall(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/vpc/docs/firewalls)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=firewall_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/forwarding_rule.py
+++ b/sdk/python/pulumi_gcp/compute/forwarding_rule.py
@@ -51,12 +51,6 @@ class ForwardingRule(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=forwarding_rule_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/global_address.py
+++ b/sdk/python/pulumi_gcp/compute/global_address.py
@@ -41,12 +41,6 @@ class GlobalAddress(pulumi.CustomResource):
         * How-to Guides
             * [Reserving a Static External IP Address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=global_address_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/health_check.py
+++ b/sdk/python/pulumi_gcp/compute/health_check.py
@@ -51,12 +51,6 @@ class HealthCheck(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/health-checks)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/http_health_check.py
+++ b/sdk/python/pulumi_gcp/compute/http_health_check.py
@@ -47,12 +47,6 @@ class HttpHealthCheck(pulumi.CustomResource):
         * How-to Guides
             * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=http_health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/https_health_check.py
+++ b/sdk/python/pulumi_gcp/compute/https_health_check.py
@@ -47,12 +47,6 @@ class HttpsHealthCheck(pulumi.CustomResource):
         * How-to Guides
             * [Adding Health Checks](https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=https_health_check_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/image.py
+++ b/sdk/python/pulumi_gcp/compute/image.py
@@ -55,12 +55,6 @@ class Image(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/images)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=image_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/manged_ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/manged_ssl_certificate.py
@@ -57,12 +57,6 @@ class MangedSslCertificate(pulumi.CustomResource):
         
         In conclusion: Be extremely cautious.
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=managed_ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/network.py
+++ b/sdk/python/pulumi_gcp/compute/network.py
@@ -35,12 +35,6 @@ class Network(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/vpc/docs/vpc)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=network_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/region_autoscaler.py
+++ b/sdk/python/pulumi_gcp/compute/region_autoscaler.py
@@ -35,12 +35,6 @@ class RegionAutoscaler(pulumi.CustomResource):
         * How-to Guides
             * [Autoscaling Groups of Instances](https://cloud.google.com/compute/docs/autoscaler/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_autoscaler_beta&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """

--- a/sdk/python/pulumi_gcp/compute/region_disk.py
+++ b/sdk/python/pulumi_gcp/compute/region_disk.py
@@ -64,12 +64,6 @@ class RegionDisk(pulumi.CustomResource):
         state as plain-text.
         [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/route.py
+++ b/sdk/python/pulumi_gcp/compute/route.py
@@ -67,12 +67,6 @@ class Route(pulumi.CustomResource):
         * How-to Guides
             * [Using Routes](https://cloud.google.com/vpc/docs/using-routes)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=route_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] next_hop_instance_zone: (Optional when `next_hop_instance` is

--- a/sdk/python/pulumi_gcp/compute/router.py
+++ b/sdk/python/pulumi_gcp/compute/router.py
@@ -35,12 +35,6 @@ class Router(pulumi.CustomResource):
         * How-to Guides
             * [Google Cloud Router](https://cloud.google.com/router/docs/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=router_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/snapshot.py
+++ b/sdk/python/pulumi_gcp/compute/snapshot.py
@@ -54,12 +54,6 @@ class Snapshot(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=snapshot_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_certificate.py
@@ -42,12 +42,6 @@ class SSLCertificate(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] name_prefix: Creates a unique name beginning with the

--- a/sdk/python/pulumi_gcp/compute/ssl_policy.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_policy.py
@@ -38,12 +38,6 @@ class SSLPolicy(pulumi.CustomResource):
         * How-to Guides
             * [Using SSL Policies](https://cloud.google.com/compute/docs/load-balancing/ssl-policies)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/subnetwork.py
+++ b/sdk/python/pulumi_gcp/compute/subnetwork.py
@@ -62,12 +62,6 @@ class Subnetwork(pulumi.CustomResource):
             * [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
             * [Cloud Networking](https://cloud.google.com/vpc/docs/using-vpc)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=subnetwork_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/target_http_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_http_proxy.py
@@ -35,12 +35,6 @@ class TargetHttpProxy(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_http_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/target_https_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_https_proxy.py
@@ -38,12 +38,6 @@ class TargetHttpsProxy(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_https_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/target_ssl_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_ssl_proxy.py
@@ -39,12 +39,6 @@ class TargetSSLProxy(pulumi.CustomResource):
         * How-to Guides
             * [Setting Up SSL proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_ssl_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/target_tcp_proxy.py
+++ b/sdk/python/pulumi_gcp/compute/target_tcp_proxy.py
@@ -37,12 +37,6 @@ class TargetTCPProxy(pulumi.CustomResource):
         * How-to Guides
             * [Setting Up TCP proxy for Google Cloud Load Balancing](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_tcp_proxy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/url_map.py
+++ b/sdk/python/pulumi_gcp/compute/url_map.py
@@ -32,14 +32,6 @@ class URLMap(pulumi.CustomResource):
         UrlMaps are used to route requests to a backend service based on rules
         that you define for the host and path of an incoming URL.
         
-        
-        
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=url_map_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/vpn_gateway.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_gateway.py
@@ -33,12 +33,6 @@ class VPNGateway(pulumi.CustomResource):
         
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=target_vpn_gateway_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
@@ -49,12 +49,6 @@ class VPNTunnel(pulumi.CustomResource):
         state as plain-text.
         [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=vpn_tunnel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/containeranalysis/note.py
+++ b/sdk/python/pulumi_gcp/containeranalysis/note.py
@@ -25,12 +25,6 @@ class Note(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/container-analysis/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=container_analysis_note_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """

--- a/sdk/python/pulumi_gcp/dns/managed_zone.py
+++ b/sdk/python/pulumi_gcp/dns/managed_zone.py
@@ -35,12 +35,6 @@ class ManagedZone(pulumi.CustomResource):
         * How-to Guides
             * [Managing Zones](https://cloud.google.com/dns/zones/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dns_managed_zone_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/dns/policy.py
+++ b/sdk/python/pulumi_gcp/dns/policy.py
@@ -33,12 +33,6 @@ class Policy(pulumi.CustomResource):
         * How-to Guides
             * [Using DNS server policies](https://cloud.google.com/dns/zones/#using-dns-server-policies)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dns_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/filestore/instance.py
+++ b/sdk/python/pulumi_gcp/filestore/instance.py
@@ -34,12 +34,6 @@ class Instance(pulumi.CustomResource):
             * [Use with Kubernetes](https://cloud.google.com/filestore/docs/accessing-fileshares)
             * [Copying Data In/Out](https://cloud.google.com/filestore/docs/copying-data)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=filestore_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """

--- a/sdk/python/pulumi_gcp/monitoring/alert_policy.py
+++ b/sdk/python/pulumi_gcp/monitoring/alert_policy.py
@@ -32,12 +32,6 @@ class AlertPolicy(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/alerts/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=monitoring_alert_policy_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """

--- a/sdk/python/pulumi_gcp/monitoring/group.py
+++ b/sdk/python/pulumi_gcp/monitoring/group.py
@@ -33,12 +33,6 @@ class Group(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/groups/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=monitoring_group_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/monitoring/notification_channel.py
+++ b/sdk/python/pulumi_gcp/monitoring/notification_channel.py
@@ -36,12 +36,6 @@ class NotificationChannel(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/api/v3/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=notification_channel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
+++ b/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
@@ -38,12 +38,6 @@ class UptimeCheckConfig(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=uptime_check_config_http&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/pubsub/topic.py
+++ b/sdk/python/pulumi_gcp/pubsub/topic.py
@@ -27,12 +27,6 @@ class Topic(pulumi.CustomResource):
         * How-to Guides
             * [Managing Topics](https://cloud.google.com/pubsub/docs/admin#managing_topics)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=pubsub_topic_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/redis/instance.py
+++ b/sdk/python/pulumi_gcp/redis/instance.py
@@ -41,12 +41,6 @@ class Instance(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/memorystore/docs/redis/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=redis_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/sourcerepo/repository.py
+++ b/sdk/python/pulumi_gcp/sourcerepo/repository.py
@@ -28,12 +28,6 @@ class Repository(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/source-repositories/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=sourcerepo_repository_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/spanner/database.py
+++ b/sdk/python/pulumi_gcp/spanner/database.py
@@ -29,12 +29,6 @@ class Database(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/spanner/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=spanner_database_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/spanner/instance.py
+++ b/sdk/python/pulumi_gcp/spanner/instance.py
@@ -32,12 +32,6 @@ class Instance(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/spanner/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=spanner_instance_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.

--- a/sdk/python/pulumi_gcp/storage/default_object_access_control.py
+++ b/sdk/python/pulumi_gcp/storage/default_object_access_control.py
@@ -41,12 +41,6 @@ class DefaultObjectAccessControl(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/storage/docs/access-control/create-manage-lists)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_default_object_access_control_public&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """

--- a/sdk/python/pulumi_gcp/storage/object_access_control.py
+++ b/sdk/python/pulumi_gcp/storage/object_access_control.py
@@ -40,12 +40,6 @@ class ObjectAccessControl(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/storage/docs/access-control/create-manage-lists)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_object_access_control_public_object&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """

--- a/sdk/python/pulumi_gcp/tpu/node.py
+++ b/sdk/python/pulumi_gcp/tpu/node.py
@@ -36,12 +36,6 @@ class Node(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/tpu/docs/)
         
-        <div class = "oics-button" style="float: right; margin: 0 0 -15px">
-          <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=tpu_node_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-            <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-          </a>
-        </div>
-        
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.


### PR DESCRIPTION
Use the latest `pulumi-terraform`, which strips "Open in Cloud Shell"
buttons from doc comments.