### PR TITLE
Reenable the Loadbalancer test

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -100,14 +100,12 @@ func TestExamples(t *testing.T) {
 	}
 
 	longTests := []integration.ProgramTestOptions{
-		//jsBase.With(integration.ProgramTestOptions{
-		//	Dir: path.Join(cwd, "loadbalancer"),
-		//	// TODO[pulumi/pulumi-terraform#241] This test currently triggers a bug in refresh, so we'll skip
-		//	// running the refresh step for now.
-		//	SkipRefresh:              true,
-		//	AllowEmptyPreviewChanges: true,
-		//	AllowEmptyUpdateChanges:  true,
-		//}),
+		jsBase.With(integration.ProgramTestOptions{
+			Dir: path.Join(cwd, "loadbalancer"),
+			// TODO[pulumi/pulumi-terraform#241] This test currently triggers a bug in refresh, so we'll skip
+			// running the refresh step for now.
+			SkipRefresh:              true,
+		}),
 		jsBase.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "webserver"),
 			// TODO[pulumi/pulumi-terraform#241] This test currently triggers a bug in refresh, so we'll skip

--- a/examples/loadbalancer/index.ts
+++ b/examples/loadbalancer/index.ts
@@ -159,7 +159,7 @@ let httpProxy = new gcp.compute.TargetHttpProxy("http-lb-proxy", {
 let forwardingRule = new gcp.compute.GlobalForwardingRule("default-rule", {
     project: projectName,
     target: httpProxy.selfLink,
-    ipAddress: globalAddress.selfLink,
+    ipAddress: globalAddress.address,
     portRange: "80",
 });
 


### PR DESCRIPTION
Fixes: #183

After https://github.com/GoogleCloudPlatform/magic-modules/pull/2084 was merged
we can see that we should be using an actual IP address rather than the
self link due to how the resolution appears. This means that the functionality
has changed and therefore, we will update the example