### PR TITLE
Use Python 3 Explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,13 @@ before_install:
     - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
+    - export CLOUDSDK_PYTHON=python3
     # Install GCP SDK and Authenticate
-    - if [ ! -d $HOME/google-cloud-sdk ]; then curl https://sdk.cloud.google.com | bash; fi
-    - export PATH=$PATH:$HOME/google-cloud-sdk/bin
-    - export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+    - if [ ! -d ${HOME}/google-cloud-sdk/bin ]; then
+          export CLOUDSDK_CORE_DISABLE_PROMPTS=1; rm -rf ${HOME}/google-cloud-sdk; curl https://sdk.cloud.google.com | bash;
+      fi
+    - export PATH=${HOME}/google-cloud-sdk/bin:$PATH
+    - gcloud version
     - openssl aes-256-cbc -K $encrypted_9ddc6194f0f2_key -iv $encrypted_9ddc6194f0f2_iv -in gcp-credentials.json.enc -out gcp-credentials.json -d
     - export GOOGLE_CREDENTIALS=$(cat gcp-credentials.json)
     - gcloud auth activate-service-account --key-file gcp-credentials.json

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ install::
 		yarn install --offline --production && \
 		(yarn unlink > /dev/null 2>&1 || true) && \
 		yarn link
-	cd ${PACKDIR}/python/bin && $(PIP) install --user -e .
 
 test_fast::
 	$(GO_TEST_FAST) ./examples

--- a/build/common.mk
+++ b/build/common.mk
@@ -112,41 +112,8 @@ GO_TEST = go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM}
 # ensure that `default` is the target that is run when no arguments are passed to make
 default::
 
-# Ensure the requisite tools are on the PATH.
-#     - Prefer Python2 over Python.
-PYTHON := $(shell command -v python2 2>/dev/null)
-ifeq ($(PYTHON),)
-	PYTHON = $(shell command -v python 2>/dev/null)
-endif
-ifeq ($(PYTHON),)
-ensure::
-	$(error "missing python 2.7 (`python2` or `python`) from your $$PATH; \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-else
-PYTHON_VERSION := $(shell command $(PYTHON) --version 2>&1)
-ifeq (,$(findstring 2.7,$(PYTHON_VERSION)))
-ensure::
-	$(error "$(PYTHON) did not report a 2.7 version number ($(PYTHON_VERSION)); \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-endif
-endif
-#     - Prefer Pip2 over Pip.
-PIP := $(shell command -v pip2 2>/dev/null)
-ifeq ($(PIP),)
-	PIP = $(shell command -v pip 2>/dev/null)
-endif
-ifeq ($(PIP),)
-ensure::
-	$(error "missing pip 2.7 (`pip2` or `pip`) from your $$PATH; \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-else
-PIP_VERSION := $(shell command $(PIP) --version 2>&1)
-ifeq (,$(findstring python 2.7,$(PIP_VERSION)))
-ensure::
-	$(error "$(PIP) did not report a 2.7 version number ($(PIP_VERSION)); \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-endif
-endif
+PYTHON ?= python3
+PIP ?= pip3
 
 # If there are sub projects, our default, all, and ensure targets will
 # recurse into them.


### PR DESCRIPTION
- Remove check for Python 2.7 (we haven't used it in forever!)
- Invoke `pip3` and `python3` so we always get a Python 3 runtime
- Don't install the just built python package. We never use the version
  we install there and it's not great to just drop some random version
  of the package into the user's site-package (vs letting them install
  it into a virtualenv of their choice)