### PR TITLE
Fix go.mod with v2+ version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To use from Python, install using `pip`:
 
 To use from Go, use `go get` to grab the latest version of the library
 
-    $ go get github.com/pulumi/pulumi-gcp/sdk/go/...
+    $ go get github.com/pulumi/pulumi-gcp/v2
 
 ## Configuring credentials
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-gcp
+module github.com/pulumi/pulumi-gcp/v2
 
 go 1.13
 
@@ -8,7 +8,7 @@ require (
 	github.com/pulumi/pulumi v1.9.1
 	github.com/pulumi/pulumi-terraform-bridge v1.6.5
 	github.com/stretchr/testify v1.4.1-0.20191106224347-f1bd0923b832
-	github.com/terraform-providers/terraform-provider-google-beta v0.0.0-00010101000000-000000000000
+	github.com/terraform-providers/terraform-provider-google-beta v1.20.0
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 )
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -40,7 +40,7 @@ To use from Python, install using `pip`:
 
 To use from Go, use `go get` to grab the latest version of the library
 
-    $ go get github.com/pulumi/pulumi-gcp/sdk/go/...
+    $ go get github.com/pulumi/pulumi-gcp/v2
 
 ## Configuring credentials
 


### PR DESCRIPTION
go modules with version >v1 requires v2/v3/etc suffix in go.mod. Right now this repo is not gomodules compatible (only v1.x releases are go gettable).

also, by using real github.com/terraform-providers/terraform-provider-google-beta version instead of non-existing  v0.0.0-00010101000000-000000000000 - this PR fixes https://github.com/pulumi/pulumi-gcp/issues/275