### PR TITLE
Update travis tag matching for release builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # It may be tempting to add parens around each individual clause in this expression, but Travis then builds pushes anyway
-if: branch = master OR branch =~ ^features/ OR branch =~ ^feature- OR branch =~ ^release/ OR tag IS present
+if: branch = master OR branch =~ ^features/ OR branch =~ ^feature- OR branch =~ ^release/ OR tag =~ ^v\d+.*
 language: go
 go:
   - 1.13.4

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -9,6 +9,6 @@ replace (
 )
 
 require (
-	github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3
+	github.com/pulumi/pulumi/pkg v1.13.1
 	github.com/stretchr/testify v1.5.1
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -388,8 +388,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3 h1:CUswHMz3r5GBJHeGL5p4NtAGwqoelFyv54KW1A1XQfk=
-github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3/go.mod h1:iX8/aPGtI3VhJnIUqHoT2iy3/0wQJySIRMs9y2TBILw=
+github.com/pulumi/pulumi/pkg v1.13.1 h1:jtUfc+BLefpoF56pCNITXHRJNfKhrD+p8Z+QXjDzcVE=
+github.com/pulumi/pulumi/pkg v1.13.1/go.mod h1:iX8/aPGtI3VhJnIUqHoT2iy3/0wQJySIRMs9y2TBILw=
 github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e h1:7FaBH2rQioJVydRq6l+Zqrsw3R8vxPegBztClpzOd0c=
 github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e/go.mod h1:ZCVEM4V8vr5IogqUhSu28+FEEn3bIjGYpEOSHRureO0=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
 	github.com/pulumi/pulumi-terraform-bridge v1.8.4-0.20200326020012-c5fd7318ced1
-	github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3
+	github.com/pulumi/pulumi/sdk v1.13.1
 	github.com/terraform-providers/terraform-provider-google-beta v0.0.0-20200309221941-5fc1579be217
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -515,6 +515,8 @@ github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3/go.mod h1:iX8/aP
 github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e/go.mod h1:ZCVEM4V8vr5IogqUhSu28+FEEn3bIjGYpEOSHRureO0=
 github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3 h1:O7Kt01GMn4lP61yHLg97TIl2D7l8BoBp4eawjqwefxY=
 github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3/go.mod h1:0jjygtqEwLnjNEL3zIn3ynjT/37ZJ42DZE6k2+2NAUM=
+github.com/pulumi/pulumi/sdk v1.13.1 h1:BX0ttL/g5ofKxkK2VY/gp8SdBxJi4eIyIG34JRn9ENU=
+github.com/pulumi/pulumi/sdk v1.13.1/go.mod h1:0jjygtqEwLnjNEL3zIn3ynjT/37ZJ42DZE6k2+2NAUM=
 github.com/pulumi/terraform-provider-google-beta v0.0.0-20200324140421-7bf2ed0276b7 h1:j/vcDVSk3M2kEtU4ZuDSqEKXtH6lk2yjDOfZW9t0ccc=
 github.com/pulumi/terraform-provider-google-beta v0.0.0-20200324140421-7bf2ed0276b7/go.mod h1:qDvM6QtDMVB8SkF5So58kFo1ctO67PDTvXdGKtH8ltM=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -2,4 +2,4 @@ module github.com/pulumi/pulumi-gcp/scripts
 
 go 1.13
 
-require github.com/pulumi/pulumi/pkg v0.0.0-20200322194843-61928f04e052
+require github.com/pulumi/pulumi/pkg v1.13.1

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -294,8 +294,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/pkg v0.0.0-20200322194843-61928f04e052 h1:5D1N4YdbWyWmJFvfMBQNTbdrLyvO8+OFTjZNK8Y6814=
-github.com/pulumi/pulumi/pkg v0.0.0-20200322194843-61928f04e052/go.mod h1:+03f1v63f9KpRzECPGnYy45weXJqpABXVKqrFlhJZ4Y=
+github.com/pulumi/pulumi/pkg v1.13.1 h1:jtUfc+BLefpoF56pCNITXHRJNfKhrD+p8Z+QXjDzcVE=
+github.com/pulumi/pulumi/pkg v1.13.1/go.mod h1:iX8/aPGtI3VhJnIUqHoT2iy3/0wQJySIRMs9y2TBILw=
 github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e h1:7FaBH2rQioJVydRq6l+Zqrsw3R8vxPegBztClpzOd0c=
 github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e/go.mod h1:ZCVEM4V8vr5IogqUhSu28+FEEn3bIjGYpEOSHRureO0=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
@@ -346,6 +346,7 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
+github.com/zclconf/go-cty v1.3.1/go.mod h1:YO23e2L18AG+ZYQfSobnY4G65nvwvprPCxBHkufUH1k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3
+	github.com/pulumi/pulumi/sdk v1.13.1
 )

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -143,8 +143,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3 h1:O7Kt01GMn4lP61yHLg97TIl2D7l8BoBp4eawjqwefxY=
-github.com/pulumi/pulumi/sdk v0.0.0-20200325225746-80f1989600a3/go.mod h1:0jjygtqEwLnjNEL3zIn3ynjT/37ZJ42DZE6k2+2NAUM=
+github.com/pulumi/pulumi/sdk v1.13.1 h1:BX0ttL/g5ofKxkK2VY/gp8SdBxJi4eIyIG34JRn9ENU=
+github.com/pulumi/pulumi/sdk v1.13.1/go.mod h1:0jjygtqEwLnjNEL3zIn3ynjT/37ZJ42DZE6k2+2NAUM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=


### PR DESCRIPTION
Replicating: https://github.com/pulumi/pulumi/pull/4219

Accommodates the new module release pattern that includes tags for `vX.X.X` `sdk/vX.X.X`. 