### PR TITLE
Bump modules to v2 structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Bump consumable git modules to v2 as per [go documentation](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher)
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ generate_schema:: tfgen
 
 provider::
 	go generate ${PROJECT}/provider/cmd/${PROVIDER}
-	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-gcp/provider/pkg/version.Version=${VERSION}" ${PROJECT}/provider/cmd/${PROVIDER}
+	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-gcp/provider/v2/pkg/version.Version=${VERSION}" ${PROJECT}/provider/v2/cmd/${PROVIDER}
 
 tfgen::
-	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-gcp/provider/pkg/version.Version=${VERSION}" ${PROJECT}/provider/cmd/${TFGEN}
+	cd provider && go install -ldflags "-X github.com/pulumi/pulumi-gcp/provider/v2/pkg/version.Version=${VERSION}" ${PROJECT}/provider/v2/cmd/${TFGEN}
 
 install_plugins::
 	[ -x "$(shell which pulumi)" ] || curl -fsSL https://get.pulumi.com | sh

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-gcp/examples
+module github.com/pulumi/pulumi-gcp/examples/v2
 
 go 1.13
 

--- a/provider/cmd/pulumi-resource-gcp/main.go
+++ b/provider/cmd/pulumi-resource-gcp/main.go
@@ -17,8 +17,8 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/provider/pkg/version"
-	gcp "github.com/pulumi/pulumi-gcp/provider"
+	gcp "github.com/pulumi/pulumi-gcp/provider/v2"
+	"github.com/pulumi/pulumi-gcp/provider/v2/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfbridge"
 )
 

--- a/provider/cmd/pulumi-tfgen-gcp/main.go
+++ b/provider/cmd/pulumi-tfgen-gcp/main.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	gcp "github.com/pulumi/pulumi-gcp/provider"
-	"github.com/pulumi/pulumi-gcp/provider/pkg/version"
+	gcp "github.com/pulumi/pulumi-gcp/provider/v2"
+	"github.com/pulumi/pulumi-gcp/provider/v2/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfgen"
 )
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,10 +1,10 @@
-module github.com/pulumi/pulumi-gcp/provider
+module github.com/pulumi/pulumi-gcp/provider/v2
 
 go 1.13
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.4.0
-	github.com/pulumi/pulumi-terraform-bridge v1.8.4-0.20200326020012-c5fd7318ced1
+	github.com/pulumi/pulumi-terraform-bridge v1.8.4
 	github.com/pulumi/pulumi/sdk v1.13.1
 	github.com/terraform-providers/terraform-provider-google-beta v0.0.0-20200309221941-5fc1579be217
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -508,8 +508,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi-terraform-bridge v1.8.4-0.20200326020012-c5fd7318ced1 h1:8kQVP38y6kgvy21uT5G9vMp/MYKo3uZKvxSoUtCetJQ=
-github.com/pulumi/pulumi-terraform-bridge v1.8.4-0.20200326020012-c5fd7318ced1/go.mod h1:EGMJtAh9rdqiqO0B5P458iigWu7BAwLxqgUWvGs33Es=
+github.com/pulumi/pulumi-terraform-bridge v1.8.4 h1:pfDNoYxduzsSEWj3M7hRuDw9Ic0z+Siks7uCJulPsow=
+github.com/pulumi/pulumi-terraform-bridge v1.8.4/go.mod h1:EGMJtAh9rdqiqO0B5P458iigWu7BAwLxqgUWvGs33Es=
 github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3 h1:CUswHMz3r5GBJHeGL5p4NtAGwqoelFyv54KW1A1XQfk=
 github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3/go.mod h1:iX8/aPGtI3VhJnIUqHoT2iy3/0wQJySIRMs9y2TBILw=
 github.com/pulumi/pulumi/sdk v0.0.0-20200321193742-f095e64d0f8e/go.mod h1:ZCVEM4V8vr5IogqUhSu28+FEEn3bIjGYpEOSHRureO0=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -7,11 +7,10 @@ import (
 	"unicode"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	google "github.com/terraform-providers/terraform-provider-google-beta/google-beta"
-
 	"github.com/pulumi/pulumi-terraform-bridge/pkg/tfbridge"
 	"github.com/pulumi/pulumi/sdk/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/go/common/tokens"
+	google "github.com/terraform-providers/terraform-provider-google-beta/google-beta"
 )
 
 // all of the Google Cloud Platform token components used below.

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -17,7 +17,7 @@ if [ "$(go env GOOS)" = "windows" ]; then
 fi
 
 (cd "${ROOT}/provider" && go build \
-   -ldflags "-X github.com/pulumi/pulumi-gcp/provider/pkg/version.Version=${VERSION}" \
+   -ldflags "-X github.com/pulumi/pulumi-gcp/provider/v2/pkg/version.Version=${VERSION}" \
    -o "${WORK_PATH}/pulumi-resource-gcp${BIN_SUFFIX}" \
    "${ROOT}/cmd/pulumi-resource-gcp")
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-gcp/sdk
+module github.com/pulumi/pulumi-gcp/sdk/v2
 
 go 1.13
 


### PR DESCRIPTION
This is required so that users can run go get and the version without
needing to know the individual Git SHA