### PR TITLE
fix: correct go get command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To use from Python, install using `pip`:
 
 To use from Go, use `go get` to grab the latest version of the library
 
-    $ go get github.com/pulumi/pulumi-gcp/sdk/go/...
+    $ go get github.com/pulumi/pulumi-gcp/sdk/v3
 
 ### .NET 
 


### PR DESCRIPTION
otherwise it defaults to use 1.9.0 which does not work correctly in go modules.