### PR TITLE
Do not install the gcp provider.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ tfgen::
 
 install_plugins::
 	[ -x "$(shell which pulumi)" ] || curl -fsSL https://get.pulumi.com | sh
-	pulumi plugin install resource $(PACK) $(PROVIDER_VERSION)
 	pulumi plugin install resource random 2.0.0
 
 lint::


### PR DESCRIPTION
This is no longer necessary for example conversion.