### PR TITLE
Prevent panic in gcp.sql.DatabaseInstance when using a Get request to lookup existing Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Prevent panic in `gcp.sql.DatabaseInstance` when using a Get request to lookup existing Database
 
 ---
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -11,6 +11,6 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20201218231525-9cca98608a5e
-	github.com/hashicorp/terraform-provider-google-beta => github.com/pulumi/terraform-provider-google-beta v0.0.0-20210622123700-6a49e7eabb81
+	github.com/hashicorp/terraform-provider-google-beta => github.com/pulumi/terraform-provider-google-beta v0.0.0-20210623102734-5affe8f5a9f6
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1232,6 +1232,8 @@ github.com/pulumi/terraform-provider-google-beta v0.0.0-20210615182856-4393ac1b9
 github.com/pulumi/terraform-provider-google-beta v0.0.0-20210615182856-4393ac1b95d8/go.mod h1:J5MPYZYH2DTnG5iwqoenC3v0hZ+clsNJnVyvaYFUUEE=
 github.com/pulumi/terraform-provider-google-beta v0.0.0-20210622123700-6a49e7eabb81 h1:roIdq3un5VaIo1VwuSmvoc4SVM2VS3G02pAo4/4xras=
 github.com/pulumi/terraform-provider-google-beta v0.0.0-20210622123700-6a49e7eabb81/go.mod h1:uMcVQlHTno9aziCSUxVRyLJPWzRKgX7RaqeMZWRAxGM=
+github.com/pulumi/terraform-provider-google-beta v0.0.0-20210623102734-5affe8f5a9f6 h1:3MrF927mbC4ig9qkvVartndlRte+NPRa9srujLednGM=
+github.com/pulumi/terraform-provider-google-beta v0.0.0-20210623102734-5affe8f5a9f6/go.mod h1:uMcVQlHTno9aziCSUxVRyLJPWzRKgX7RaqeMZWRAxGM=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c h1:JoUA0uz9U0FVFq5p4LjEq4C0VgQ0El320s3Ms0V4eww=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8/go.mod h1:KsAh3x0e7Fkpgs+Q9pNLS5XpFSvYCEVl5gP9Pp1xp30=


### PR DESCRIPTION
Fixes: #599
