### PR TITLE
Fix: code examples for gcp-compute-subnetwork

### DIFF
--- a/sdk/go/gcp/compute/subnetwork.go
+++ b/sdk/go/gcp/compute/subnetwork.go
@@ -54,7 +54,7 @@ import (
 //
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
+// 		custom_test, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
 // 			AutoCreateSubnetworks: pulumi.Bool(false),
 // 		})
 // 		if err != nil {
@@ -90,7 +90,7 @@ import (
 //
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
+// 		custom_test, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
 // 			AutoCreateSubnetworks: pulumi.Bool(false),
 // 		})
 // 		if err != nil {
@@ -125,7 +125,7 @@ import (
 //
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
+// 		custom_test, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
 // 			AutoCreateSubnetworks: pulumi.Bool(false),
 // 		}, pulumi.Provider(google_beta))
 // 		if err != nil {
@@ -157,7 +157,7 @@ import (
 //
 // func main() {
 // 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
+// 		custom_test, err := compute.NewNetwork(ctx, "custom_test", &compute.NetworkArgs{
 // 			AutoCreateSubnetworks: pulumi.Bool(false),
 // 		})
 // 		if err != nil {


### PR DESCRIPTION
Hi,

I hope the code i touched is the part that your docs that is displayed here: https://www.pulumi.com/registry/packages/gcp/api-docs/compute/subnetwork/#example-usage

Without those modifications the displayed go code won't work as there is no object "custom_test".

Bye