### PR TITLE
Create a unique network name for old example

### DIFF
--- a/examples/webserver-py-old/__main__.py
+++ b/examples/webserver-py-old/__main__.py
@@ -18,7 +18,7 @@ region_zone = config.zone
 project_name = config.project
 
 compute_network = compute.Network(
-    "network",
+    "network-old",
     project=project_name,
     auto_create_subnetworks=True,
 )


### PR DESCRIPTION
Attempt at fixing a test flake involving `TestAccWebserver/webserver-py ` example

This test failed during autoupdate as well as manual trigger:

https://github.com/pulumi/pulumi-gcp/runs/6131866796?check_suite_focus=true
https://github.com/pulumi/pulumi-gcp/runs/6264140212?check_suite_focus=true

I believe this is due to the network name being global and used in both tests too close together. CI will tell.