### PR TITLE
#861 - rename sqlServerUserDetails to sqlserverUserDetails

### DIFF
--- a/sdk/dotnet/Sql/User.cs
+++ b/sdk/dotnet/Sql/User.cs
@@ -153,7 +153,7 @@ namespace Pulumi.Gcp.Sql
         [Output("project")]
         public Output<string> Project { get; private set; } = null!;
 
-        [Output("sqlServerUserDetails")]
+        [Output("sqlserverUserDetails")]
         public Output<Outputs.UserSqlServerUserDetails?> SqlServerUserDetails { get; private set; } = null!;
 
         /// <summary>
@@ -255,7 +255,7 @@ namespace Pulumi.Gcp.Sql
         [Input("project")]
         public Input<string>? Project { get; set; }
 
-        [Input("sqlServerUserDetails")]
+        [Input("sqlserverUserDetails")]
         public Input<Inputs.UserSqlServerUserDetailsArgs>? SqlServerUserDetails { get; set; }
 
         /// <summary>
@@ -318,7 +318,7 @@ namespace Pulumi.Gcp.Sql
         [Input("project")]
         public Input<string>? Project { get; set; }
 
-        [Input("sqlServerUserDetails")]
+        [Input("sqlserverUserDetails")]
         public Input<Inputs.UserSqlServerUserDetailsGetArgs>? SqlServerUserDetails { get; set; }
 
         /// <summary>

--- a/sdk/go/gcp/sql/user.go
+++ b/sdk/go/gcp/sql/user.go
@@ -141,7 +141,7 @@ type User struct {
 	// The ID of the project in which the resource belongs. If it
 	// is not provided, the provider project is used.
 	Project              pulumi.StringOutput               `pulumi:"project"`
-	SqlServerUserDetails UserSqlServerUserDetailsPtrOutput `pulumi:"sqlServerUserDetails"`
+	SqlServerUserDetails UserSqlServerUserDetailsPtrOutput `pulumi:"sqlserverUserDetails"`
 	// The user type. It determines the method to authenticate the
 	// user during login. The default is the database's built-in user type. Flags
 	// include "BUILT_IN", "CLOUD_IAM_USER", or "CLOUD_IAM_SERVICE_ACCOUNT".
@@ -201,7 +201,7 @@ type userState struct {
 	// The ID of the project in which the resource belongs. If it
 	// is not provided, the provider project is used.
 	Project              *string                   `pulumi:"project"`
-	SqlServerUserDetails *UserSqlServerUserDetails `pulumi:"sqlServerUserDetails"`
+	SqlServerUserDetails *UserSqlServerUserDetails `pulumi:"sqlserverUserDetails"`
 	// The user type. It determines the method to authenticate the
 	// user during login. The default is the database's built-in user type. Flags
 	// include "BUILT_IN", "CLOUD_IAM_USER", or "CLOUD_IAM_SERVICE_ACCOUNT".
@@ -263,7 +263,7 @@ type userArgs struct {
 	// The ID of the project in which the resource belongs. If it
 	// is not provided, the provider project is used.
 	Project              *string                   `pulumi:"project"`
-	SqlServerUserDetails *UserSqlServerUserDetails `pulumi:"sqlServerUserDetails"`
+	SqlServerUserDetails *UserSqlServerUserDetails `pulumi:"sqlserverUserDetails"`
 	// The user type. It determines the method to authenticate the
 	// user during login. The default is the database's built-in user type. Flags
 	// include "BUILT_IN", "CLOUD_IAM_USER", or "CLOUD_IAM_SERVICE_ACCOUNT".

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/User.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/User.java
@@ -216,7 +216,7 @@ public class User extends com.pulumi.resources.CustomResource {
     public Output<String> project() {
         return this.project;
     }
-    @Export(name="sqlServerUserDetails", type=UserSqlServerUserDetails.class, parameters={})
+    @Export(name="sqlserverUserDetails", type=UserSqlServerUserDetails.class, parameters={})
     private Output</* @Nullable */ UserSqlServerUserDetails> sqlServerUserDetails;
 
     public Output<Optional<UserSqlServerUserDetails>> sqlServerUserDetails() {

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/UserArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/UserArgs.java
@@ -124,7 +124,7 @@ public final class UserArgs extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.project);
     }
 
-    @Import(name="sqlServerUserDetails")
+    @Import(name="sqlserverUserDetails")
     private @Nullable Output<UserSqlServerUserDetailsArgs> sqlServerUserDetails;
 
     public Optional<Output<UserSqlServerUserDetailsArgs>> sqlServerUserDetails() {

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/inputs/UserState.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/inputs/UserState.java
@@ -124,7 +124,7 @@ public final class UserState extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.project);
     }
 
-    @Import(name="sqlServerUserDetails")
+    @Import(name="sqlserverUserDetails")
     private @Nullable Output<UserSqlServerUserDetailsArgs> sqlServerUserDetails;
 
     public Optional<Output<UserSqlServerUserDetailsArgs>> sqlServerUserDetails() {

--- a/sdk/nodejs/sql/user.ts
+++ b/sdk/nodejs/sql/user.ts
@@ -159,7 +159,7 @@ export class User extends pulumi.CustomResource {
             resourceInputs["name"] = state ? state.name : undefined;
             resourceInputs["password"] = state ? state.password : undefined;
             resourceInputs["project"] = state ? state.project : undefined;
-            resourceInputs["sqlServerUserDetails"] = state ? state.sqlServerUserDetails : undefined;
+            resourceInputs["sqlserverUserDetails"] = state ? state.sqlServerUserDetails : undefined;
             resourceInputs["type"] = state ? state.type : undefined;
         } else {
             const args = argsOrState as UserArgs | undefined;
@@ -172,7 +172,7 @@ export class User extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["password"] = args ? args.password : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
-            resourceInputs["sqlServerUserDetails"] = args ? args.sqlServerUserDetails : undefined;
+            resourceInputs["sqlserverUserDetails"] = args ? args.sqlServerUserDetails : undefined;
             resourceInputs["type"] = args ? args.type : undefined;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);

--- a/sdk/python/pulumi_gcp/sql/user.py
+++ b/sdk/python/pulumi_gcp/sql/user.py
@@ -142,7 +142,7 @@ class UserArgs:
         pulumi.set(self, "project", value)
 
     @property
-    @pulumi.getter(name="sqlServerUserDetails")
+    @pulumi.getter(name="sqlserverUserDetails")
     def sql_server_user_details(self) -> Optional[pulumi.Input['UserSqlServerUserDetailsArgs']]:
         return pulumi.get(self, "sql_server_user_details")
 
@@ -296,7 +296,7 @@ class _UserState:
         pulumi.set(self, "project", value)
 
     @property
-    @pulumi.getter(name="sqlServerUserDetails")
+    @pulumi.getter(name="sqlserverUserDetails")
     def sql_server_user_details(self) -> Optional[pulumi.Input['UserSqlServerUserDetailsArgs']]:
         return pulumi.get(self, "sql_server_user_details")
 
@@ -645,7 +645,7 @@ class User(pulumi.CustomResource):
         return pulumi.get(self, "project")
 
     @property
-    @pulumi.getter(name="sqlServerUserDetails")
+    @pulumi.getter(name="sqlserverUserDetails")
     def sql_server_user_details(self) -> pulumi.Output[Optional['outputs.UserSqlServerUserDetails']]:
         return pulumi.get(self, "sql_server_user_details")
 


### PR DESCRIPTION
Hello guys,
In regards to issue #861, I have replaced all occurrences of the property names across the different SDKs. Please have a look if that's all that needs to be done. Please note that the property is properly typed in the native provider, so the problem is only for the classic version.

Summary:
Rename sqlServerUserDetails to sqlserverUserDetails to reflect the actual naming in the google Cloud SQL API - https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/users#resource:-user

