### PR TITLE
Add preConfigureCallback check for GCP creds

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -178,7 +178,6 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 
 	// explicitly check to make sure that the user has a project available before we do
 	// anything with the provider
-
 	project := stringValue(vars, "project", []string{"GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT",
 		"GCLOUD_PROJECT",
 		"CLOUDSDK_CORE_PROJECT"})
@@ -198,7 +197,7 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 	config := google.Config{
 		AccessToken:               stringValue(vars, "accessToken", []string{"GOOGLE_OAUTH_ACCESS_TOKEN"}),
 		Credentials:               stringValue(vars, "credentials", []string{"GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"}),
-		ImpersonateServiceAccount: stringValue(vars, "", []string{"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"}),
+		ImpersonateServiceAccount: stringValue(vars, "impersonateServiceAccount", []string{"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"}),
 		Project:                   project,
 		Region: stringValue(vars, "region", []string{"GOOGLE_REGION",
 			"GCLOUD_REGION",
@@ -208,20 +207,15 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 			"CLOUDSDK_COMPUTE_ZONE"}),
 	}
 
-	// we need to catch the default gcloud config
+	// validate the gcloud config
 	err := config.LoadAndValidate(context.Background())
 	if err != nil {
-		// TODO: parse other errors too?
-		return fmt.Errorf("failed to load application default credentials.\n" +
-			"To use your gcloud credentials, run:\n" +
+		return fmt.Errorf("failed to load application credentials.\n" +
+			"To use your default gcloud credentials, run:\n" +
 			"\t`gcloud auth application-default login`\n" +
 			"See https://www.pulumi.com/registry/packages/gcp/installation-configuration/ for details.")
-
 	}
-	fmt.Println("and the error WAS nil, wtf GUINEVERE")
-
 	return nil
-
 }
 
 // Provider returns additional overlaid schema and metadata associated with the gcp package.

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -3,7 +3,9 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -11,9 +13,11 @@ import (
 	google "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 	"github.com/pulumi/pulumi-gcp/provider/v6/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	googleoauth "golang.org/x/oauth2/google"
 )
 
 // all of the Google Cloud Platform token components used below.
@@ -156,6 +160,122 @@ func boolRef(b bool) *bool {
 	return &b
 }
 
+// Get a set of credentials with a given scope (clientScopes).
+// If defaultCredentials is true, we anre not running as a service account and return the initial set of creds instead.
+// TODO: expand serviceaccount options if defaultCredentials are not true
+func getCredentials(clientScopes []string, defaultCredentials bool, vars resource.PropertyMap) (googleoauth.Credentials, error) {
+	if !defaultCredentials {
+		// this means we're authenticating via Service Account
+
+		return googleoauth.Credentials{}, fmt.Errorf("unable to check non-default creds yet")
+
+	}
+	//	if c.Credentials != "" {
+	//		contents, _, err := pathOrContents(c.Credentials)
+	//		if err != nil {
+	//			return googleoauth.Credentials{}, fmt.Errorf("error loading credentials: %s", err)
+	//		}
+	//
+	//		if c.ImpersonateServiceAccount != "" && !initialCredentialsOnly {
+	//			opts := []option.ClientOption{option.WithCredentialsJSON([]byte(contents)), option.ImpersonateCredentials(c.ImpersonateServiceAccount, c.ImpersonateServiceAccountDelegates...), option.WithScopes(clientScopes...)}
+	//			creds, err := transport.Creds(context.TODO(), opts...)
+	//			if err != nil {
+	//				return googleoauth.Credentials{}, err
+	//			}
+	//			return *creds, nil
+	//		}
+	//
+	//		creds, err := googleoauth.CredentialsFromJSON(c.context, []byte(contents), clientScopes...)
+	//		if err != nil {
+	//			return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials from '%s': %s", contents, err)
+	//		}
+	//
+	//		log.Printf("[INFO] Authenticating using configured Google JSON 'credentials'...")
+	//		log.Printf("[INFO]   -- Scopes: %s", clientScopes)
+	//		return *creds, nil
+	//	}
+	//
+	//	if c.ImpersonateServiceAccount != "" && !initialCredentialsOnly {
+	//		opts := option.ImpersonateCredentials(c.ImpersonateServiceAccount, c.ImpersonateServiceAccountDelegates...)
+	//		creds, err := transport.Creds(context.TODO(), opts, option.WithScopes(clientScopes...))
+	//		if err != nil {
+	//			return googleoauth.Credentials{}, err
+	//		}
+	//
+	//		return *creds, nil
+	//	}
+
+	fmt.Println("Authenticating using DefaultClient...")
+	fmt.Printf("Client Scopes: %s\n", clientScopes)
+	defaultTS, err := googleoauth.DefaultTokenSource(context.Background(), clientScopes...)
+	if err != nil {
+		// TODO: make this error more Pulumi specific
+		return googleoauth.Credentials{}, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
+	}
+
+	return googleoauth.Credentials{
+		TokenSource: defaultTS,
+	}, err
+}
+
+func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) error {
+
+	// check if skipCredentialsValidation is True, if yes, exit early
+	if val, ok := vars["skipCredentialsValidation"]; ok {
+		if val.IsBool() {
+			return nil
+		}
+	}
+
+	// GCP has default client scopes.
+	var defaultClientScopes = []string{
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/userinfo.email",
+	}
+
+	fmt.Println("here are some vars!")
+
+	fmt.Println(vars)
+
+	//// first, let's verify required vars are set at all - ACTUALLY we probably don't want to reinvent the wheel even if it saves us an auth call
+	//if _, found := vars["project"]; !found {
+	//	// check the environment
+	//	_, inEnv := os.LookupEnv("GOOGLE_PROJECT")
+	//	if !inEnv {
+	//		// TODO: abstract this error message
+	//		return fmt.Errorf("Unable to find Google Project. Make sure you have: \n" +
+	//			" \t Set your GCP project, e.g. `pulumi config set gcp:project pulumi-example\n")
+	//	}
+	//}
+
+	// check if this is a service account situation
+
+	_, svcAcct := os.LookupEnv("GOOGLE_CREDENTIALS")
+	if svcAcct {
+		err := fmt.Errorf("unable to check non-default creds yet")
+		return err
+	}
+
+	// else we use default creds
+	fmt.Println("Authenticating using DefaultClient...")
+	fmt.Printf("Client Scopes: %s\n", defaultClientScopes)
+	defaultTS, err := googleoauth.DefaultTokenSource(context.Background(), defaultClientScopes...)
+	if err != nil {
+		// TODO: make this error more Pulumi specific
+		return fmt.Errorf("Attempted to load application default credentials since `credentials` was not set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth login'.")
+	}
+
+	creds := googleoauth.Credentials{
+		TokenSource: defaultTS,
+	}
+
+	tokenSource := creds.TokenSource
+	fmt.Println(&tokenSource)
+
+	return nil
+
+}
+
 // Provider returns additional overlaid schema and metadata associated with the gcp package.
 func Provider() tfbridge.ProviderInfo {
 	p := shimv2.NewProvider(google.Provider())
@@ -205,6 +325,7 @@ func Provider() tfbridge.ProviderInfo {
 			// See: https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/data_source_dataproc_metastore_service
 			"google_dataproc_metastore_service",
 		},
+		PreConfigureCallback: preConfigureCallback,
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// Access Context Manager
 			"google_access_context_manager_access_level": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -178,33 +178,37 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 
 	// explicitly check to make sure that the user has a project available before we do
 	// anything with the provider
-	project := stringValue(vars, "project", []string{"GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT",
+	project := stringValue(vars, "project", []string{
+		"GOOGLE_PROJECT",
+		"GOOGLE_CLOUD_PROJECT",
 		"GCLOUD_PROJECT",
-		"CLOUDSDK_CORE_PROJECT"})
+		"CLOUDSDK_CORE_PROJECT",
+	})
 	if project == "" {
 		return fmt.Errorf("unable to find required configuration setting: GCP Project\n" +
 			"Set the GCP Project by using:\n" +
 			"\t`pulumi config set gcp:project <project>`")
 	}
 
-	// check if skipCredentialsValidation is True, if yes, exit early
-	if val, ok := vars["skipCredentialsValidation"]; ok {
-		if val.IsBool() {
-			return nil
-		}
-	}
-
 	config := google.Config{
-		AccessToken:               stringValue(vars, "accessToken", []string{"GOOGLE_OAUTH_ACCESS_TOKEN"}),
-		Credentials:               stringValue(vars, "credentials", []string{"GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"}),
+		AccessToken: stringValue(vars, "accessToken", []string{"GOOGLE_OAUTH_ACCESS_TOKEN"}),
+		Credentials: stringValue(vars, "credentials", []string{
+			"GOOGLE_CREDENTIALS",
+			"GOOGLE_CLOUD_KEYFILE_JSON",
+			"GCLOUD_KEYFILE_JSON",
+		}),
 		ImpersonateServiceAccount: stringValue(vars, "impersonateServiceAccount", []string{"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"}),
 		Project:                   project,
-		Region: stringValue(vars, "region", []string{"GOOGLE_REGION",
+		Region: stringValue(vars, "region", []string{
+			"GOOGLE_REGION",
 			"GCLOUD_REGION",
-			"CLOUDSDK_COMPUTE_REGION"}),
-		Zone: stringValue(vars, "zone", []string{"GOOGLE_ZONE",
+			"CLOUDSDK_COMPUTE_REGION",
+		}),
+		Zone: stringValue(vars, "zone", []string{
+			"GOOGLE_ZONE",
 			"GCLOUD_ZONE",
-			"CLOUDSDK_COMPUTE_ZONE"}),
+			"CLOUDSDK_COMPUTE_ZONE",
+		}),
 	}
 
 	// validate the gcloud config


### PR DESCRIPTION
Add authentication error messages

- sketch out callback func
- use given library to validate
- Error early if Project not set. Catch default app error.
- finalize messaging
- make sdks with go 1.19

Fixes #860
