### PR TITLE
Surface access key validation error

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -238,10 +238,8 @@ func preConfigureCallbackWithLogger(ctx context.Context, host *provider.HostClie
 	// validate the gcloud config
 	err := config.LoadAndValidate(context.Background())
 	if err != nil {
-		return fmt.Errorf("failed to load application credentials.\n" +
-			"To use your default gcloud credentials, run:\n" +
-			"\t`gcloud auth application-default login`\n" +
-			"See https://www.pulumi.com/registry/packages/gcp/installation-configuration/ for details.")
+		return fmt.Errorf(
+			"failed to load application credentials.\nTo use your default gcloud credentials, run:\n\t`gcloud auth application-default login`\nSee https://www.pulumi.com/registry/packages/gcp/installation-configuration/ for details.\nExpanded error message: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Helps surface the issue behind #989 

This PR surfaces the error when validating access credentials fails. Previously, we assumed that validation fails because the GCP credentials are not provided and instructs the user to specify credentials. However, validation could fail for different reasons so this should also be surfaced to the user to provide more helpful error messages for debugging.