### PR TITLE
Allow specifying environment variables from secrets in generated CloudFunction

### DIFF
--- a/sdk/nodejs/cloudfunctions/zMixins.ts
+++ b/sdk/nodejs/cloudfunctions/zMixins.ts
@@ -354,6 +354,10 @@ export interface CallbackFunctionArgs {
      */
     region?: pulumi.Input<string>;
     /**
+     * Secret environment variables configuration. Structure is documented below.
+     */
+    secretEnvironmentVariables?: pulumi.Input<pulumi.Input<inputs.cloudfunctions.FunctionSecretEnvironmentVariable>[]>;
+    /**
      * If provided, the self-provided service account to run the function with.
      */
     serviceAccountEmail?: pulumi.Input<string>;


### PR DESCRIPTION
There's a mechanism already in place to specify custom args to the auto-generated functions created as the result of callbacks defined for bucket's onObjectEvents, but unfortunately this option supported by CloudFunction is not whitelisted in the type.

This should be all that it takes for our use-case to be able to customize this value.