### PR TITLE
Upgrade terraform-provider-google-beta to v4.63.1

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -12,7 +12,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9
-	github.com/hashicorp/terraform-provider-google-beta => github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230424234059-dfa18b76f348
+	github.com/hashicorp/terraform-provider-google-beta => github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230504034140-e03b9895b934
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1725,8 +1725,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9 h1:JMw+t5I+6E8Lna7JF+ghAoOLOl23UIbshJyRNP+K1HU=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9/go.mod h1:mYPs/uchNcBq7AclQv9QUtSf9iNcfp1Ag21jqTlDf2M=
-github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230424234059-dfa18b76f348 h1:OXoTyqO7T+dm7WDjjBhjt/jNAvRoaLShIeniBg/figM=
-github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230424234059-dfa18b76f348/go.mod h1:qe2S9HXOjXynqC4E0RKjCBXoll0PUPMba5wcC6cZP0A=
+github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230504034140-e03b9895b934 h1:pamP0QgIgL4RxaIdY+VvifOdLbtmIYkmS0tKP0oLZe8=
+github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230504034140-e03b9895b934/go.mod h1:qe2S9HXOjXynqC4E0RKjCBXoll0PUPMba5wcC6cZP0A=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=


### PR DESCRIPTION
Contains only one fix, _bigtable: fixed plan failure because of an unused zone being unavailable_.

Resolves #1070 