### PR TITLE
Replace upstream fork with submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "upstream"]
+	path = upstream
+	url = https://github.com/hashicorp/terraform-provider-google-beta.git
+	ignore = dirty

--- a/patches/0001-fork.patch
+++ b/patches/0001-fork.patch
@@ -1,0 +1,6220 @@
+diff --git b/CHANGELOG.md a/CHANGELOG.md
+index 5131ff6ab..f4340b2fc 100644
+--- b/CHANGELOG.md
++++ a/CHANGELOG.md
+@@ -66,6 +66,32 @@ BUG FIXES:
+ * provider: fixed an issue where mtls transports were not used consistently(initial implementation in v4.65.0, reverted in v4.65.1) ([#5645](https://github.com/hashicorp/terraform-provider-google-beta/pull/5645))
+ * storage: fixed inconsistent final plan when labels are added to `google_storage_bucket` ([#5634](https://github.com/hashicorp/terraform-provider-google-beta/pull/5634))
+ 
++NOTE:
++* Upgraded to Go 1.19.9 ([#5623](https://github.com/hashicorp/terraform-provider-google-beta/pull/5623))
++
++FEATURES:
++* **New Resource:** `google_network_security_server_tls_policy` ([#5619](https://github.com/hashicorp/terraform-provider-google-beta/pull/5619))
++
++IMPROVEMENTS:
++* bigquery: added `ICEBERG` as an enum for `external_data_configuration.source_format` field in `google_bigquery_table` ([#5622](https://github.com/hashicorp/terraform-provider-google-beta/pull/5622))
++* cloudfunctions: added `status` attribute to the `google_cloudfunctions_function` resource and data source ([#5625](https://github.com/hashicorp/terraform-provider-google-beta/pull/5625))
++* compute: added `storage_location` field in `google_compute_image` resource ([#5644](https://github.com/hashicorp/terraform-provider-google-beta/pull/5644))
++* compute: added support for additional machine types in `google_compute_region_commitment` ([#5633](https://github.com/hashicorp/terraform-provider-google-beta/pull/5633))
++* dataflow: added multiple fields to `google_dataflow_flex_template_job` ([#5635](https://github.com/hashicorp/terraform-provider-google-beta/pull/5635))
++* monitoring: added `forecast_options` field to `google_monitoring_alert_policy` resource ([#5642](https://github.com/hashicorp/terraform-provider-google-beta/pull/5642))
++* monitoring: added `notification_channel_strategy` field to `google_monitoring_alert_policy` resource ([#5624](https://github.com/hashicorp/terraform-provider-google-beta/pull/5624))
++* sql: added `advanced_machine_features` field in `google_sql_database_instance` ([#5639](https://github.com/hashicorp/terraform-provider-google-beta/pull/5639))
++* storagetransfer: added field `path` to `transfer_spec.aws_s3_data_source` in `google_storage_transfer_job` ([#5641](https://github.com/hashicorp/terraform-provider-google-beta/pull/5641))
++* workstations: added support for `source_snapshot` in `google_workstations_workstation_config` ([#5636](https://github.com/hashicorp/terraform-provider-google-beta/pull/5636))
++
++BUG FIXES:
++* artifactregistry: fixed new repositories ignoring the provider region if location is unset in `google_artifact_registry_repository`. ([#5637](https://github.com/hashicorp/terraform-provider-google-beta/pull/5637))
++* compute: fixed permadiff on `log_config.sample_rate` of `google_compute_backend_service` ([#5631](https://github.com/hashicorp/terraform-provider-google-beta/pull/5631))
++* container: fixed permadiff on `gateway_api_config.channel` of `google_container_cluster` ([#5626](https://github.com/hashicorp/terraform-provider-google-beta/pull/5626))
++* dataflow: fixed inconsistent final plan when labels are added to `google_dataflow_job` ([#5634](https://github.com/hashicorp/terraform-provider-google-beta/pull/5634))
++* provider: fixed an issue where mtls transports were not used consistently(initial implementation in v4.65.0, reverted in v4.65.1) ([#5645](https://github.com/hashicorp/terraform-provider-google-beta/pull/5645))
++* storage: fixed inconsistent final plan when labels are added to `google_storage_bucket` ([#5634](https://github.com/hashicorp/terraform-provider-google-beta/pull/5634))
++
+ ## 4.65.2 (May 16, 2023)
+ 
+ BUG FIXES:
+diff --git b/google-beta/data_source_dns_keys_reverted.go a/google-beta/data_source_dns_keys_reverted.go
+new file mode 100644
+index 000000000..252fb016e
+--- /dev/null
++++ a/google-beta/data_source_dns_keys_reverted.go
+@@ -0,0 +1,237 @@
++package google
++
++import (
++	"context"
++	"fmt"
++	"log"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
++	"google.golang.org/api/dns/v1"
++)
++
++// // DNSSEC Algorithm Numbers: https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
++// // The following are algorithms that are supported by Cloud DNS
++// var dnssecAlgoNums = map[string]int{
++// 	"rsasha1":         5,
++// 	"rsasha256":       8,
++// 	"rsasha512":       10,
++// 	"ecdsap256sha256": 13,
++// 	"ecdsap384sha384": 14,
++// }
++
++// // DS RR Digest Types: https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
++// // The following are digests that are supported by Cloud DNS
++// var dnssecDigestType = map[string]int{
++// 	"sha1":   1,
++// 	"sha256": 2,
++// 	"sha384": 4,
++// }
++
++// Renamed with SDK suffix to avoid conflict with the framework version
++func DataSourceDNSKeysSdk() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceDNSKeysRead,
++
++		Schema: map[string]*schema.Schema{
++			"managed_zone": {
++				Type:             schema.TypeString,
++				Required:         true,
++				DiffSuppressFunc: compareSelfLinkOrResourceName,
++			},
++			"project": {
++				Type:     schema.TypeString,
++				Optional: true,
++				Computed: true,
++				ForceNew: true,
++			},
++			"key_signing_keys": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem:     kskResource(),
++			},
++			"zone_signing_keys": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem:     dnsKeyResource(),
++			},
++		},
++	}
++}
++
++func dnsKeyResource() *schema.Resource {
++	return &schema.Resource{
++		Schema: map[string]*schema.Schema{
++			"algorithm": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"creation_time": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"description": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"digests": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem: &schema.Resource{
++					Schema: map[string]*schema.Schema{
++						"digest": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++						"type": {
++							Type:     schema.TypeString,
++							Optional: true,
++						},
++					},
++				},
++			},
++			"id": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++			"is_active": {
++				Type:     schema.TypeBool,
++				Computed: true,
++			},
++			"key_length": {
++				Type:     schema.TypeInt,
++				Computed: true,
++			},
++			"key_tag": {
++				Type:     schema.TypeInt,
++				Computed: true,
++			},
++			"public_key": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func kskResource() *schema.Resource {
++	resource := dnsKeyResource()
++
++	resource.Schema["ds_record"] = &schema.Schema{
++		Type:     schema.TypeString,
++		Computed: true,
++	}
++
++	return resource
++}
++
++// Use the same implementation as the framework version
++
++// func generateDSRecord(signingKey *dns.DnsKey) (string, error) {
++// 	algoNum, found := dnssecAlgoNums[signingKey.Algorithm]
++// 	if !found {
++// 		return "", fmt.Errorf("DNSSEC Algorithm number for %s not found", signingKey.Algorithm)
++// 	}
++
++// 	digestType, found := dnssecDigestType[signingKey.Digests[0].Type]
++// 	if !found {
++// 		return "", fmt.Errorf("DNSSEC Digest type for %s not found", signingKey.Digests[0].Type)
++// 	}
++
++// 	return fmt.Sprintf("%d %d %d %s",
++// 		signingKey.KeyTag,
++// 		algoNum,
++// 		digestType,
++// 		signingKey.Digests[0].Digest), nil
++// }
++
++// Reworked to use the same implementation as the framework version
++
++// func flattenSigningKeys(signingKeys []*dns.DnsKey, keyType string) []map[string]interface{} {
++// 	var keys []map[string]interface{}
++
++// 	for _, signingKey := range signingKeys {
++// 		if signingKey != nil && signingKey.Type == keyType {
++// 			data := map[string]interface{}{
++// 				"algorithm":     signingKey.Algorithm,
++// 				"creation_time": signingKey.CreationTime,
++// 				"description":   signingKey.Description,
++// 				"digests":       flattenDigests(signingKey.Digests),
++// 				"id":            signingKey.Id,
++// 				"is_active":     signingKey.IsActive,
++// 				"key_length":    signingKey.KeyLength,
++// 				"key_tag":       signingKey.KeyTag,
++// 				"public_key":    signingKey.PublicKey,
++// 			}
++
++// 			if signingKey.Type == "keySigning" && len(signingKey.Digests) > 0 {
++// 				dsRecord, err := generateDSRecord(signingKey)
++// 				if err == nil {
++// 					data["ds_record"] = dsRecord
++// 				}
++// 			}
++
++// 			keys = append(keys, data)
++// 		}
++// 	}
++
++// 	return keys
++// }
++
++func flattenDigests(dnsKeyDigests []*dns.DnsKeyDigest) []map[string]interface{} {
++	var digests []map[string]interface{}
++
++	for _, dnsKeyDigest := range dnsKeyDigests {
++		if dnsKeyDigest != nil {
++			data := map[string]interface{}{
++				"digest": dnsKeyDigest.Digest,
++				"type":   dnsKeyDigest.Type,
++			}
++
++			digests = append(digests, data)
++		}
++	}
++
++	return digests
++}
++
++func dataSourceDNSKeysRead(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*transport_tpg.Config)
++	userAgent, err := generateUserAgentString(d, config.UserAgent)
++	if err != nil {
++		return err
++	}
++
++	fv, err := parseProjectFieldValue("managedZones", d.Get("managed_zone").(string), "project", d, config, false)
++	if err != nil {
++		return err
++	}
++	project := fv.Project
++	managedZone := fv.Name
++
++	if err := d.Set("project", project); err != nil {
++		return fmt.Errorf("Error setting project: %s", err)
++	}
++	d.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, managedZone))
++
++	log.Printf("[DEBUG] Fetching DNS keys from managed zone %s", managedZone)
++
++	response, err := config.NewDnsClient(userAgent).DnsKeys.List(project, managedZone).Do()
++	if err != nil && !transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
++		return fmt.Errorf("error retrieving DNS keys: %s", err)
++	} else if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
++		return nil
++	}
++
++	log.Printf("[DEBUG] Fetched DNS keys from managed zone %s", managedZone)
++
++	zoneSigningKeys, keySigningKeys := flattenSigningKeys(context.Background(), response.DnsKeys, nil)
++	if err := d.Set("key_signing_keys", keySigningKeys); err != nil {
++		return fmt.Errorf("Error setting key_signing_keys: %s", err)
++	}
++	if err := d.Set("zone_signing_keys", zoneSigningKeys); err != nil {
++		return fmt.Errorf("Error setting zone_signing_keys: %s", err)
++	}
++
++	return nil
++}
+diff --git b/google-beta/data_source_dns_managed_zone_reverted.go a/google-beta/data_source_dns_managed_zone_reverted.go
+new file mode 100644
+index 000000000..f2098ffdf
+--- /dev/null
++++ a/google-beta/data_source_dns_managed_zone_reverted.go
+@@ -0,0 +1,102 @@
++package google
++
++import (
++	"fmt"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
++)
++
++func DataSourceDnsManagedZoneSdk() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceDnsManagedZoneRead,
++
++		Schema: map[string]*schema.Schema{
++			"dns_name": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"name": {
++				Type:     schema.TypeString,
++				Required: true,
++			},
++
++			"description": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"managed_zone_id": {
++				Type:        schema.TypeInt,
++				Computed:    true,
++				Description: `Unique identifier for the resource; defined by the server.`,
++			},
++
++			"name_servers": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem: &schema.Schema{
++					Type: schema.TypeString,
++				},
++			},
++
++			"visibility": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			// Google Cloud DNS ManagedZone resources do not have a SelfLink attribute.
++			"project": {
++				Type:     schema.TypeString,
++				Optional: true,
++			},
++		},
++	}
++}
++
++func dataSourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*transport_tpg.Config)
++	userAgent, err := generateUserAgentString(d, config.UserAgent)
++	if err != nil {
++		return err
++	}
++
++	project, err := getProject(d, config)
++	if err != nil {
++		return err
++	}
++
++	name := d.Get("name").(string)
++	d.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, name))
++
++	zone, err := config.NewDnsClient(userAgent).ManagedZones.Get(
++		project, name).Do()
++	if err != nil {
++		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("DataSourceDnsManagedZone %q", name))
++	}
++
++	if err := d.Set("dns_name", zone.DnsName); err != nil {
++		return fmt.Errorf("Error setting dns_name: %s", err)
++	}
++	if err := d.Set("name", zone.Name); err != nil {
++		return fmt.Errorf("Error setting name: %s", err)
++	}
++	if err := d.Set("description", zone.Description); err != nil {
++		return fmt.Errorf("Error setting description: %s", err)
++	}
++	if err := d.Set("managed_zone_id", zone.Id); err != nil {
++		return fmt.Errorf("Error setting managed_zone_id: %s", err)
++	}
++	if err := d.Set("name_servers", zone.NameServers); err != nil {
++		return fmt.Errorf("Error setting name_servers: %s", err)
++	}
++	if err := d.Set("visibility", zone.Visibility); err != nil {
++		return fmt.Errorf("Error setting visibility: %s", err)
++	}
++	if err := d.Set("project", project); err != nil {
++		return fmt.Errorf("Error setting project: %s", err)
++	}
++
++	return nil
++}
+diff --git b/google-beta/data_source_dns_record_set_reverted.go a/google-beta/data_source_dns_record_set_reverted.go
+new file mode 100644
+index 000000000..e1a8288d8
+--- /dev/null
++++ a/google-beta/data_source_dns_record_set_reverted.go
+@@ -0,0 +1,87 @@
++package google
++
++import (
++	"fmt"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
++)
++
++func DataSourceDnsRecordSetSdk() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceDnsRecordSetRead,
++
++		Schema: map[string]*schema.Schema{
++			"managed_zone": {
++				Type:     schema.TypeString,
++				Required: true,
++			},
++
++			"name": {
++				Type:     schema.TypeString,
++				Required: true,
++			},
++
++			"rrdatas": {
++				Type:     schema.TypeList,
++				Computed: true,
++				Elem: &schema.Schema{
++					Type: schema.TypeString,
++				},
++			},
++
++			"ttl": {
++				Type:     schema.TypeInt,
++				Computed: true,
++			},
++
++			"type": {
++				Type:     schema.TypeString,
++				Required: true,
++			},
++
++			"project": {
++				Type:     schema.TypeString,
++				Optional: true,
++			},
++		},
++	}
++}
++
++func dataSourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*transport_tpg.Config)
++	userAgent, err := generateUserAgentString(d, config.UserAgent)
++	if err != nil {
++		return err
++	}
++
++	project, err := getProject(d, config)
++	if err != nil {
++		return err
++	}
++
++	zone := d.Get("managed_zone").(string)
++	name := d.Get("name").(string)
++	dnsType := d.Get("type").(string)
++	d.SetId(fmt.Sprintf("projects/%s/managedZones/%s/rrsets/%s/%s", project, zone, name, dnsType))
++
++	resp, err := config.NewDnsClient(userAgent).ResourceRecordSets.List(project, zone).Name(name).Type(dnsType).Do()
++	if err != nil {
++		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("DataSourceDnsRecordSet %q", name))
++	}
++	if len(resp.Rrsets) != 1 {
++		return fmt.Errorf("Only expected 1 record set, got %d", len(resp.Rrsets))
++	}
++
++	if err := d.Set("rrdatas", resp.Rrsets[0].Rrdatas); err != nil {
++		return fmt.Errorf("Error setting rrdatas: %s", err)
++	}
++	if err := d.Set("ttl", resp.Rrsets[0].Ttl); err != nil {
++		return fmt.Errorf("Error setting ttl: %s", err)
++	}
++	if err := d.Set("project", project); err != nil {
++		return fmt.Errorf("Error setting project: %s", err)
++	}
++
++	return nil
++}
+diff --git b/google-beta/data_source_google_client_config_reverted.go a/google-beta/data_source_google_client_config_reverted.go
+new file mode 100644
+index 000000000..d41c1fc08
+--- /dev/null
++++ a/google-beta/data_source_google_client_config_reverted.go
+@@ -0,0 +1,62 @@
++package google
++
++import (
++	"fmt"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
++)
++
++// Renamed with SDK suffix to avoid conflict with the framework version
++func DataSourceGoogleClientConfigSdk() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceClientConfigRead,
++		Schema: map[string]*schema.Schema{
++			"project": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"region": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"zone": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++
++			"access_token": {
++				Type:      schema.TypeString,
++				Computed:  true,
++				Sensitive: true,
++			},
++		},
++	}
++}
++
++func dataSourceClientConfigRead(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*transport_tpg.Config)
++
++	d.SetId(fmt.Sprintf("projects/%s/regions/%s/zones/%s", config.Project, config.Region, config.Zone))
++	if err := d.Set("project", config.Project); err != nil {
++		return fmt.Errorf("Error setting project: %s", err)
++	}
++	if err := d.Set("region", config.Region); err != nil {
++		return fmt.Errorf("Error setting region: %s", err)
++	}
++	if err := d.Set("zone", config.Zone); err != nil {
++		return fmt.Errorf("Error setting zone: %s", err)
++	}
++
++	token, err := config.TokenSource.Token()
++	if err != nil {
++		return err
++	}
++	if err := d.Set("access_token", token.AccessToken); err != nil {
++		return fmt.Errorf("Error setting access_token: %s", err)
++	}
++
++	return nil
++}
+diff --git b/google-beta/data_source_google_client_openid_userinfo_reverted.go a/google-beta/data_source_google_client_openid_userinfo_reverted.go
+new file mode 100644
+index 000000000..d7ee6ee2f
+--- /dev/null
++++ a/google-beta/data_source_google_client_openid_userinfo_reverted.go
+@@ -0,0 +1,38 @@
++package google
++
++import (
++	"fmt"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
++)
++
++func DataSourceGoogleClientOpenIDUserinfoSdk() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceGoogleClientOpenIDUserinfoRead,
++		Schema: map[string]*schema.Schema{
++			"email": {
++				Type:     schema.TypeString,
++				Computed: true,
++			},
++		},
++	}
++}
++
++func dataSourceGoogleClientOpenIDUserinfoRead(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*transport_tpg.Config)
++	userAgent, err := generateUserAgentString(d, config.UserAgent)
++	if err != nil {
++		return err
++	}
++
++	email, err := transport_tpg.GetCurrentUserEmail(config, userAgent)
++	if err != nil {
++		return err
++	}
++	d.SetId(email)
++	if err := d.Set("email", email); err != nil {
++		return fmt.Errorf("Error setting email: %s", err)
++	}
++	return nil
++}
+diff --git b/google-beta/data_source_google_firebase_apple_app_config_reverted.go a/google-beta/data_source_google_firebase_apple_app_config_reverted.go
+new file mode 100644
+index 000000000..d3e8aef7c
+--- /dev/null
++++ a/google-beta/data_source_google_firebase_apple_app_config_reverted.go
+@@ -0,0 +1,83 @@
++package google
++
++import (
++	"fmt"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
++)
++
++func DataSourceGoogleFirebaseAppleAppConfigSdk() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceGoogleFirebaseAppleAppConfigRead,
++
++		Schema: map[string]*schema.Schema{
++			"app_id": {
++				Type:        schema.TypeString,
++				Required:    true,
++				Description: `The id of the Firebase iOS App.`,
++			},
++			"project": {
++				Type:        schema.TypeString,
++				Optional:    true,
++				Description: `The project id of the Firebase iOS App.`,
++			},
++			"config_filename": {
++				Type:        schema.TypeString,
++				Computed:    true,
++				Description: `The filename that the configuration artifact for the IosApp is typically saved as.`,
++			},
++			"config_file_contents": {
++				Type:        schema.TypeString,
++				Computed:    true,
++				Description: `The content of the XML configuration file as a base64-encoded string.`,
++			},
++		},
++	}
++
++}
++
++func dataSourceGoogleFirebaseAppleAppConfigRead(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*transport_tpg.Config)
++	userAgent, err := generateUserAgentString(d, config.UserAgent)
++	if err != nil {
++		return err
++	}
++
++	project, err := getProject(d, config)
++	if err != nil {
++		return err
++	}
++
++	id := fmt.Sprintf("projects/%s/iosApps/%s", project, d.Get("app_id").(string))
++
++	url, err := ReplaceVars(d, config, "{{FirebaseBasePath}}projects/{{project}}/iosApps/{{app_id}}/config")
++	if err != nil {
++		return err
++	}
++
++	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
++		Config:    config,
++		Method:    "GET",
++		Project:   project,
++		RawURL:    url,
++		UserAgent: userAgent,
++	})
++	if err != nil {
++		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("FirebaseAppleApp config %q", d.Id()))
++	}
++
++	if err = d.Set("config_filename", res["configFilename"]); err != nil {
++		return err
++	}
++
++	if err = d.Set("config_file_contents", res["configFileContents"]); err != nil {
++		return err
++	}
++	if err = d.Set("project", project); err != nil {
++		return err
++	}
++
++	d.SetId(id)
++	return nil
++}
+diff --git b/google-beta/data_source_google_firebase_web_app_config_reverted.go a/google-beta/data_source_google_firebase_web_app_config_reverted.go
+new file mode 100644
+index 000000000..7cde0002b
+--- /dev/null
++++ a/google-beta/data_source_google_firebase_web_app_config_reverted.go
+@@ -0,0 +1,139 @@
++package google
++
++import (
++	"fmt"
++
++	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
++)
++
++func DataSourceGoogleFirebaseWebAppConfigSdk() *schema.Resource {
++	return &schema.Resource{
++		Read: dataSourceGoogleFirebaseWebappConfigRead,
++
++		Schema: map[string]*schema.Schema{
++			"web_app_id": {
++				Type:        schema.TypeString,
++				Required:    true,
++				Description: `The id of the Firebase web App.`,
++			},
++			"project": {
++				Type:        schema.TypeString,
++				Optional:    true,
++				Description: `The project id of the Firebase web App.`,
++			},
++			"api_key": {
++				Type:        schema.TypeString,
++				Computed:    true,
++				Description: `The API key associated with the web App.`,
++			},
++			"auth_domain": {
++				Type:     schema.TypeString,
++				Computed: true,
++				Description: `The domain Firebase Auth configures for OAuth redirects, in the format:
++
++projectId.firebaseapp.com`,
++			},
++			"database_url": {
++				Type:        schema.TypeString,
++				Computed:    true,
++				Description: `The default Firebase Realtime Database URL.`,
++			},
++			"location_id": {
++				Type:     schema.TypeString,
++				Computed: true,
++				Description: `The ID of the project's default GCP resource location. The location is one of the available GCP resource
++locations.
++
++This field is omitted if the default GCP resource location has not been finalized yet. To set your project's
++default GCP resource location, call defaultLocation.finalize after you add Firebase services to your project.`,
++			},
++			"measurement_id": {
++				Type:     schema.TypeString,
++				Computed: true,
++				Description: `The unique Google-assigned identifier of the Google Analytics web stream associated with the Firebase Web App.
++Firebase SDKs use this ID to interact with Google Analytics APIs.
++
++This field is only present if the App is linked to a web stream in a Google Analytics App + Web property.
++Learn more about this ID and Google Analytics web streams in the Analytics documentation.
++
++To generate a measurementId and link the Web App with a Google Analytics web stream,
++call projects.addGoogleAnalytics.`,
++			},
++			"messaging_sender_id": {
++				Type:        schema.TypeString,
++				Computed:    true,
++				Description: `The sender ID for use with Firebase Cloud Messaging.`,
++			},
++			"storage_bucket": {
++				Type:        schema.TypeString,
++				Computed:    true,
++				Description: `The default Cloud Storage for Firebase storage bucket name.`,
++			},
++		},
++	}
++
++}
++
++func dataSourceGoogleFirebaseWebappConfigRead(d *schema.ResourceData, meta interface{}) error {
++	config := meta.(*transport_tpg.Config)
++	userAgent, err := generateUserAgentString(d, config.UserAgent)
++	if err != nil {
++		return err
++	}
++
++	id := d.Get("web_app_id").(string)
++
++	project, err := getProject(d, config)
++	if err != nil {
++		return err
++	}
++
++	url, err := ReplaceVars(d, config, "{{FirebaseBasePath}}projects/{{project}}/webApps/{{web_app_id}}/config")
++	if err != nil {
++		return err
++	}
++
++	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
++		Config:    config,
++		Method:    "GET",
++		Project:   project,
++		RawURL:    url,
++		UserAgent: userAgent,
++	})
++	if err != nil {
++		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("FirebaseWebApp config %q", d.Id()))
++	}
++
++	err = d.Set("api_key", res["apiKey"])
++	if err != nil {
++		return err
++	}
++	err = d.Set("auth_domain", res["authDomain"])
++	if err != nil {
++		return err
++	}
++	err = d.Set("database_url", res["databaseURL"])
++	if err != nil {
++		return err
++	}
++	err = d.Set("location_id", res["locationId"])
++	if err != nil {
++		return err
++	}
++	err = d.Set("measurement_id", res["measurementId"])
++	if err != nil {
++		return err
++	}
++	err = d.Set("messaging_sender_id", res["messagingSenderId"])
++	if err != nil {
++		return err
++	}
++	err = d.Set("storage_bucket", res["storageBucket"])
++	if err != nil {
++		return err
++	}
++
++	d.SetId(id)
++	return nil
++}
+diff --git b/google-beta/provider.go a/google-beta/provider.go
+index 166fc370d..a1fa7b427 100644
+--- b/google-beta/provider.go
++++ a/google-beta/provider.go
+@@ -122,6 +122,19 @@ func Provider() *schema.Provider {
+ 				Optional: true,
+ 			},
+ 
++			"google_partner_name": {
++				Type:     schema.TypeString,
++				Optional: true,
++			},
++
++			"disable_google_partner_name": {
++				Type:     schema.TypeBool,
++				Optional: true,
++				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
++					"GOOGLE_DISABLE_PARTNER_NAME",
++				}, nil),
++			},
++
+ 			"request_reason": {
+ 				Type:     schema.TypeString,
+ 				Optional: true,
+@@ -658,8 +671,158 @@ func Provider() *schema.Provider {
+ 			},
+ 		},
+ 
+-		DataSourcesMap: DatasourceMap(),
+-		ResourcesMap:   ResourceMap(),
++		DataSourcesMap: map[string]*schema.Resource{
++			// Reverted framework conversions
++			"google_client_config":             DataSourceGoogleClientConfigSdk(),
++			"google_client_openid_userinfo":    DataSourceGoogleClientOpenIDUserinfoSdk(),
++			"google_dns_keys":                  DataSourceDNSKeysSdk(),
++			"google_dns_managed_zone":          DataSourceDnsManagedZoneSdk(),
++			"google_dns_record_set":            DataSourceDnsRecordSetSdk(),
++			"google_firebase_apple_app_config": DataSourceGoogleFirebaseAppleAppConfigSdk(),
++			"google_firebase_web_app_config":   DataSourceGoogleFirebaseWebAppConfigSdk(),
++
++			// ####### START datasources ###########
++			"google_access_approval_folder_service_account":       DataSourceAccessApprovalFolderServiceAccount(),
++			"google_access_approval_organization_service_account": DataSourceAccessApprovalOrganizationServiceAccount(),
++			"google_access_approval_project_service_account":      DataSourceAccessApprovalProjectServiceAccount(),
++			"google_active_folder":                                DataSourceGoogleActiveFolder(),
++			"google_alloydb_locations":                            DataSourceAlloydbLocations(),
++			"google_alloydb_supported_database_flags":             DataSourceAlloydbSupportedDatabaseFlags(),
++			"google_artifact_registry_repository":                 DataSourceArtifactRegistryRepository(),
++			"google_app_engine_default_service_account":           DataSourceGoogleAppEngineDefaultServiceAccount(),
++			"google_beyondcorp_app_connection":                    DataSourceGoogleBeyondcorpAppConnection(),
++			"google_beyondcorp_app_connector":                     DataSourceGoogleBeyondcorpAppConnector(),
++			"google_beyondcorp_app_gateway":                       DataSourceGoogleBeyondcorpAppGateway(),
++			"google_billing_account":                              DataSourceGoogleBillingAccount(),
++			"google_bigquery_default_service_account":             DataSourceGoogleBigqueryDefaultServiceAccount(),
++			"google_cloudbuild_trigger":                           DataSourceGoogleCloudBuildTrigger(),
++			"google_cloudfunctions_function":                      DataSourceGoogleCloudFunctionsFunction(),
++			"google_cloudfunctions2_function":                     DataSourceGoogleCloudFunctions2Function(),
++			"google_cloud_asset_resources_search_all":             DataSourceGoogleCloudAssetResourcesSearchAll(),
++			"google_cloud_identity_groups":                        DataSourceGoogleCloudIdentityGroups(),
++			"google_cloud_identity_group_memberships":             DataSourceGoogleCloudIdentityGroupMemberships(),
++			"google_cloud_run_locations":                          DataSourceGoogleCloudRunLocations(),
++			"google_cloud_run_service":                            DataSourceGoogleCloudRunService(),
++			"google_composer_environment":                         DataSourceGoogleComposerEnvironment(),
++			"google_composer_image_versions":                      DataSourceGoogleComposerImageVersions(),
++			"google_compute_address":                              DataSourceGoogleComputeAddress(),
++			"google_compute_addresses":                            DataSourceGoogleComputeAddresses(),
++			"google_compute_backend_service":                      DataSourceGoogleComputeBackendService(),
++			"google_compute_backend_bucket":                       DataSourceGoogleComputeBackendBucket(),
++			"google_compute_default_service_account":              DataSourceGoogleComputeDefaultServiceAccount(),
++			"google_compute_disk":                                 DataSourceGoogleComputeDisk(),
++			"google_compute_forwarding_rule":                      DataSourceGoogleComputeForwardingRule(),
++			"google_compute_global_address":                       DataSourceGoogleComputeGlobalAddress(),
++			"google_compute_global_forwarding_rule":               DataSourceGoogleComputeGlobalForwardingRule(),
++			"google_compute_ha_vpn_gateway":                       DataSourceGoogleComputeHaVpnGateway(),
++			"google_compute_health_check":                         DataSourceGoogleComputeHealthCheck(),
++			"google_compute_image":                                DataSourceGoogleComputeImage(),
++			"google_compute_instance":                             DataSourceGoogleComputeInstance(),
++			"google_compute_instance_group":                       DataSourceGoogleComputeInstanceGroup(),
++			"google_compute_instance_group_manager":               DataSourceGoogleComputeInstanceGroupManager(),
++			"google_compute_instance_serial_port":                 DataSourceGoogleComputeInstanceSerialPort(),
++			"google_compute_instance_template":                    DataSourceGoogleComputeInstanceTemplate(),
++			"google_compute_lb_ip_ranges":                         DataSourceGoogleComputeLbIpRanges(),
++			"google_compute_network":                              DataSourceGoogleComputeNetwork(),
++			"google_compute_network_endpoint_group":               DataSourceGoogleComputeNetworkEndpointGroup(),
++			"google_compute_network_peering":                      DataSourceComputeNetworkPeering(),
++			"google_compute_node_types":                           DataSourceGoogleComputeNodeTypes(),
++			"google_compute_regions":                              DataSourceGoogleComputeRegions(),
++			"google_compute_region_network_endpoint_group":        DataSourceGoogleComputeRegionNetworkEndpointGroup(),
++			"google_compute_region_instance_group":                DataSourceGoogleComputeRegionInstanceGroup(),
++			"google_compute_region_instance_template":             DataSourceGoogleComputeRegionInstanceTemplate(),
++			"google_compute_region_ssl_certificate":               DataSourceGoogleRegionComputeSslCertificate(),
++			"google_compute_resource_policy":                      DataSourceGoogleComputeResourcePolicy(),
++			"google_compute_router":                               DataSourceGoogleComputeRouter(),
++			"google_compute_router_nat":                           DataSourceGoogleComputeRouterNat(),
++			"google_compute_router_status":                        DataSourceGoogleComputeRouterStatus(),
++			"google_compute_snapshot":                             DataSourceGoogleComputeSnapshot(),
++			"google_compute_ssl_certificate":                      DataSourceGoogleComputeSslCertificate(),
++			"google_compute_ssl_policy":                           DataSourceGoogleComputeSslPolicy(),
++			"google_compute_subnetwork":                           DataSourceGoogleComputeSubnetwork(),
++			"google_compute_vpn_gateway":                          DataSourceGoogleComputeVpnGateway(),
++			"google_compute_zones":                                DataSourceGoogleComputeZones(),
++			"google_container_azure_versions":                     DataSourceGoogleContainerAzureVersions(),
++			"google_container_aws_versions":                       DataSourceGoogleContainerAwsVersions(),
++			"google_container_attached_versions":                  DataSourceGoogleContainerAttachedVersions(),
++			"google_container_attached_install_manifest":          DataSourceGoogleContainerAttachedInstallManifest(),
++			"google_container_cluster":                            DataSourceGoogleContainerCluster(),
++			"google_container_engine_versions":                    DataSourceGoogleContainerEngineVersions(),
++			"google_container_registry_image":                     DataSourceGoogleContainerImage(),
++			"google_container_registry_repository":                DataSourceGoogleContainerRepo(),
++			"google_dataproc_metastore_service":                   DataSourceDataprocMetastoreService(),
++			"google_datastream_static_ips":                        DataSourceGoogleDatastreamStaticIps(),
++			"google_game_services_game_server_deployment_rollout": DataSourceGameServicesGameServerDeploymentRollout(),
++			"google_iam_policy":                                   DataSourceGoogleIamPolicy(),
++			"google_iam_role":                                     DataSourceGoogleIamRole(),
++			"google_iam_testable_permissions":                     DataSourceGoogleIamTestablePermissions(),
++			"google_iam_workload_identity_pool":                   DataSourceIAMBetaWorkloadIdentityPool(),
++			"google_iam_workload_identity_pool_provider":          DataSourceIAMBetaWorkloadIdentityPoolProvider(),
++			"google_iap_client":                                   DataSourceGoogleIapClient(),
++			"google_kms_crypto_key":                               DataSourceGoogleKmsCryptoKey(),
++			"google_kms_crypto_key_version":                       DataSourceGoogleKmsCryptoKeyVersion(),
++			"google_kms_key_ring":                                 DataSourceGoogleKmsKeyRing(),
++			"google_kms_secret":                                   DataSourceGoogleKmsSecret(),
++			"google_kms_secret_ciphertext":                        DataSourceGoogleKmsSecretCiphertext(),
++			"google_kms_secret_asymmetric":                        DataSourceGoogleKmsSecretAsymmetric(),
++			"google_firebase_android_app":                         DataSourceGoogleFirebaseAndroidApp(),
++			"google_firebase_apple_app":                           DataSourceGoogleFirebaseAppleApp(),
++			"google_firebase_hosting_channel":                     DataSourceGoogleFirebaseHostingChannel(),
++			"google_firebase_web_app":                             DataSourceGoogleFirebaseWebApp(),
++			"google_folder":                                       DataSourceGoogleFolder(),
++			"google_folders":                                      DataSourceGoogleFolders(),
++			"google_folder_organization_policy":                   DataSourceGoogleFolderOrganizationPolicy(),
++			"google_logging_project_cmek_settings":                DataSourceGoogleLoggingProjectCmekSettings(),
++			"google_logging_sink":                                 DataSourceGoogleLoggingSink(),
++			"google_monitoring_notification_channel":              DataSourceMonitoringNotificationChannel(),
++			"google_monitoring_cluster_istio_service":             DataSourceMonitoringServiceClusterIstio(),
++			"google_monitoring_istio_canonical_service":           DataSourceMonitoringIstioCanonicalService(),
++			"google_monitoring_mesh_istio_service":                DataSourceMonitoringServiceMeshIstio(),
++			"google_monitoring_app_engine_service":                DataSourceMonitoringServiceAppEngine(),
++			"google_monitoring_uptime_check_ips":                  DataSourceGoogleMonitoringUptimeCheckIps(),
++			"google_netblock_ip_ranges":                           DataSourceGoogleNetblockIpRanges(),
++			"google_organization":                                 DataSourceGoogleOrganization(),
++			"google_privateca_certificate_authority":              DataSourcePrivatecaCertificateAuthority(),
++			"google_project":                                      DataSourceGoogleProject(),
++			"google_projects":                                     DataSourceGoogleProjects(),
++			"google_project_organization_policy":                  DataSourceGoogleProjectOrganizationPolicy(),
++			"google_project_service":                              DataSourceGoogleProjectService(),
++			"google_pubsub_subscription":                          DataSourceGooglePubsubSubscription(),
++			"google_pubsub_topic":                                 DataSourceGooglePubsubTopic(),
++			"google_runtimeconfig_config":                         runtimeconfig.DataSourceGoogleRuntimeconfigConfig(),
++			"google_runtimeconfig_variable":                       runtimeconfig.DataSourceGoogleRuntimeconfigVariable(),
++			"google_secret_manager_secret":                        DataSourceSecretManagerSecret(),
++			"google_secret_manager_secret_version":                DataSourceSecretManagerSecretVersion(),
++			"google_secret_manager_secret_version_access":         DataSourceSecretManagerSecretVersionAccess(),
++			"google_service_account":                              DataSourceGoogleServiceAccount(),
++			"google_service_account_access_token":                 DataSourceGoogleServiceAccountAccessToken(),
++			"google_service_account_id_token":                     DataSourceGoogleServiceAccountIdToken(),
++			"google_service_account_jwt":                          DataSourceGoogleServiceAccountJwt(),
++			"google_service_account_key":                          DataSourceGoogleServiceAccountKey(),
++			"google_sourcerepo_repository":                        DataSourceGoogleSourceRepoRepository(),
++			"google_spanner_instance":                             DataSourceSpannerInstance(),
++			"google_sql_ca_certs":                                 DataSourceGoogleSQLCaCerts(),
++			"google_sql_tiers":                                    DataSourceGoogleSQLTiers(),
++			"google_sql_backup_run":                               DataSourceSqlBackupRun(),
++			"google_sql_databases":                                DataSourceSqlDatabases(),
++			"google_sql_database":                                 DataSourceSqlDatabase(),
++			"google_sql_database_instance":                        DataSourceSqlDatabaseInstance(),
++			"google_sql_database_instances":                       DataSourceSqlDatabaseInstances(),
++			"google_service_networking_peered_dns_domain":         DataSourceGoogleServiceNetworkingPeeredDNSDomain(),
++			"google_storage_bucket":                               DataSourceGoogleStorageBucket(),
++			"google_storage_bucket_object":                        DataSourceGoogleStorageBucketObject(),
++			"google_storage_bucket_object_content":                DataSourceGoogleStorageBucketObjectContent(),
++			"google_storage_object_signed_url":                    DataSourceGoogleSignedUrl(),
++			"google_storage_project_service_account":              DataSourceGoogleStorageProjectServiceAccount(),
++			"google_storage_transfer_project_service_account":     DataSourceGoogleStorageTransferProjectServiceAccount(),
++			"google_tags_tag_key":                                 DataSourceGoogleTagsTagKey(),
++			"google_tags_tag_value":                               DataSourceGoogleTagsTagValue(),
++			"google_tpu_tensorflow_versions":                      DataSourceTpuTensorflowVersions(),
++			"google_vpc_access_connector":                         DataSourceVPCAccessConnector(),
++			"google_redis_instance":                               DataSourceGoogleRedisInstance(),
++			// ####### END datasources ###########
++		},
++		ResourcesMap: ResourceMap(),
+ 	}
+ 
+ 	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+@@ -1671,6 +1834,21 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
+ 		UserAgent:           p.UserAgent("terraform-provider-google-beta", version.ProviderVersion),
+ 	}
+ 
++	disablePartnerName := d.Get("disable_google_partner_name").(bool)
++	userSpecifiedPartnerName := d.Get("google_partner_name")
++
++	partnerString := ""
++	if !disablePartnerName {
++		if userSpecifiedPartnerName != "" {
++			partnerString = fmt.Sprintf("GPN:%s; ", userSpecifiedPartnerName)
++		} else {
++			partnerString = "GPN:Pulumi; "
++		}
++	}
++	userAgent := fmt.Sprintf("Pulumi/3.0 (%shttps://www.pulumi.com) pulumi-gcp/%s", partnerString, version.ProviderVersion)
++
++	config.UserAgent = userAgent
++
+ 	// opt in extension for adding to the User-Agent header
+ 	if ext := os.Getenv("GOOGLE_TERRAFORM_USERAGENT_EXTENSION"); ext != "" {
+ 		ua := config.UserAgent
+diff --git b/google-beta/resource_bigquery_dataset.go a/google-beta/resource_bigquery_dataset.go
+index bf74e519f..1adc44d88 100644
+--- b/google-beta/resource_bigquery_dataset.go
++++ a/google-beta/resource_bigquery_dataset.go
+@@ -635,8 +635,13 @@ func resourceBigQueryDatasetRead(d *schema.ResourceData, meta interface{}) error
+ 	if err := d.Set("default_collation", flattenBigQueryDatasetDefaultCollation(res["defaultCollation"], d, config)); err != nil {
+ 		return fmt.Errorf("Error reading Dataset: %s", err)
+ 	}
+-	if err := d.Set("self_link", tpgresource.ConvertSelfLinkToV1(res["selfLink"].(string))); err != nil {
+-		return fmt.Errorf("Error reading Dataset: %s", err)
++	if res["selfLink"] != nil {
++		if err := d.Set("self_link", tpgresource.ConvertSelfLinkToV1(res["selfLink"].(string))); err != nil {
++			return fmt.Errorf("Error reading Dataset: %s", err)
++		}
++	} else {
++		// we don't have a self_link so we set an empty string
++		d.Set("self_link", "")
+ 	}
+ 
+ 	return nil
+diff --git b/google-beta/resource_certificate_manager_certificate.go a/google-beta/resource_certificate_manager_certificate.go
+index eab200a3b..977238ef1 100644
+--- b/google-beta/resource_certificate_manager_certificate.go
++++ a/google-beta/resource_certificate_manager_certificate.go
+@@ -401,6 +401,9 @@ func resourceCertificateManagerCertificateRead(d *schema.ResourceData, meta inte
+ 	if err := d.Set("scope", flattenCertificateManagerCertificateScope(res["scope"], d, config)); err != nil {
+ 		return fmt.Errorf("Error reading Certificate: %s", err)
+ 	}
++	if err := d.Set("self_managed", flattenCertificateManagerCertificateSelfManaged(res["selfManaged"], d, config)); err != nil {
++		return fmt.Errorf("Error reading Certificate: %s", err)
++	}
+ 	if err := d.Set("managed", flattenCertificateManagerCertificateManaged(res["managed"], d, config)); err != nil {
+ 		return fmt.Errorf("Error reading Certificate: %s", err)
+ 	}
+@@ -576,6 +579,30 @@ func flattenCertificateManagerCertificateScope(v interface{}, d *schema.Resource
+ 	return v
+ }
+ 
++func flattenCertificateManagerCertificateSelfManaged(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
++	if v == nil {
++		return nil
++	}
++	original := v.(map[string]interface{})
++	if len(original) == 0 {
++		return nil
++	}
++	transformed := make(map[string]interface{})
++	transformed["certificate_pem"] =
++		flattenCertificateManagerCertificateSelfManagedCertificatePem(original["certificatePem"], d, config)
++	transformed["private_key_pem"] =
++		flattenCertificateManagerCertificateSelfManagedPrivateKeyPem(original["privateKeyPem"], d, config)
++	return []interface{}{transformed}
++}
++
++func flattenCertificateManagerCertificateSelfManagedCertificatePem(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
++	return v
++}
++
++func flattenCertificateManagerCertificateSelfManagedPrivateKeyPem(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
++	return v
++}
++
+ func flattenCertificateManagerCertificateManaged(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+ 	if v == nil {
+ 		return nil
+diff --git b/google-beta/resource_certificate_manager_certificate_generated_test.go a/google-beta/resource_certificate_manager_certificate_generated_test.go
+index f104c4117..a2b0e520e 100644
+--- b/google-beta/resource_certificate_manager_certificate_generated_test.go
++++ a/google-beta/resource_certificate_manager_certificate_generated_test.go
+@@ -158,11 +158,7 @@ resource "google_certificate_manager_certificate" "default" {
+   name        = "tf-test-self-managed-cert%{random_suffix}"
+   description = "Regional cert"
+   location    = "us-central1"
+-  self_managed {
+     pem_certificate = file("test-fixtures/certificatemanager/cert.pem")
+-    pem_private_key = file("test-fixtures/certificatemanager/private-key.pem")
+-  }
+-}
+ `, context)
+ }
+ 
+diff --git b/google-beta/resource_compute_disk.go a/google-beta/resource_compute_disk.go
+index 3d3d2f6ef..7d41bc047 100644
+--- b/google-beta/resource_compute_disk.go
++++ a/google-beta/resource_compute_disk.go
+@@ -1487,8 +1487,6 @@ func flattenComputeDiskSourceImageEncryptionKey(v interface{}, d *schema.Resourc
+ 		flattenComputeDiskSourceImageEncryptionKeySha256(original["sha256"], d, config)
+ 	transformed["kms_key_self_link"] =
+ 		flattenComputeDiskSourceImageEncryptionKeyKmsKeySelfLink(original["kmsKeyName"], d, config)
+-	transformed["kms_key_service_account"] =
+-		flattenComputeDiskSourceImageEncryptionKeyKmsKeyServiceAccount(original["kmsKeyServiceAccount"], d, config)
+ 	return []interface{}{transformed}
+ }
+ func flattenComputeDiskSourceImageEncryptionKeyRawKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+@@ -1503,10 +1501,6 @@ func flattenComputeDiskSourceImageEncryptionKeyKmsKeySelfLink(v interface{}, d *
+ 	return v
+ }
+ 
+-func flattenComputeDiskSourceImageEncryptionKeyKmsKeyServiceAccount(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+-	return v
+-}
+-
+ func flattenComputeDiskSourceImageId(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+ 	return v
+ }
+@@ -1528,8 +1522,6 @@ func flattenComputeDiskDiskEncryptionKey(v interface{}, d *schema.ResourceData,
+ 		flattenComputeDiskDiskEncryptionKeySha256(original["sha256"], d, config)
+ 	transformed["kms_key_self_link"] =
+ 		flattenComputeDiskDiskEncryptionKeyKmsKeySelfLink(original["kmsKeyName"], d, config)
+-	transformed["kms_key_service_account"] =
+-		flattenComputeDiskDiskEncryptionKeyKmsKeyServiceAccount(original["kmsKeyServiceAccount"], d, config)
+ 	return []interface{}{transformed}
+ }
+ func flattenComputeDiskDiskEncryptionKeyRawKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+@@ -1548,10 +1540,6 @@ func flattenComputeDiskDiskEncryptionKeyKmsKeySelfLink(v interface{}, d *schema.
+ 	return v
+ }
+ 
+-func flattenComputeDiskDiskEncryptionKeyKmsKeyServiceAccount(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+-	return v
+-}
+-
+ func flattenComputeDiskSnapshot(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+ 	if v == nil {
+ 		return v
+@@ -1574,8 +1562,6 @@ func flattenComputeDiskSourceSnapshotEncryptionKey(v interface{}, d *schema.Reso
+ 		flattenComputeDiskSourceSnapshotEncryptionKeyKmsKeySelfLink(original["kmsKeyName"], d, config)
+ 	transformed["sha256"] =
+ 		flattenComputeDiskSourceSnapshotEncryptionKeySha256(original["sha256"], d, config)
+-	transformed["kms_key_service_account"] =
+-		flattenComputeDiskSourceSnapshotEncryptionKeyKmsKeyServiceAccount(original["kmsKeyServiceAccount"], d, config)
+ 	return []interface{}{transformed}
+ }
+ func flattenComputeDiskSourceSnapshotEncryptionKeyRawKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+@@ -1590,10 +1576,6 @@ func flattenComputeDiskSourceSnapshotEncryptionKeySha256(v interface{}, d *schem
+ 	return v
+ }
+ 
+-func flattenComputeDiskSourceSnapshotEncryptionKeyKmsKeyServiceAccount(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+-	return v
+-}
+-
+ func flattenComputeDiskSourceSnapshotId(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+ 	return v
+ }
+@@ -1773,13 +1755,6 @@ func expandComputeDiskSourceImageEncryptionKey(v interface{}, d tpgresource.Terr
+ 		transformed["kmsKeyName"] = transformedKmsKeySelfLink
+ 	}
+ 
+-	transformedKmsKeyServiceAccount, err := expandComputeDiskSourceImageEncryptionKeyKmsKeyServiceAccount(original["kms_key_service_account"], d, config)
+-	if err != nil {
+-		return nil, err
+-	} else if val := reflect.ValueOf(transformedKmsKeyServiceAccount); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+-		transformed["kmsKeyServiceAccount"] = transformedKmsKeyServiceAccount
+-	}
+-
+ 	return transformed, nil
+ }
+ 
+@@ -1795,10 +1770,6 @@ func expandComputeDiskSourceImageEncryptionKeyKmsKeySelfLink(v interface{}, d tp
+ 	return v, nil
+ }
+ 
+-func expandComputeDiskSourceImageEncryptionKeyKmsKeyServiceAccount(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	return v, nil
+-}
+-
+ func expandComputeDiskDiskEncryptionKey(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+ 	l := v.([]interface{})
+ 	if len(l) == 0 || l[0] == nil {
+@@ -1836,13 +1807,6 @@ func expandComputeDiskDiskEncryptionKey(v interface{}, d tpgresource.TerraformRe
+ 		transformed["kmsKeyName"] = transformedKmsKeySelfLink
+ 	}
+ 
+-	transformedKmsKeyServiceAccount, err := expandComputeDiskDiskEncryptionKeyKmsKeyServiceAccount(original["kms_key_service_account"], d, config)
+-	if err != nil {
+-		return nil, err
+-	} else if val := reflect.ValueOf(transformedKmsKeyServiceAccount); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+-		transformed["kmsKeyServiceAccount"] = transformedKmsKeyServiceAccount
+-	}
+-
+ 	return transformed, nil
+ }
+ 
+@@ -1862,12 +1826,8 @@ func expandComputeDiskDiskEncryptionKeyKmsKeySelfLink(v interface{}, d tpgresour
+ 	return v, nil
+ }
+ 
+-func expandComputeDiskDiskEncryptionKeyKmsKeyServiceAccount(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	return v, nil
+-}
+-
+ func expandComputeDiskSnapshot(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	f, err := tpgresource.ParseGlobalFieldValue("snapshots", v.(string), "project", d, config, true)
++	f, err := parseGlobalFieldValue("snapshots", v.(string), "project", d, config, true)
+ 	if err != nil {
+ 		return nil, fmt.Errorf("Invalid value for snapshot: %s", err)
+ 	}
+@@ -1904,13 +1864,6 @@ func expandComputeDiskSourceSnapshotEncryptionKey(v interface{}, d tpgresource.T
+ 		transformed["sha256"] = transformedSha256
+ 	}
+ 
+-	transformedKmsKeyServiceAccount, err := expandComputeDiskSourceSnapshotEncryptionKeyKmsKeyServiceAccount(original["kms_key_service_account"], d, config)
+-	if err != nil {
+-		return nil, err
+-	} else if val := reflect.ValueOf(transformedKmsKeyServiceAccount); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+-		transformed["kmsKeyServiceAccount"] = transformedKmsKeyServiceAccount
+-	}
+-
+ 	return transformed, nil
+ }
+ 
+@@ -1926,10 +1879,6 @@ func expandComputeDiskSourceSnapshotEncryptionKeySha256(v interface{}, d tpgreso
+ 	return v, nil
+ }
+ 
+-func expandComputeDiskSourceSnapshotEncryptionKeyKmsKeyServiceAccount(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	return v, nil
+-}
+-
+ func resourceComputeDiskEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
+ 	config := meta.(*transport_tpg.Config)
+ 
+diff --git b/google-beta/resource_compute_region_backend_service.go a/google-beta/resource_compute_region_backend_service.go
+index 40ada2286..430d58ff1 100644
+--- b/google-beta/resource_compute_region_backend_service.go
++++ a/google-beta/resource_compute_region_backend_service.go
+@@ -960,7 +960,7 @@ If it is not provided, the provider region is used.`,
+ 				Optional:     true,
+ 				ValidateFunc: verify.ValidateEnum([]string{"NONE", "CLIENT_IP", "CLIENT_IP_PORT_PROTO", "CLIENT_IP_PROTO", "GENERATED_COOKIE", "HEADER_FIELD", "HTTP_COOKIE", "CLIENT_IP_NO_DESTINATION", ""}),
+ 				Description: `Type of session affinity to use. The default is NONE. Session affinity is
+-not applicable if the protocol is UDP. Possible values: ["NONE", "CLIENT_IP", "CLIENT_IP_PORT_PROTO", "CLIENT_IP_PROTO", "GENERATED_COOKIE", "HEADER_FIELD", "HTTP_COOKIE", "CLIENT_IP_NO_DESTINATION"]`,
++not applicable if the protocol is UDP. Possible values: ["NONE", "CLIENT_IP", "CLIENT_IP_PORT_PROTO", "CLIENT_IP_PROTO", "GENERATED_COOKIE", "HEADER_FIELD", "HTTP_COOKIE"]`,
+ 			},
+ 			"subsetting": {
+ 				Type:        schema.TypeList,
+@@ -1273,12 +1273,6 @@ func resourceComputeRegionBackendServiceCreate(d *schema.ResourceData, meta inte
+ 	} else if v, ok := d.GetOkExists("session_affinity"); !tpgresource.IsEmptyValue(reflect.ValueOf(sessionAffinityProp)) && (ok || !reflect.DeepEqual(v, sessionAffinityProp)) {
+ 		obj["sessionAffinity"] = sessionAffinityProp
+ 	}
+-	connectionTrackingPolicyProp, err := expandComputeRegionBackendServiceConnectionTrackingPolicy(d.Get("connection_tracking_policy"), d, config)
+-	if err != nil {
+-		return err
+-	} else if v, ok := d.GetOkExists("connection_tracking_policy"); !tpgresource.IsEmptyValue(reflect.ValueOf(connectionTrackingPolicyProp)) && (ok || !reflect.DeepEqual(v, connectionTrackingPolicyProp)) {
+-		obj["connectionTrackingPolicy"] = connectionTrackingPolicyProp
+-	}
+ 	timeoutSecProp, err := expandComputeRegionBackendServiceTimeoutSec(d.Get("timeout_sec"), d, config)
+ 	if err != nil {
+ 		return err
+@@ -1493,9 +1487,6 @@ func resourceComputeRegionBackendServiceRead(d *schema.ResourceData, meta interf
+ 	if err := d.Set("session_affinity", flattenComputeRegionBackendServiceSessionAffinity(res["sessionAffinity"], d, config)); err != nil {
+ 		return fmt.Errorf("Error reading RegionBackendService: %s", err)
+ 	}
+-	if err := d.Set("connection_tracking_policy", flattenComputeRegionBackendServiceConnectionTrackingPolicy(res["connectionTrackingPolicy"], d, config)); err != nil {
+-		return fmt.Errorf("Error reading RegionBackendService: %s", err)
+-	}
+ 	if err := d.Set("timeout_sec", flattenComputeRegionBackendServiceTimeoutSec(res["timeoutSec"], d, config)); err != nil {
+ 		return fmt.Errorf("Error reading RegionBackendService: %s", err)
+ 	}
+@@ -1648,12 +1639,6 @@ func resourceComputeRegionBackendServiceUpdate(d *schema.ResourceData, meta inte
+ 	} else if v, ok := d.GetOkExists("session_affinity"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, sessionAffinityProp)) {
+ 		obj["sessionAffinity"] = sessionAffinityProp
+ 	}
+-	connectionTrackingPolicyProp, err := expandComputeRegionBackendServiceConnectionTrackingPolicy(d.Get("connection_tracking_policy"), d, config)
+-	if err != nil {
+-		return err
+-	} else if v, ok := d.GetOkExists("connection_tracking_policy"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, connectionTrackingPolicyProp)) {
+-		obj["connectionTrackingPolicy"] = connectionTrackingPolicyProp
+-	}
+ 	timeoutSecProp, err := expandComputeRegionBackendServiceTimeoutSec(d.Get("timeout_sec"), d, config)
+ 	if err != nil {
+ 		return err
+@@ -3917,51 +3902,6 @@ func expandComputeRegionBackendServiceSessionAffinity(v interface{}, d tpgresour
+ 	return v, nil
+ }
+ 
+-func expandComputeRegionBackendServiceConnectionTrackingPolicy(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	l := v.([]interface{})
+-	if len(l) == 0 || l[0] == nil {
+-		return nil, nil
+-	}
+-	raw := l[0]
+-	original := raw.(map[string]interface{})
+-	transformed := make(map[string]interface{})
+-
+-	transformedIdleTimeoutSec, err := expandComputeRegionBackendServiceConnectionTrackingPolicyIdleTimeoutSec(original["idle_timeout_sec"], d, config)
+-	if err != nil {
+-		return nil, err
+-	} else if val := reflect.ValueOf(transformedIdleTimeoutSec); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+-		transformed["idleTimeoutSec"] = transformedIdleTimeoutSec
+-	}
+-
+-	transformedTrackingMode, err := expandComputeRegionBackendServiceConnectionTrackingPolicyTrackingMode(original["tracking_mode"], d, config)
+-	if err != nil {
+-		return nil, err
+-	} else if val := reflect.ValueOf(transformedTrackingMode); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+-		transformed["trackingMode"] = transformedTrackingMode
+-	}
+-
+-	transformedConnectionPersistenceOnUnhealthyBackends, err := expandComputeRegionBackendServiceConnectionTrackingPolicyConnectionPersistenceOnUnhealthyBackends(original["connection_persistence_on_unhealthy_backends"], d, config)
+-	if err != nil {
+-		return nil, err
+-	} else if val := reflect.ValueOf(transformedConnectionPersistenceOnUnhealthyBackends); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+-		transformed["connectionPersistenceOnUnhealthyBackends"] = transformedConnectionPersistenceOnUnhealthyBackends
+-	}
+-
+-	return transformed, nil
+-}
+-
+-func expandComputeRegionBackendServiceConnectionTrackingPolicyIdleTimeoutSec(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	return v, nil
+-}
+-
+-func expandComputeRegionBackendServiceConnectionTrackingPolicyTrackingMode(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	return v, nil
+-}
+-
+-func expandComputeRegionBackendServiceConnectionTrackingPolicyConnectionPersistenceOnUnhealthyBackends(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+-	return v, nil
+-}
+-
+ func expandComputeRegionBackendServiceTimeoutSec(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+ 	return v, nil
+ }
+diff --git b/google-beta/resource_compute_security_policy.go a/google-beta/resource_compute_security_policy.go
+index 9b0a2f1cb..f1e568f1a 100644
+--- b/google-beta/resource_compute_security_policy.go
++++ a/google-beta/resource_compute_security_policy.go
+@@ -114,7 +114,6 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
+ 									"versioned_expr": {
+ 										Type:         schema.TypeString,
+ 										Optional:     true,
+-										Default:      "",
+ 										ValidateFunc: validation.StringInSlice([]string{"SRC_IPS_V1"}, false),
+ 										Description:  `Predefined rule expression. If this field is specified, config must also be specified. Available options:   SRC_IPS_V1: Must specify the corresponding src_ip_ranges field in config.`,
+ 									},
+diff --git b/google-beta/resource_dataproc_cluster.go a/google-beta/resource_dataproc_cluster.go
+index fca15f4d3..05e022564 100644
+--- b/google-beta/resource_dataproc_cluster.go
++++ a/google-beta/resource_dataproc_cluster.go
+@@ -61,8 +61,6 @@ var (
+ 		"cluster_config.0.gce_cluster_config.0.internal_ip_only",
+ 		"cluster_config.0.gce_cluster_config.0.shielded_instance_config",
+ 		"cluster_config.0.gce_cluster_config.0.metadata",
+-		"cluster_config.0.gce_cluster_config.0.reservation_affinity",
+-		"cluster_config.0.gce_cluster_config.0.node_group_affinity",
+ 	}
+ 
+ 	schieldedInstanceConfigKeys = []string{
+@@ -71,12 +69,6 @@ var (
+ 		"cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_integrity_monitoring",
+ 	}
+ 
+-	reservationAffinityKeys = []string{
+-		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.consume_reservation_type",
+-		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.key",
+-		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.values",
+-	}
+-
+ 	preemptibleWorkerDiskConfigKeys = []string{
+ 		"cluster_config.0.preemptible_worker_config.0.disk_config.0.num_local_ssds",
+ 		"cluster_config.0.preemptible_worker_config.0.disk_config.0.boot_disk_size_gb",
+@@ -650,62 +642,6 @@ func ResourceDataprocCluster() *schema.Resource {
+ 											},
+ 										},
+ 									},
+-
+-									"reservation_affinity": {
+-										Type:         schema.TypeList,
+-										Optional:     true,
+-										AtLeastOneOf: gceClusterConfigKeys,
+-										Computed:     true,
+-										MaxItems:     1,
+-										Description:  `Reservation Affinity for consuming Zonal reservation.`,
+-										Elem: &schema.Resource{
+-											Schema: map[string]*schema.Schema{
+-												"consume_reservation_type": {
+-													Type:         schema.TypeString,
+-													Optional:     true,
+-													AtLeastOneOf: reservationAffinityKeys,
+-													ForceNew:     true,
+-													ValidateFunc: validation.StringInSlice([]string{"NO_RESERVATION", "ANY_RESERVATION", "SPECIFIC_RESERVATION"}, false),
+-													Description:  `Type of reservation to consume.`,
+-												},
+-												"key": {
+-													Type:         schema.TypeString,
+-													Optional:     true,
+-													AtLeastOneOf: reservationAffinityKeys,
+-													ForceNew:     true,
+-													Description:  `Corresponds to the label key of reservation resource.`,
+-												},
+-												"values": {
+-													Type:         schema.TypeSet,
+-													Elem:         &schema.Schema{Type: schema.TypeString},
+-													Optional:     true,
+-													AtLeastOneOf: reservationAffinityKeys,
+-													ForceNew:     true,
+-													Description:  `Corresponds to the label values of reservation resource.`,
+-												},
+-											},
+-										},
+-									},
+-
+-									"node_group_affinity": {
+-										Type:         schema.TypeList,
+-										Optional:     true,
+-										AtLeastOneOf: gceClusterConfigKeys,
+-										Computed:     true,
+-										MaxItems:     1,
+-										Description:  `Node Group Affinity for sole-tenant clusters.`,
+-										Elem: &schema.Resource{
+-											Schema: map[string]*schema.Schema{
+-												"node_group_uri": {
+-													Type:             schema.TypeString,
+-													ForceNew:         true,
+-													Required:         true,
+-													Description:      `The URI of a sole-tenant that the cluster will be created on.`,
+-													DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+-												},
+-											},
+-										},
+-									},
+ 								},
+ 							},
+ 						},
+@@ -1682,26 +1618,6 @@ func expandGceClusterConfig(d *schema.ResourceData, config *transport_tpg.Config
+ 			conf.ShieldedInstanceConfig.EnableVtpm = v.(bool)
+ 		}
+ 	}
+-	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.reservation_affinity"); ok {
+-		cfgRa := v.([]interface{})[0].(map[string]interface{})
+-		conf.ReservationAffinity = &dataproc.ReservationAffinity{}
+-		if v, ok := cfgRa["consume_reservation_type"]; ok {
+-			conf.ReservationAffinity.ConsumeReservationType = v.(string)
+-		}
+-		if v, ok := cfgRa["key"]; ok {
+-			conf.ReservationAffinity.Key = v.(string)
+-		}
+-		if v, ok := cfgRa["values"]; ok {
+-			conf.ReservationAffinity.Values = convertStringSet(v.(*schema.Set))
+-		}
+-	}
+-	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.node_group_affinity"); ok {
+-		cfgNga := v.([]interface{})[0].(map[string]interface{})
+-		conf.NodeGroupAffinity = &dataproc.NodeGroupAffinity{}
+-		if v, ok := cfgNga["node_group_uri"]; ok {
+-			conf.NodeGroupAffinity.NodeGroupUri = v.(string)
+-		}
+-	}
+ 	return conf, nil
+ }
+ 
+@@ -2457,22 +2373,6 @@ func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterCon
+ 			},
+ 		}
+ 	}
+-	if gcc.ReservationAffinity != nil {
+-		gceConfig["reservation_affinity"] = []map[string]interface{}{
+-			{
+-				"consume_reservation_type": gcc.ReservationAffinity.ConsumeReservationType,
+-				"key":                      gcc.ReservationAffinity.Key,
+-				"values":                   gcc.ReservationAffinity.Values,
+-			},
+-		}
+-	}
+-	if gcc.NodeGroupAffinity != nil {
+-		gceConfig["node_group_affinity"] = []map[string]interface{}{
+-			{
+-				"node_group_uri": gcc.NodeGroupAffinity.NodeGroupUri,
+-			},
+-		}
+-	}
+ 
+ 	return []map[string]interface{}{gceConfig}
+ }
+diff --git b/google-beta/resource_sql_database_instance.go a/google-beta/resource_sql_database_instance.go
+index 65b6c7453..bb85fb05c 100644
+--- b/google-beta/resource_sql_database_instance.go
++++ a/google-beta/resource_sql_database_instance.go
+@@ -1851,6 +1851,10 @@ func resourceSqlDatabaseInstanceImport(d *schema.ResourceData, meta interface{})
+ }
+ 
+ func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
++	if settings == nil {
++		return nil
++	}
++
+ 	data := map[string]interface{}{
+ 		"version":                     settings.SettingsVersion,
+ 		"tier":                        settings.Tier,
+@@ -1922,6 +1926,10 @@ func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
+ }
+ 
+ func flattenBackupConfiguration(backupConfiguration *sqladmin.BackupConfiguration) []map[string]interface{} {
++	if backupConfiguration == nil {
++		return nil
++	}
++
+ 	data := map[string]interface{}{
+ 		"binary_log_enabled":             backupConfiguration.BinaryLogEnabled,
+ 		"enabled":                        backupConfiguration.Enabled,
+@@ -2014,6 +2022,10 @@ func flattenDatabaseFlags(databaseFlags []*sqladmin.DatabaseFlags) []map[string]
+ }
+ 
+ func flattenIpConfiguration(ipConfiguration *sqladmin.IpConfiguration) interface{} {
++	if ipConfiguration == nil {
++		return nil
++	}
++
+ 	data := map[string]interface{}{
+ 		"ipv4_enabled":       ipConfiguration.Ipv4Enabled,
+ 		"private_network":    ipConfiguration.PrivateNetwork,
+@@ -2046,6 +2058,10 @@ func flattenAuthorizedNetworks(entries []*sqladmin.AclEntry) interface{} {
+ }
+ 
+ func flattenLocationPreference(locationPreference *sqladmin.LocationPreference) interface{} {
++	if locationPreference == nil {
++		return nil
++	}
++
+ 	data := map[string]interface{}{
+ 		"follow_gae_application": locationPreference.FollowGaeApplication,
+ 		"zone":                   locationPreference.Zone,
+@@ -2056,6 +2072,10 @@ func flattenLocationPreference(locationPreference *sqladmin.LocationPreference)
+ }
+ 
+ func flattenMaintenanceWindow(maintenanceWindow *sqladmin.MaintenanceWindow) interface{} {
++	if maintenanceWindow == nil {
++		return nil
++	}
++
+ 	data := map[string]interface{}{
+ 		"day":          maintenanceWindow.Day,
+ 		"hour":         maintenanceWindow.Hour,
+@@ -2130,6 +2150,10 @@ func flattenServerCaCerts(caCerts []*sqladmin.SslCert) []map[string]interface{}
+ }
+ 
+ func flattenInsightsConfig(insightsConfig *sqladmin.InsightsConfig) interface{} {
++	if insightsConfig == nil {
++		return nil
++	}
++
+ 	data := map[string]interface{}{
+ 		"query_insights_enabled":  insightsConfig.QueryInsightsEnabled,
+ 		"query_string_length":     insightsConfig.QueryStringLength,
+diff --git b/google-beta/transport/config.go a/google-beta/transport/config.go
+index 9aaf68845..b7a68b305 100644
+--- b/google-beta/transport/config.go
++++ a/google-beta/transport/config.go
+@@ -41,7 +41,7 @@ import (
+ 	"google.golang.org/api/cloudkms/v1"
+ 	"google.golang.org/api/cloudresourcemanager/v1"
+ 	resourceManagerV3 "google.golang.org/api/cloudresourcemanager/v3"
+-	"google.golang.org/api/composer/v1beta1"
++	composer "google.golang.org/api/composer/v1beta1"
+ 	compute "google.golang.org/api/compute/v0.beta"
+ 	container "google.golang.org/api/container/v1beta1"
+ 	dataflow "google.golang.org/api/dataflow/v1b3"
+@@ -181,7 +181,7 @@ type Config struct {
+ 	UserAgent          string
+ 	gRPCLoggingOptions []option.ClientOption
+ 
+-	tokenSource oauth2.TokenSource
++	TokenSource oauth2.TokenSource
+ 
+ 	AccessApprovalBasePath           string
+ 	AccessContextManagerBasePath     string
+@@ -1193,7 +1193,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
+ 		return err
+ 	}
+ 
+-	c.tokenSource = tokenSource
++	c.TokenSource = tokenSource
+ 
+ 	cleanCtx := context.WithValue(ctx, oauth2.HTTPClient, cleanhttp.DefaultClient())
+ 
+@@ -1819,7 +1819,7 @@ func (c *Config) NewCloudIdentityClient(userAgent string) *cloudidentity.Service
+ func (c *Config) BigTableClientFactory(userAgent string) *BigtableClientFactory {
+ 	bigtableClientFactory := &BigtableClientFactory{
+ 		UserAgent:           userAgent,
+-		TokenSource:         c.tokenSource,
++		TokenSource:         c.TokenSource,
+ 		gRPCLoggingOptions:  c.gRPCLoggingOptions,
+ 		BillingProject:      c.BillingProject,
+ 		UserProjectOverride: c.UserProjectOverride,
+diff --git b/google-beta/utils.go a/google-beta/utils.go
+index b1537f630..f207fe180 100644
+--- b/google-beta/utils.go
++++ a/google-beta/utils.go
+@@ -284,10 +284,10 @@ func changeFieldSchemaToForceNew(sch *schema.Schema) {
+ 	tpgresource.ChangeFieldSchemaToForceNew(sch)
+ }
+ 
+-// Deprecated: For backward compatibility generateUserAgentString is still working,
+-// but all new code should use GenerateUserAgentString in the tpgresource package instead.
+ func generateUserAgentString(d tpgresource.TerraformResourceData, currentUserAgent string) (string, error) {
+-	return tpgresource.GenerateUserAgentString(d, currentUserAgent)
++	// we don't want to append the name of the module here as it doesn't make any sense to
++	// do this with the pulumi provider
++	return currentUserAgent, nil
+ }
+ 
+ // Deprecated: For backward compatibility snakeToPascalCase is still working,
+diff --git b/scripts/diff.go a/scripts/diff.go
+deleted file mode 100644
+index 7bc48c400..000000000
+--- b/scripts/diff.go
++++ /dev/null
+@@ -1,173 +0,0 @@
+-// Copyright (c) HashiCorp, Inc.
+-// SPDX-License-Identifier: MPL-2.0
+-package main
+-
+-import (
+-	"flag"
+-	"fmt"
+-	"reflect"
+-	"runtime"
+-	"sort"
+-	"strings"
+-
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+-	googleOld "github.com/hashicorp/terraform-provider-clean-google-beta/google-beta"
+-	google "github.com/hashicorp/terraform-provider-google-beta/google-beta"
+-)
+-
+-var verbose bool
+-var vFlag = flag.Bool("verbose", false, "set to true to produce more verbose diffs")
+-var resourceFlag = flag.String("resource", "", "the name of the terraform resource to diff")
+-
+-func main() {
+-	flag.Parse()
+-	if resourceFlag == nil || *resourceFlag == "" {
+-		fmt.Print("resource flag not specified\n")
+-		panic("the resource to diff must be specified")
+-	}
+-	resourceName := *resourceFlag
+-	verbose = *vFlag
+-	m := google.ResourceMap()
+-	res, ok := m[resourceName]
+-	if !ok {
+-		panic(fmt.Sprintf("Unable to find resource in TPGB: %s", resourceName))
+-	}
+-	m2 := googleOld.ResourceMap()
+-	res2, ok := m2[resourceName]
+-	if !ok {
+-		panic(fmt.Sprintf("Unable to find resource in clean TPGB: %s", resourceName))
+-	}
+-	fmt.Printf("------------Diffing resource %s------------\n", resourceName)
+-	diffSchema(res2.Schema, res.Schema, []string{})
+-	fmt.Print("------------Done------------\n")
+-}
+-
+-// Diffs a Terraform resource schema. Calls itself recursively as some fields
+-// are implemented using schema.Resource as their element type
+-func diffSchema(old, new map[string]*schema.Schema, path []string) {
+-	var sharedKeys []string
+-	var addedKeys []string
+-	for k := range new {
+-		if _, ok := old[k]; ok {
+-			sharedKeys = append(sharedKeys, k)
+-		} else {
+-			// Key not found in old schema
+-			addedKeys = append(addedKeys, k)
+-		}
+-	}
+-	var missingKeys []string
+-	for k := range old {
+-		if _, ok := new[k]; !ok {
+-			missingKeys = append(missingKeys, k)
+-		}
+-	}
+-	sort.Strings(sharedKeys)
+-	sort.Strings(addedKeys)
+-	sort.Strings(missingKeys)
+-	if len(addedKeys) != 0 {
+-		var qualifiedKeys []string
+-		for _, k := range addedKeys {
+-			qualifiedKeys = append(qualifiedKeys, strings.Join(append(path, k), "."))
+-		}
+-		fmt.Printf("Fields added in tpgtools: %v\n", qualifiedKeys)
+-	}
+-	if len(missingKeys) != 0 {
+-		var qualifiedKeys []string
+-		for _, k := range missingKeys {
+-			qualifiedKeys = append(qualifiedKeys, strings.Join(append(path, k), "."))
+-		}
+-		fmt.Printf("Fields missing in tpgtools: %v\n", qualifiedKeys)
+-	}
+-	for _, k := range sharedKeys {
+-		diffSchemaObject(old[k], new[k], append(path, k))
+-	}
+-}
+-
+-// Diffs a schema.Schema object. Calls itself and diffSchema recursively as
+-// needed on nested fields.
+-func diffSchemaObject(old, new *schema.Schema, path []string) {
+-	if old.Required != new.Required {
+-		fmt.Printf("Required status different for path %s, was: %t is now %t\n", strings.Join(path, "."), old.Required, new.Required)
+-	}
+-	if old.Computed != new.Computed {
+-		fmt.Printf("Computed status different for path %s, was: %t is now %t\n", strings.Join(path, "."), old.Computed, new.Computed)
+-	}
+-	if old.Optional != new.Optional {
+-		fmt.Printf("Optional status different for path %s, was: %t is now %t\n", strings.Join(path, "."), old.Optional, new.Optional)
+-	}
+-	if old.ForceNew != new.ForceNew {
+-		fmt.Printf("ForceNew status different for path %s, was: %t is now %t\n", strings.Join(path, "."), old.ForceNew, new.ForceNew)
+-	}
+-	if old.Type != new.Type {
+-		fmt.Printf("Type different for path %s, was: %s is now %s\n", strings.Join(path, "."), old.Type, new.Type)
+-		// Types are different, other diffs won't make sense
+-		return
+-	}
+-	if old.Sensitive != new.Sensitive {
+-		fmt.Printf("Sensitive status different for path %s, was: %t is now %t\n", strings.Join(path, "."), old.Sensitive, new.Sensitive)
+-	}
+-	if old.Deprecated != new.Deprecated {
+-		fmt.Printf("Deprecated status different for path %s, was: %s is now %s\n", strings.Join(path, "."), old.Deprecated, new.Deprecated)
+-	}
+-	if old.MaxItems != new.MaxItems {
+-		fmt.Printf("MaxItems different for path %s, was: %d is now %d\n", strings.Join(path, "."), old.MaxItems, new.MaxItems)
+-	}
+-	if old.MinItems != new.MinItems {
+-		fmt.Printf("MinItems different for path %s, was: %d is now %d\n", strings.Join(path, "."), old.MinItems, new.MinItems)
+-	}
+-	if old.Default != new.Default {
+-		fmt.Printf("Default value different for path %s, was: %v is now %v\n", strings.Join(path, "."), old.Default, new.Default)
+-	}
+-	if old.ConfigMode != new.ConfigMode {
+-		// This is only set on very few complicated resources (instance, container cluster)
+-		fmt.Printf("ConfigMode different for path %s, was: %v is now %v\n", strings.Join(path, "."), old.ConfigMode, new.ConfigMode)
+-	}
+-	// Verbose diffs. Enabled using --verbose flag
+-	if verbose && !reflect.DeepEqual(old.ConflictsWith, new.ConflictsWith) {
+-		fmt.Printf("ConflictsWith different for path %s, was: %v is now %v\n", strings.Join(path, "."), old.ConflictsWith, new.ConflictsWith)
+-	}
+-	oldDiffSuppressFunc := findFunctionName(old.DiffSuppressFunc)
+-	newDiffSuppressFunc := findFunctionName(new.DiffSuppressFunc)
+-	if verbose && oldDiffSuppressFunc != newDiffSuppressFunc {
+-		fmt.Printf("DiffSuppressFunc for path %s, was: %s is now %s\n", strings.Join(path, "."), oldDiffSuppressFunc, newDiffSuppressFunc)
+-	}
+-	oldStateFunc := findFunctionName(old.StateFunc)
+-	newStateFunc := findFunctionName(new.StateFunc)
+-	if verbose && oldStateFunc != newStateFunc {
+-		fmt.Printf("StateFunc for path %s, was: %s is now %s\n", strings.Join(path, "."), oldStateFunc, newStateFunc)
+-	}
+-	oldValidateFunc := findFunctionName(old.ValidateFunc)
+-	newValidateFunc := findFunctionName(new.ValidateFunc)
+-	if verbose && oldValidateFunc != newValidateFunc {
+-		fmt.Printf("ValidateFunc for path %s, was: %s is now %s\n", strings.Join(path, "."), oldValidateFunc, newValidateFunc)
+-	}
+-	oldSet := findFunctionName(old.Set)
+-	newSet := findFunctionName(new.Set)
+-	if verbose && oldSet != newSet {
+-		fmt.Printf("Set function for path %s, was: %s is now %s\n", strings.Join(path, "."), oldSet, newSet)
+-	}
+-	// Recursive calls for nested objects
+-	if old.Type == schema.TypeList || old.Type == schema.TypeMap || old.Type == schema.TypeSet {
+-		oldElem := old.Elem
+-		newElem := new.Elem
+-		if reflect.TypeOf(oldElem) != reflect.TypeOf(newElem) {
+-			fmt.Printf("Elem type different for path %s, was: %T is now %T\n", strings.Join(path, "."), oldElem, newElem)
+-		}
+-		switch v := oldElem.(type) {
+-		case *schema.Resource:
+-			diffSchema(v.Schema, newElem.(*schema.Resource).Schema, path)
+-		case *schema.Schema:
+-			// Primitive unnamed field as only element
+-			diffSchemaObject(v, newElem.(*schema.Schema), append(path, "elem"))
+-		}
+-	}
+-}
+-func findFunctionName(f interface{}) string {
+-	ptr := reflect.ValueOf(f).Pointer()
+-	fun := runtime.FuncForPC(ptr)
+-	if fun == nil {
+-		return ""
+-	}
+-	split := strings.Split(fun.Name(), ".")
+-	return split[len(split)-1]
+-}
+diff --git b/website/docs/d/cloud_run_service.html.markdown a/website/docs/d/cloud_run_service.html.markdown
+index 1144e5590..9a39ce74e 100644
+--- b/website/docs/d/cloud_run_service.html.markdown
++++ a/website/docs/d/cloud_run_service.html.markdown
+@@ -34,4 +34,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_cloud_run_service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service#argument-reference) resource for details of the available attributes.
++See google_cloud_run_service resource for details of the available attributes.
+diff --git b/website/docs/d/composer_environment.html.markdown a/website/docs/d/composer_environment.html.markdown
+index 31bc2798c..785511d7e 100644
+--- b/website/docs/d/composer_environment.html.markdown
++++ a/website/docs/d/composer_environment.html.markdown
+@@ -44,7 +44,6 @@ The following attributes are exported:
+ * `id` - An identifier for the resource in format `projects/{{project}}/locations/{{region}}/environments/{{name}}`
+ 
+ * `config` - Configuration parameters for the environment.
+-    Full structure is provided by [composer environment resource documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/composer_environment#config).
+ 
+     * `config.0.gke_cluster` -
+     The Kubernetes Engine cluster used to run the environment.
+diff --git b/website/docs/d/compute_forwarding_rule.html.markdown a/website/docs/d/compute_forwarding_rule.html.markdown
+index 445cf3cdc..540791c88 100644
+--- b/website/docs/d/compute_forwarding_rule.html.markdown
++++ a/website/docs/d/compute_forwarding_rule.html.markdown
+@@ -32,4 +32,4 @@ The following arguments are supported:
+     is not provided, the project region is used.
+ 
+ ## Attributes Reference
+-See [google_compute_forwarding_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) resource for details of the available attributes.
++See google_compute_forwarding_rule resource for details of the available attributes.
+diff --git b/website/docs/d/compute_global_forwarding_rule.html.markdown a/website/docs/d/compute_global_forwarding_rule.html.markdown
+index 1e2a68c24..99f557204 100644
+--- b/website/docs/d/compute_global_forwarding_rule.html.markdown
++++ a/website/docs/d/compute_global_forwarding_rule.html.markdown
+@@ -28,4 +28,4 @@ The following arguments are supported:
+     is not provided, the provider project is used.
+ 
+ ## Attributes Reference
+-See [google_compute_global_forwarding_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) resource for details of the available attributes.
++See google_compute_global_forwarding_rule resource for details of the available attributes.
+diff --git b/website/docs/d/compute_instance.html.markdown a/website/docs/d/compute_instance.html.markdown
+index 2a3e1d03f..df3791db2 100644
+--- b/website/docs/d/compute_instance.html.markdown
++++ a/website/docs/d/compute_instance.html.markdown
+@@ -11,7 +11,6 @@ Get information about a VM instance resource within GCE. For more information se
+ and
+ [API](https://cloud.google.com/compute/docs/reference/latest/instances).
+ 
+-
+ ## Example Usage
+ 
+ ```hcl
+@@ -97,15 +96,15 @@ The following arguments are supported:
+ 
+ * `attached_disk.0.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+     encoded SHA-256 hash of the [customer-supplied encryption key]
+-    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
++    (<https://cloud.google.com/compute/docs/disks/customer-supplied-encryption>) that protects this resource.
+ 
+ * `boot_disk.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+     encoded SHA-256 hash of the [customer-supplied encryption key]
+-    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
++    (<https://cloud.google.com/compute/docs/disks/customer-supplied-encryption>) that protects this resource.
+ 
+ * `disk.0.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+     encoded SHA-256 hash of the [customer-supplied encryption key]
+-    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
++    (<https://cloud.google.com/compute/docs/disks/customer-supplied-encryption>) that protects this resource.
+ 
+ ---
+ 
+@@ -148,9 +147,9 @@ The following arguments are supported:
+ 
+ * `network` - The name or self_link of the network attached to this interface.
+ 
+-*  `subnetwork` - The name or self_link of the subnetwork attached to this interface.
++* `subnetwork` - The name or self_link of the subnetwork attached to this interface.
+ 
+-*  `subnetwork_project` - The project in which the subnetwork belongs.
++* `subnetwork_project` - The project in which the subnetwork belongs.
+ 
+ * `network_ip` - The private IP address assigned to the instance.
+ 
+@@ -195,7 +194,7 @@ The following arguments are supported:
+     
+ * `provisioning_model` - Describe the type of preemptible VM.
+ 
+-* `instance_termination_action` - Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot) 
++* `instance_termination_action` - Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot)
+ 
+ <a name="nested_guest_accelerator"></a>The `guest_accelerator` block supports:
+ 
+diff --git b/website/docs/d/compute_instance_template.html.markdown a/website/docs/d/compute_instance_template.html.markdown
+index 1c8be8857..ac649a914 100644
+--- b/website/docs/d/compute_instance_template.html.markdown
++++ a/website/docs/d/compute_instance_template.html.markdown
+@@ -63,7 +63,7 @@ The following arguments are supported:
+     To create a machine with a [custom type][custom-vm-types] (such as extended memory), format the value like `custom-VCPUS-MEM_IN_MB` like `custom-6-20480` for 6 vCPU and 20GB of RAM.
+ 
+ * `name` - The name of the instance template. If you leave
+-  this blank, Terraform will auto-generate a unique name.
++  this blank, the provider will auto-generate a unique name.
+ 
+ * `name_prefix` - Creates a unique name beginning with the specified
+   prefix. Conflicts with `name`.
+@@ -207,7 +207,7 @@ The `disk_encryption_key` block supports:
+ * `access_config` - Access configurations, i.e. IPs via which this
+     instance can be accessed via the Internet. Omit to ensure that the instance
+     is not accessible from the Internet (this means that ssh provisioners will
+-    not work unless you are running Terraform can send traffic to the instance's
++    not work unless you are running the provider can send traffic to the instance's
+     network (e.g. via tunnel or because it is running on another cloud instance
+     on that network). This block can be repeated multiple times. Structure [documented below](#nested_access_config).
+ 
+diff --git b/website/docs/d/compute_node_types.html.markdown a/website/docs/d/compute_node_types.html.markdown
+index dea98fd68..486be00b0 100644
+--- b/website/docs/d/compute_node_types.html.markdown
++++ a/website/docs/d/compute_node_types.html.markdown
+@@ -18,7 +18,7 @@ data "google_compute_node_types" "central1b" {
+ }
+ 
+ resource "google_compute_node_template" "tmpl" {
+-  name      = "terraform-test-tmpl"
++  name      = "test-tmpl"
+   region    = "us-central1"
+   node_type = data.google_compute_node_types.types.names[0]
+ }
+diff --git b/website/docs/d/compute_region_ssl_certificate.html.markdown a/website/docs/d/compute_region_ssl_certificate.html.markdown
+index 4a0982051..a871e65e3 100644
+--- b/website/docs/d/compute_region_ssl_certificate.html.markdown
++++ a/website/docs/d/compute_region_ssl_certificate.html.markdown
+@@ -44,4 +44,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_compute_region_ssl_certificate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_ssl_certificate) resource for details of the available attributes.
++See `google_compute_region_ssl_certificate` resource for details of the available attributes.
+diff --git b/website/docs/d/compute_resource_policy.html.markdown a/website/docs/d/compute_resource_policy.html.markdown
+index 0aeaddf94..f13519420 100644
+--- b/website/docs/d/compute_resource_policy.html.markdown
++++ a/website/docs/d/compute_resource_policy.html.markdown
+@@ -8,9 +8,6 @@ description: |-
+ 
+ Provide access to a Resource Policy's attributes. For more information see [the official documentation](https://cloud.google.com/compute/docs/disks/scheduled-snapshots) or the [API](https://cloud.google.com/compute/docs/reference/rest/beta/resourcePolicies).
+ 
+-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ ```hcl
+ provider "google-beta" {
+   region = "us-central1"
+diff --git b/website/docs/d/compute_router.html.markdown a/website/docs/d/compute_router.html.markdown
+index ea0966b99..857a0dd77 100644
+--- b/website/docs/d/compute_router.html.markdown
++++ a/website/docs/d/compute_router.html.markdown
+@@ -34,4 +34,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_compute_router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) resource for details of the available attributes.
++See `google_compute_router` resource for details of the available attributes.
+diff --git b/website/docs/d/compute_ssl_certificate.html.markdown a/website/docs/d/compute_ssl_certificate.html.markdown
+index b314e0f4a..7f58ace3a 100644
+--- b/website/docs/d/compute_ssl_certificate.html.markdown
++++ a/website/docs/d/compute_ssl_certificate.html.markdown
+@@ -41,4 +41,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_compute_ssl_certificate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_certificate) resource for details of the available attributes.
++See `google_compute_ssl_certificate` resource for details of the available attributes.
+diff --git b/website/docs/d/compute_zones.html.markdown a/website/docs/d/compute_zones.html.markdown
+index 484f7d2ec..f2b810b83 100644
+--- b/website/docs/d/compute_zones.html.markdown
++++ a/website/docs/d/compute_zones.html.markdown
+@@ -16,7 +16,7 @@ data "google_compute_zones" "available" {
+ resource "google_compute_instance_group_manager" "foo" {
+   count = length(data.google_compute_zones.available.names)
+ 
+-  name               = "terraform-test-${count.index}"
++  name               = "test-${count.index}"
+   instance_template  = google_compute_instance_template.foobar.self_link
+   base_instance_name = "foobar-${count.index}"
+   zone               = data.google_compute_zones.available.names[count.index]
+diff --git b/website/docs/d/container_cluster.html.markdown a/website/docs/d/container_cluster.html.markdown
+index d89775d5c..114e02345 100644
+--- b/website/docs/d/container_cluster.html.markdown
++++ a/website/docs/d/container_cluster.html.markdown
+@@ -56,4 +56,4 @@ in favour of `location`.
+ 
+ ## Attributes Reference
+ 
+-See [google_container_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster) resource for details of the available attributes.
++See `google_container_cluster` resource for details of the available attributes.
+diff --git b/website/docs/d/container_engine_versions.html.markdown a/website/docs/d/container_engine_versions.html.markdown
+index f1f5de3ab..6dc15a243 100644
+--- b/website/docs/d/container_engine_versions.html.markdown
++++ a/website/docs/d/container_engine_versions.html.markdown
+@@ -24,7 +24,7 @@ data "google_container_engine_versions" "central1b" {
+ }
+ 
+ resource "google_container_cluster" "foo" {
+-  name               = "terraform-test-cluster"
++  name               = "test-cluster"
+   location           = "us-central1-b"
+   node_version       = data.google_container_engine_versions.central1b.latest_node_version
+   initial_node_count = 1
+@@ -51,7 +51,7 @@ specified, the provider-level zone must be set and is used instead.
+ * `project` (Optional) - ID of the project to list available cluster versions for. Should match the project the cluster will be deployed to.
+   Defaults to the project that the provider is authenticated with.
+ 
+-* `version_prefix` (Optional) - If provided, Terraform will only return versions
++* `version_prefix` (Optional) - If provided, the provider will only return versions
+ that match the string prefix. For example, `1.11.` will match all `1.11` series
+ releases. Since this is just a string match, it's recommended that you append a
+ `.` after minor versions to ensure that prefixes such as `1.1` don't match
+diff --git b/website/docs/d/dns_managed_zone.html.markdown a/website/docs/d/dns_managed_zone.html.markdown
+index fa2b314b0..eb24558e0 100644
+--- b/website/docs/d/dns_managed_zone.html.markdown
++++ a/website/docs/d/dns_managed_zone.html.markdown
+@@ -38,7 +38,7 @@ resource "google_dns_record_set" "dns" {
+ 
+ The following attributes are exported:
+ 
+-* `dns_name` - The fully qualified DNS name of this zone, e.g. `terraform.io.`.
++* `dns_name` - The fully qualified DNS name of this zone, e.g. `example.io.`.
+ 
+ * `description` - A textual description field.
+ 
+diff --git b/website/docs/d/firebase_web_app.html.markdown a/website/docs/d/firebase_web_app.html.markdown
+index d76e9e372..e6bb4e4d4 100644
+--- b/website/docs/d/firebase_web_app.html.markdown
++++ a/website/docs/d/firebase_web_app.html.markdown
+@@ -8,10 +8,6 @@ description: |-
+ 
+ A Google Cloud Firebase web application instance
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+-
+ ## Argument Reference
+ 
+ The following arguments are supported:
+diff --git b/website/docs/d/firebase_web_app_config.html.markdown a/website/docs/d/firebase_web_app_config.html.markdown
+index 1b4894914..2e58bdd1e 100644
+--- b/website/docs/d/firebase_web_app_config.html.markdown
++++ a/website/docs/d/firebase_web_app_config.html.markdown
+@@ -8,9 +8,6 @@ description: |-
+ 
+ A Google Cloud Firebase web application configuration
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about WebApp, see:
+ 
+ * [API documentation](https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects.webApps)
+@@ -60,4 +57,4 @@ In addition to the arguments listed above, the following attributes are exported
+   This field is only present if the App is linked to a web stream in a Google Analytics App + Web property.
+   Learn more about this ID and Google Analytics web streams in the Analytics documentation.
+   To generate a measurementId and link the Web App with a Google Analytics web stream,
+-  call projects.addGoogleAnalytics.
+\ No newline at end of file
++  call projects.addGoogleAnalytics.
+diff --git b/website/docs/d/folder_organization_policy.html.markdown a/website/docs/d/folder_organization_policy.html.markdown
+index 8aa12841d..6e1a59af0 100644
+--- b/website/docs/d/folder_organization_policy.html.markdown
++++ a/website/docs/d/folder_organization_policy.html.markdown
+@@ -34,4 +34,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_folder_organization_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_folder_organization_policy) resource for details of the available attributes.
++See `google_folder_organization_policy` resource for details of the available attributes.
+diff --git b/website/docs/d/iam_workload_identity_pool.html.markdown a/website/docs/d/iam_workload_identity_pool.html.markdown
+index 447bb5d32..c95890b26 100644
+--- b/website/docs/d/iam_workload_identity_pool.html.markdown
++++ a/website/docs/d/iam_workload_identity_pool.html.markdown
+@@ -7,12 +7,7 @@ description: |-
+ # google\_iam\_workload\_identity\_pool
+ 
+ Get a IAM workload identity pool from Google Cloud by its id.
+-
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ ~> **Note:** The following resource requires the Beta IAM role `roles/iam.workloadIdentityPoolAdmin` in order to succeed. `OWNER` and `EDITOR` roles do not include the necessary permissions.
+-
+ ## Example Usage
+ 
+ ```tf
+@@ -34,4 +29,4 @@ The following arguments are supported:
+     is not provided, the provider project is used.
+ 
+ ## Attributes Reference
+-See [google_iam_workload_identity_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) resource for details of all the available attributes.
++See google_iam_workload_identity_pool resource for details of all the available attributes.
+diff --git b/website/docs/d/iam_workload_identity_pool_provider.html.markdown a/website/docs/d/iam_workload_identity_pool_provider.html.markdown
+index 6fe3f160f..ca0c32a9c 100644
+--- b/website/docs/d/iam_workload_identity_pool_provider.html.markdown
++++ a/website/docs/d/iam_workload_identity_pool_provider.html.markdown
+@@ -8,9 +8,6 @@ description: |-
+ 
+ Get a IAM workload identity provider from Google Cloud by its id.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ ## Example Usage
+ 
+ ```tf
+@@ -35,4 +32,4 @@ The following arguments are supported:
+     is not provided, the provider project is used.
+ 
+ ## Attributes Reference
+-See [google_iam_workload_identity_pool_provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) resource for details of all the available attributes.
++See google_iam_workload_identity_pool_provider resource for details of all the available attributes.
+diff --git b/website/docs/d/iap_client.html.markdown a/website/docs/d/iap_client.html.markdown
+index 4fbd593b8..251e21c44 100644
+--- b/website/docs/d/iap_client.html.markdown
++++ a/website/docs/d/iap_client.html.markdown
+@@ -31,4 +31,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_iap_client](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_client) resource for details of the available attributes.
++See google_iap_client resource for details of the available attributes.
+diff --git b/website/docs/d/project.html.markdown a/website/docs/d/project.html.markdown
+index 8d42b188b..93997c699 100644
+--- b/website/docs/d/project.html.markdown
++++ a/website/docs/d/project.html.markdown
+@@ -34,5 +34,5 @@ The following attributes are exported:
+ 
+ * `number` - The numeric identifier of the project.
+ 
+-See [google_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project) resource for details of the available attributes.
++See `google_project` resource for details of the available attributes.
+ 
+diff --git b/website/docs/d/project_organization_policy.html.markdown a/website/docs/d/project_organization_policy.html.markdown
+index ce4c6d317..b745a1ce9 100644
+--- b/website/docs/d/project_organization_policy.html.markdown
++++ a/website/docs/d/project_organization_policy.html.markdown
+@@ -34,5 +34,5 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_project_organization_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_organization_policy) resource for details of the available attributes.
++See `google_project_organization_policy` resource for details of the available attributes.
+ 
+diff --git b/website/docs/d/pubsub_topic.html.markdown a/website/docs/d/pubsub_topic.html.markdown
+index de0dea39b..53e8a7b0e 100644
+--- b/website/docs/d/pubsub_topic.html.markdown
++++ a/website/docs/d/pubsub_topic.html.markdown
+@@ -31,4 +31,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_pubsub_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic#argument-reference) resource for details of the available attributes.
++See google_pubsub_topic resource for details of the available attributes.
+diff --git b/website/docs/d/redis_instance.html.markdown a/website/docs/d/redis_instance.html.markdown
+index 2c656bc84..c3d03a6c6 100644
+--- b/website/docs/d/redis_instance.html.markdown
++++ a/website/docs/d/redis_instance.html.markdown
+@@ -44,4 +44,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_redis_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance) resource for details of the available attributes.
++See google_redis_instance resource for details of the available attributes.
+diff --git b/website/docs/d/runtimeconfig_config.html.markdown a/website/docs/d/runtimeconfig_config.html.markdown
+index 189ae141d..58e7ab0fc 100644
+--- b/website/docs/d/runtimeconfig_config.html.markdown
++++ a/website/docs/d/runtimeconfig_config.html.markdown
+@@ -36,4 +36,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_runtimeconfig_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/runtimeconfig_config#argument-reference) resource for details of the available attributes.
++See google_runtimeconfig_config resource for details of the available attributes.
+diff --git b/website/docs/d/runtimeconfig_variable.html.markdown a/website/docs/d/runtimeconfig_variable.html.markdown
+index c56bf178c..1e92663ff 100644
+--- b/website/docs/d/runtimeconfig_variable.html.markdown
++++ a/website/docs/d/runtimeconfig_variable.html.markdown
+@@ -38,4 +38,4 @@ The following arguments are supported:
+ 
+ ## Attributes Reference
+ 
+-See [google_runtimeconfig_variable](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/runtimeconfig_variable#argument-reference) resource for details of the available attributes.
++See google_runtimeconfig_variable resource for details of the available attributes.
+diff --git b/website/docs/d/service_account_id_token.html.markdown a/website/docs/d/service_account_id_token.html.markdown
+index d415f5779..98e6395ae 100644
+--- b/website/docs/d/service_account_id_token.html.markdown
++++ a/website/docs/d/service_account_id_token.html.markdown
+@@ -12,7 +12,7 @@ For more information see
+ [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html#IDToken).
+ 
+ ## Example Usage - ServiceAccount JSON credential file.
+-  `google_service_account_id_token` will use the configured [provider credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#credentials-1)
++  `google_service_account_id_token` will use the configured provider credentials
+ 
+   ```hcl
+   data "google_service_account_id_token" "oidc" {
+@@ -25,7 +25,7 @@ For more information see
+   ```
+ 
+ ## Example Usage - Service Account Impersonation.
+-  `google_service_account_access_token` will use background impersonated credentials provided by [google_service_account_access_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account_access_token).
++  `google_service_account_access_token` will use background impersonated credentials provided by `google_service_account_access_token`.
+ 
+   Note: to use the following, you must grant `target_service_account` the
+   `roles/iam.serviceAccountTokenCreator` role on itself.
+@@ -59,7 +59,7 @@ For more information see
+ 
+ ## Example Usage - Invoking Cloud Run Endpoint
+ 
+-  The following configuration will invoke [Cloud Run](https://cloud.google.com/run/docs/authenticating/service-to-service) endpoint where the service account for Terraform has been granted `roles/run.invoker` role previously.
++  The following configuration will invoke [Cloud Run](https://cloud.google.com/run/docs/authenticating/service-to-service) endpoint where the service account for the provider has been granted `roles/run.invoker` role previously.
+ 
+ ```hcl
+ 
+diff --git b/website/docs/d/spanner_instance.html.markdown a/website/docs/d/spanner_instance.html.markdown
+index e3d0514b1..ef732c30a 100644
+--- b/website/docs/d/spanner_instance.html.markdown
++++ a/website/docs/d/spanner_instance.html.markdown
+@@ -28,4 +28,4 @@ The following arguments are supported:
+     is not provided, the provider project is used.
+ 
+ ## Attributes Reference
+-See [google_spanner_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_instance) resource for details of all the available attributes.
++See google_spanner_instance resource for details of all the available attributes.
+diff --git b/website/docs/d/sql_database_instance.html.markdown a/website/docs/d/sql_database_instance.html.markdown
+index 6bf824950..e01e2dccf 100644
+--- b/website/docs/d/sql_database_instance.html.markdown
++++ a/website/docs/d/sql_database_instance.html.markdown
+@@ -26,4 +26,4 @@ The following arguments are supported:
+ * `project` - (optional) The ID of the project in which the resource belongs.
+ 
+ ## Attributes Reference
+-See [google_sql_database_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) resource for details of all the available attributes.
++See google_sql_database_instance resource for details of all the available attributes.
+diff --git b/website/docs/d/storage_project_service_account.html.markdown a/website/docs/d/storage_project_service_account.html.markdown
+index d0494f08b..0ebec0d7e 100644
+--- b/website/docs/d/storage_project_service_account.html.markdown
++++ a/website/docs/d/storage_project_service_account.html.markdown
+@@ -27,14 +27,14 @@ on the bucket creation page.
+ Use of this data source calls the relevant API endpoint to obtain the service account's identity and thus ensures it exists prior to any API operations
+ which demand its existence, such as specifying it in Cloud IAM policy.
+ Always prefer to use this data source over interpolating the project ID into the well-known format for this service account, as the latter approach may cause
+-Terraform apply errors in cases where the service account does not yet exist.
++provider update errors in cases where the service account does not yet exist.
+ 
+->  When you write Terraform code which uses features depending on this service account *and* your Terraform code adds the service account in IAM policy on other resources,
++>  When you write provider code which uses features depending on this service account *and* your provider code adds the service account in IAM policy on other resources,
+    you must take care for race conditions between the establishment of the IAM policy and creation of the relevant Cloud Storage resource.
+    Cloud Storage APIs will require permissions on resources such as pub/sub topics or Cloud KMS keys to exist *before* the attempt to utilise them in a
+    bucket configuration, otherwise the API calls will fail.
+    You may need to use `depends_on` to create an explicit dependency between the IAM policy resource and the Cloud Storage resource which depends on it.
+-   See the examples here and in the [`google_storage_notification`](/docs/providers/google/r/storage_notification.html) resource.
++   See the examples here and in the `google_storage_notification` resource.
+ 
+ For more information see
+ [the API reference](https://cloud.google.com/storage/docs/json_api/v1/projects/serviceAccount).
+diff --git b/website/docs/r/api_gateway_api.html.markdown a/website/docs/r/api_gateway_api.html.markdown
+index 9581836d8..4076dc46a 100644
+--- b/website/docs/r/api_gateway_api.html.markdown
++++ a/website/docs/r/api_gateway_api.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ A consumable API that can be used by multiple Gateways.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about Api, see:
+ 
+ * [API documentation](https://cloud.google.com/api-gateway/docs/reference/rest/v1beta/projects.locations.apis)
+diff --git b/website/docs/r/api_gateway_api_config.html.markdown a/website/docs/r/api_gateway_api_config.html.markdown
+index d2e073f16..c03f35904 100644
+--- b/website/docs/r/api_gateway_api_config.html.markdown
++++ a/website/docs/r/api_gateway_api_config.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ An API Configuration is an association of an API Controller Config and a Gateway Config
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about ApiConfig, see:
+ 
+ * [API documentation](https://cloud.google.com/api-gateway/docs/reference/rest/v1beta/projects.locations.apis.configs)
+diff --git b/website/docs/r/api_gateway_api_config_iam.html.markdown a/website/docs/r/api_gateway_api_config_iam.html.markdown
+index e579e915b..580daf6ff 100644
+--- b/website/docs/r/api_gateway_api_config_iam.html.markdown
++++ a/website/docs/r/api_gateway_api_config_iam.html.markdown
+@@ -33,9 +33,6 @@ A data source can be used to retrieve policy data in advent you do not need crea
+ ~> **Note:** `google_api_gateway_api_config_iam_binding` resources **can be** used in conjunction with `google_api_gateway_api_config_iam_member` resources **only if** they do not grant privilege to the same role.
+ 
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ 
+ ## google\_api\_gateway\_api\_config\_iam\_policy
+ 
+diff --git b/website/docs/r/api_gateway_api_iam.html.markdown a/website/docs/r/api_gateway_api_iam.html.markdown
+index 0889b9be9..9b0366546 100644
+--- b/website/docs/r/api_gateway_api_iam.html.markdown
++++ a/website/docs/r/api_gateway_api_iam.html.markdown
+@@ -33,9 +33,6 @@ A data source can be used to retrieve policy data in advent you do not need crea
+ ~> **Note:** `google_api_gateway_api_iam_binding` resources **can be** used in conjunction with `google_api_gateway_api_iam_member` resources **only if** they do not grant privilege to the same role.
+ 
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ 
+ ## google\_api\_gateway\_api\_iam\_policy
+ 
+diff --git b/website/docs/r/api_gateway_gateway.html.markdown a/website/docs/r/api_gateway_gateway.html.markdown
+index 0899b839e..07c9b64ac 100644
+--- b/website/docs/r/api_gateway_gateway.html.markdown
++++ a/website/docs/r/api_gateway_gateway.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ A consumable API that can be used by multiple Gateways.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about Gateway, see:
+ 
+ * [API documentation](https://cloud.google.com/api-gateway/docs/reference/rest/v1beta/projects.locations.apis)
+diff --git b/website/docs/r/api_gateway_gateway_iam.html.markdown a/website/docs/r/api_gateway_gateway_iam.html.markdown
+index 956a1a11e..7f511dfc6 100644
+--- b/website/docs/r/api_gateway_gateway_iam.html.markdown
++++ a/website/docs/r/api_gateway_gateway_iam.html.markdown
+@@ -33,10 +33,6 @@ A data source can be used to retrieve policy data in advent you do not need crea
+ ~> **Note:** `google_api_gateway_gateway_iam_binding` resources **can be** used in conjunction with `google_api_gateway_gateway_iam_member` resources **only if** they do not grant privilege to the same role.
+ 
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+-
+ ## google\_api\_gateway\_gateway\_iam\_policy
+ 
+ ```hcl
+diff --git b/website/docs/r/apigee_instance.html.markdown a/website/docs/r/apigee_instance.html.markdown
+index 023796a57..087d81619 100644
+--- b/website/docs/r/apigee_instance.html.markdown
++++ a/website/docs/r/apigee_instance.html.markdown
+@@ -197,7 +197,7 @@ resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+ resource "google_apigee_organization" "apigee_org" {
+   analytics_region                     = "us-central1"
+   display_name                         = "apigee-org"
+-  description                          = "Terraform-provisioned Apigee Org."
++  description                          = "Auto-provisioned Apigee Org."
+   project_id                           = data.google_client_config.current.project
+   authorized_network                   = google_compute_network.apigee_network.id
+   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
+@@ -211,7 +211,7 @@ resource "google_apigee_organization" "apigee_org" {
+ resource "google_apigee_instance" "apigee_instance" {
+   name                     = "my-instance-name"
+   location                 = "us-central1"
+-  description              = "Terraform-managed Apigee Runtime Instance"
++  description              = "Auto-managed Apigee Runtime Instance"
+   display_name             = "my-instance-name"
+   org_id                   = google_apigee_organization.apigee_org.id
+   disk_encryption_key_name = google_kms_crypto_key.apigee_key.id
+diff --git b/website/docs/r/apigee_organization.html.markdown a/website/docs/r/apigee_organization.html.markdown
+index e98b60311..12b92a221 100644
+--- b/website/docs/r/apigee_organization.html.markdown
++++ a/website/docs/r/apigee_organization.html.markdown
+@@ -115,7 +115,7 @@ resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+ resource "google_apigee_organization" "org" {
+   analytics_region                     = "us-central1"
+   display_name                         = "apigee-org"
+-  description                          = "Terraform-provisioned Apigee Org."
++  description                          = "Auto-provisioned Apigee Org."
+   project_id                           = data.google_client_config.current.project
+   authorized_network                   = google_compute_network.apigee_network.id
+   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
+diff --git b/website/docs/r/app_engine_application.html.markdown a/website/docs/r/app_engine_application.html.markdown
+index fb45b44d1..265836942 100644
+--- b/website/docs/r/app_engine_application.html.markdown
++++ a/website/docs/r/app_engine_application.html.markdown
+@@ -9,9 +9,9 @@ description: |-
+ Allows creation and management of an App Engine application.
+ 
+ ~> App Engine applications cannot be deleted once they're created; you have to delete the
+-   entire project to delete the application. Terraform will report the application has been
+-   successfully deleted; this is a limitation of Terraform, and will go away in the future.
+-   Terraform is not able to delete App Engine applications.
++   entire project to delete the application. This provider will report the application has been
++   successfully deleted; this is a limitation of the provider, and will go away in the future.
++   This provider is not able to delete App Engine applications.
+ 
+ ~> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
+ state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+diff --git b/website/docs/r/app_engine_flexible_app_version.html.markdown a/website/docs/r/app_engine_flexible_app_version.html.markdown
+index ea0eb5bc6..52e66034b 100644
+--- b/website/docs/r/app_engine_flexible_app_version.html.markdown
++++ a/website/docs/r/app_engine_flexible_app_version.html.markdown
+@@ -302,7 +302,7 @@ The following arguments are supported:
+ 
+ * `env_variables` -
+   (Optional)
+-  Environment variables available to the application.  As these are not returned in the API request, Terraform will not detect any changes made outside of the Terraform config.
++  Environment variables available to the application.  As these are not returned in the API request, the provider will not detect any changes made outside of the config.
+ 
+ * `default_expiration` -
+   (Optional)
+diff --git b/website/docs/r/bigquery_job.html.markdown a/website/docs/r/bigquery_job.html.markdown
+index eb35f4623..f55592e94 100644
+--- b/website/docs/r/bigquery_job.html.markdown
++++ a/website/docs/r/bigquery_job.html.markdown
+@@ -717,8 +717,8 @@ The following arguments are supported:
+ 
+ * `null_marker` -
+   (Optional)
+-  Specifies a string that represents a null value in a CSV file. For example, if you specify "\N", BigQuery interprets "\N" as a null value
+-  when loading a CSV file. The default value is the empty string. If you set this property to a custom value, BigQuery throws an error if an
++  Specifies a string that represents a null value in a CSV file. The default value is the empty string. If you set this 
++  property to a custom value, BigQuery throws an error if an
+   empty string is present for all data types except for STRING and BYTE. For STRING and BYTE columns, BigQuery interprets the empty string as
+   an empty value.
+ 
+diff --git b/website/docs/r/bigquery_reservation.html.markdown a/website/docs/r/bigquery_reservation.html.markdown
+index f8642bacf..3257bf784 100644
+--- b/website/docs/r/bigquery_reservation.html.markdown
++++ a/website/docs/r/bigquery_reservation.html.markdown
+@@ -28,11 +28,6 @@ To get more information about Reservation, see:
+ * How-to Guides
+     * [Introduction to Reservations](https://cloud.google.com/bigquery/docs/reservations-intro)
+ 
+-<div class = "oics-button" style="float: right; margin: 0 0 -15px">
+-  <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=bigquery_reservation_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+-    <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+-  </a>
+-</div>
+ ## Example Usage - Bigquery Reservation Basic
+ 
+ 
+diff --git b/website/docs/r/bigquery_reservation_assignment.html.markdown a/website/docs/r/bigquery_reservation_assignment.html.markdown
+index 5c8d2408d..e4163d30d 100644
+--- b/website/docs/r/bigquery_reservation_assignment.html.markdown
++++ a/website/docs/r/bigquery_reservation_assignment.html.markdown
+@@ -25,7 +25,7 @@ The BigqueryReservation Assignment resource
+ ## Example Usage - basic
+ ```hcl
+ resource "google_bigquery_reservation" "basic" {
+-  name  = "tf-test-my-reservation%{random_suffix}"
++  name  = "tf-test-my-reservation"
+   project = "my-project-name"
+   location = "us-central1"
+   slot_capacity = 0
+diff --git b/website/docs/r/bigquery_table.html.markdown a/website/docs/r/bigquery_table.html.markdown
+index e0f551b0f..aaea57b55 100644
+--- b/website/docs/r/bigquery_table.html.markdown
++++ a/website/docs/r/bigquery_table.html.markdown
+@@ -11,7 +11,7 @@ Creates a table resource in a dataset for Google BigQuery. For more information
+ [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).
+ 
+ -> **Note**: On newer versions of the provider, you must explicitly set `deletion_protection=false`
+-(and run `terraform apply` to write the field to state) in order to destroy an instance.
++(and run `pulumi update` to write the field to state) in order to destroy an instance.
+ It is recommended to not set this field (or set it to true) until you're ready to destroy.
+ 
+ 
+@@ -141,8 +141,8 @@ The following arguments are supported:
+ * `materialized_view` - (Optional) If specified, configures this table as a materialized view.
+     Structure is [documented below](#nested_materialized_view).
+ 
+-* `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
+-in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
++* `deletion_protection` - (Optional) Whether or not to allow the provider to destroy the instance. Unless this field is set to false
++in state, a `=destroy` or `=update` that would delete the instance will fail.
+ 
+ <a name="nested_external_data_configuration"></a>The `external_data_configuration` block supports:
+ 
+@@ -211,8 +211,8 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
+     CSV file. If your data does not contain quoted sections, set the
+     property value to an empty string. If your data contains quoted newline
+     characters, you must also set the `allow_quoted_newlines` property to true.
+-    The API-side default is `"`, specified in Terraform escaped as `\"`. Due to
+-    limitations with Terraform default values, this value is required to be
++    The API-side default is `"`, specified in the provider escaped as `\"`. Due to
++    limitations with default values, this value is required to be
+     explicitly set.
+ 
+ * `allow_jagged_rows` (Optional) - Indicates if BigQuery should accept rows
+diff --git b/website/docs/r/bigquery_table_iam.html.markdown a/website/docs/r/bigquery_table_iam.html.markdown
+index 46550c28d..cc06739c8 100644
+--- b/website/docs/r/bigquery_table_iam.html.markdown
++++ a/website/docs/r/bigquery_table_iam.html.markdown
+@@ -184,8 +184,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, this provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/bigtable_instance.html.markdown a/website/docs/r/bigtable_instance.html.markdown
+index 79eeaa0b2..987079d37 100644
+--- b/website/docs/r/bigtable_instance.html.markdown
++++ a/website/docs/r/bigtable_instance.html.markdown
+@@ -1,4 +1,4 @@
+----
+++---
+ subcategory: "Cloud Bigtable"
+ description: |-
+   Creates a Google Bigtable instance.
+@@ -12,17 +12,6 @@ Creates a Google Bigtable instance. For more information see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/bigtable/docs)
+ 
+-
+--> **Note**: It is strongly recommended to set `lifecycle { prevent_destroy = true }`
+-on instances in order to prevent accidental data loss. See
+-[Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
+-for more information on lifecycle parameters.
+-
+--> **Note**: On newer versions of the provider, you must explicitly set `deletion_protection=false`
+-(and run `terraform apply` to write the field to state) in order to destroy an instance.
+-It is recommended to not set this field (or set it to true) until you're ready to destroy.
+-
+-
+ ## Example Usage - Simple Instance
+ 
+ ```hcl
+@@ -97,8 +86,8 @@ to default to the backend value. See [structure below](#nested_cluster).
+ 
+ * `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
+ 
+-* `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
+-in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
++* `deletion_protection` - (Optional) Whether or not to allow this provider to destroy the instance. Unless this field is set to false
++in the statefile, a `pulumi destroy` or `pulumi up` that would delete the instance will fail.
+ 
+ * `labels` - (Optional) A set of key/value label pairs to assign to the resource. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.
+ 
+@@ -132,8 +121,10 @@ Required, with a minimum of `1` for each cluster in an instance.
+ 
+ -> **Note**: Removing the field entirely from the config will cause the provider to default to the backend value.
+ 
++!> **Warning**: Modifying this field will cause the provider to delete/recreate the entire resource.
++
+ !> **Warning:** Modifying the `storage_type`, `zone` or `kms_key_name` of an existing cluster (by
+-`cluster_id`) will cause Terraform to delete/recreate the entire
++`cluster_id`) will cause the provider to delete/recreate the entire
+ `google_bigtable_instance` resource. If these values are changing, use a new
+ `cluster_id`.
+ 
+diff --git b/website/docs/r/bigtable_instance_iam.html.markdown a/website/docs/r/bigtable_instance_iam.html.markdown
+index cf4259ba3..f9908e704 100644
+--- b/website/docs/r/bigtable_instance_iam.html.markdown
++++ a/website/docs/r/bigtable_instance_iam.html.markdown
+@@ -84,7 +84,7 @@ For `google_bigtable_instance_iam_member` or `google_bigtable_instance_iam_bindi
+ - - -
+ 
+ * `project` - (Optional) The project in which the instance belongs. If it
+-    is not provided, Terraform will use the provider default.
++    is not provided, a default will be supplied.
+ 
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/bigtable_table.html.markdown a/website/docs/r/bigtable_table.html.markdown
+index 39da07798..a73216f83 100644
+--- b/website/docs/r/bigtable_table.html.markdown
++++ a/website/docs/r/bigtable_table.html.markdown
+@@ -10,12 +10,6 @@ Creates a Google Cloud Bigtable table inside an instance. For more information s
+ [the official documentation](https://cloud.google.com/bigtable/) and
+ [API](https://cloud.google.com/bigtable/docs/go/reference).
+ 
+--> **Note:** It is strongly recommended to set `lifecycle { prevent_destroy = true }`
+-on tables in order to prevent accidental data loss. See
+-[Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
+-for more information on lifecycle parameters.
+-
+-
+ ## Example Usage
+ 
+ ```hcl
+@@ -62,7 +56,7 @@ The following arguments are supported:
+ * `instance_name` - (Required) The name of the Bigtable instance.
+ 
+ * `split_keys` - (Optional) A list of predefined keys to split the table on.
+-!> **Warning:** Modifying the `split_keys` of an existing table will cause Terraform
++!> **Warning:** Modifying the `split_keys` of an existing table will cause the provider
+ to delete/recreate the entire `google_bigtable_table` resource.
+ 
+ * `column_family` - (Optional) A group of columns within a table which share a common configuration. This can be specified multiple times. Structure is documented below.
+diff --git b/website/docs/r/bigtable_table_iam.html.markdown a/website/docs/r/bigtable_table_iam.html.markdown
+index b4e7a56ac..2cec72cf8 100644
+--- b/website/docs/r/bigtable_table_iam.html.markdown
++++ a/website/docs/r/bigtable_table_iam.html.markdown
+@@ -89,7 +89,7 @@ For `google_bigtable_table_iam_member` or `google_bigtable_table_iam_binding`:
+ - - -
+ 
+ * `project` - (Optional) The project in which the table belongs. If it
+-    is not provided, Terraform will use the provider default.
++    is not provided, this provider will use the provider default.
+ 
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/certificate_manager_certificate.html.markdown a/website/docs/r/certificate_manager_certificate.html.markdown
+index 2559f6fe5..2882ae9ef 100644
+--- b/website/docs/r/certificate_manager_certificate.html.markdown
++++ a/website/docs/r/certificate_manager_certificate.html.markdown
+@@ -66,11 +66,11 @@ resource "google_certificate_manager_dns_authorization" "instance2" {
+ }
+ ```
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+-  <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=certificate_manager_self_managed_certificate&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
++  <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=certificate_manager_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+   </a>
+ </div>
+-## Example Usage - Certificate Manager Self Managed Certificate
++## Example Usage - Certificate Manager Certificate Basic
+ 
+ 
+ ```hcl
+@@ -78,11 +78,30 @@ resource "google_certificate_manager_certificate" "default" {
+   name        = "self-managed-cert"
+   description = "Global cert"
+   scope       = "EDGE_CACHE"
+-  self_managed {
+-    pem_certificate = file("test-fixtures/certificatemanager/cert.pem")
+-    pem_private_key = file("test-fixtures/certificatemanager/private-key.pem")
++  managed {
++    domains = [
++      google_certificate_manager_dns_authorization.instance.domain,
++      google_certificate_manager_dns_authorization.instance2.domain,
++      ]
++    dns_authorizations = [
++      google_certificate_manager_dns_authorization.instance.id,
++      google_certificate_manager_dns_authorization.instance2.id,
++      ]
+   }
+ }
++
++
++resource "google_certificate_manager_dns_authorization" "instance" {
++  name        = "dns-auth"
++  description = "The default dnss"
++  domain      = "subdomain.hashicorptest.com"
++}
++
++resource "google_certificate_manager_dns_authorization" "instance2" {
++  name        = "dns-auth2"
++  description = "The default dnss"
++  domain      = "subdomain2.hashicorptest.com"
++}
+ ```
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=certificate_manager_self_managed_certificate_regional&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -175,6 +194,7 @@ The following arguments are supported:
+   (Optional)
+   The certificate chain in PEM-encoded form.
+   Leaf certificate comes first, followed by intermediate ones if any.
++  **Note**: This property is sensitive and will not be displayed in the plan.
+ 
+ * `pem_private_key` -
+   (Optional)
+diff --git b/website/docs/r/cloud_identity_group_membership.html.markdown a/website/docs/r/cloud_identity_group_membership.html.markdown
+index 0544e308a..90d4f7d17 100644
+--- b/website/docs/r/cloud_identity_group_membership.html.markdown
++++ a/website/docs/r/cloud_identity_group_membership.html.markdown
+@@ -140,7 +140,7 @@ The following arguments are supported:
+ 
+ 
+ * `member_key` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   EntityKey of the member.
+   Structure is [documented below](#nested_member_key).
+ 
+diff --git b/website/docs/r/cloud_run_domain_mapping.html.markdown a/website/docs/r/cloud_run_domain_mapping.html.markdown
+index 2aa88eb2e..f3a309b9f 100644
+--- b/website/docs/r/cloud_run_domain_mapping.html.markdown
++++ a/website/docs/r/cloud_run_domain_mapping.html.markdown
+@@ -152,7 +152,7 @@ The following arguments are supported:
+   may be set by external tools to store and retrieve arbitrary metadata. More
+   info: http://kubernetes.io/docs/user-guide/annotations
+   **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+-  If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
++  If the provider plan shows a diff where a server-side annotation is added, you can add it to your config
+   or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+ 
+ - - -
+diff --git b/website/docs/r/cloud_run_service.html.markdown a/website/docs/r/cloud_run_service.html.markdown
+index 3fd9ce3eb..9bda55f56 100644
+--- b/website/docs/r/cloud_run_service.html.markdown
++++ a/website/docs/r/cloud_run_service.html.markdown
+@@ -31,9 +31,64 @@ To get more information about Service, see:
+ ~> **Warning:** We recommend using the `google_cloud_run_v2_service` resource which offers a better
+ developer experience and broader support of Cloud Run features.
+ 
+-## Example Usage - Cloud Run Service Basic
++## Example Usage - Cloud Run Service Pubsub
+ 
+ 
++```hcl
++resource "google_cloud_run_service" "default" {
++    name     = "cloud_run_service_name"
++    location = "us-central1"
++    template {
++      spec {
++            containers {
++                image = "gcr.io/cloudrun/hello"
++            }
++      }
++    }
++    traffic {
++      percent         = 100
++      latest_revision = true
++    }
++}
++
++resource "google_service_account" "sa" {
++  account_id   = "cloud-run-pubsub-invoker"
++  display_name = "Cloud Run Pub/Sub Invoker"
++}
++
++resource "google_cloud_run_service_iam_binding" "binding" {
++  location = google_cloud_run_service.default.location
++  service = google_cloud_run_service.default.name
++  role = "roles/run.invoker"
++  members = ["serviceAccount:${google_service_account.sa.email}"]
++}
++
++resource "google_project_iam_binding" "project" {
++  role    = "roles/iam.serviceAccountTokenCreator"
++  members = ["serviceAccount:${google_service_account.sa.email}"]
++}
++
++resource "google_pubsub_topic" "topic" {
++  name = "pubsub_topic"
++}
++
++resource "google_pubsub_subscription" "subscription" {
++  name  = "pubsub_subscription"
++  topic = google_pubsub_topic.topic.name
++  push_config {
++    push_endpoint = google_cloud_run_service.default.status[0].url
++    oidc_token {
++      service_account_email = google_service_account.sa.email
++    }
++    attributes = {
++      x-goog-version = "v1"
++    }
++  }
++}
++```
++
++## Example Usage - Cloud Run Service Basic
++
+ ```hcl
+ resource "google_cloud_run_service" "default" {
+   name     = "cloudrun-srv"
+@@ -77,7 +132,7 @@ resource "google_cloud_run_service" "default" {
+       annotations = {
+         "autoscaling.knative.dev/maxScale"      = "1000"
+         "run.googleapis.com/cloudsql-instances" = google_sql_database_instance.instance.connection_name
+-        "run.googleapis.com/client-name"        = "terraform"
++        "run.googleapis.com/client-name"        = "demo"
+       }
+     }
+   }
+@@ -342,7 +397,7 @@ The following arguments are supported:
+   may be set by external tools to store and retrieve arbitrary metadata. More
+   info: http://kubernetes.io/docs/user-guide/annotations
+   **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+-  If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
++  If the provider plan shows a diff where a server-side annotation is added, you can add it to your config
+   or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+   Annotations with `run.googleapis.com/` and `autoscaling.knative.dev` are restricted. Use the following annotation
+   keys to configure features on a Revision template:
+@@ -489,7 +544,8 @@ The following arguments are supported:
+ 
+ * `liveness_probe` -
+   (Optional)
+-  Periodic probe of container liveness. Container will be restarted if the probe fails.
++  Periodic probe of container liveness. Container will be restarted if the probe fails. More info:
++  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+   Structure is [documented below](#nested_liveness_probe).
+ 
+ 
+@@ -579,9 +635,9 @@ The following arguments are supported:
+ 
+ * `name` -
+   (Required)
+-  The name of the secret in Cloud Secret Manager. By default, the secret is assumed to be in the same project.
+-  If the secret is in another project, you must define an alias.
+-  An alias definition has the form: :projects/{project-id|project-number}/secrets/.
++  The name of the secret in Cloud Secret Manager. By default, the secret is assumed to be in the same project. 
++  If the secret is in another project, you must define an alias. 
++  An alias definition has the form: :projects/{project-id|project-number}/secrets/. 
+   If multiple alias definitions are needed, they must be separated by commas.
+   The alias definitions must be set on the run.googleapis.com/secrets annotation.
+ 
+@@ -947,7 +1003,7 @@ this field is set to false, the revision name will still autogenerate.)
+   may be set by external tools to store and retrieve arbitrary metadata. More
+   info: http://kubernetes.io/docs/user-guide/annotations
+   **Note**: The Cloud Run API may add additional annotations that were not provided in your config.
+-  If terraform plan shows a diff where a server-side annotation is added, you can add it to your config
++  If the provider plan shows a diff where a server-side annotation is added, you can add it to your config
+   or apply the lifecycle.ignore_changes rule to the metadata.0.annotations field.
+   Annotations with `run.googleapis.com/` and `autoscaling.knative.dev` are restricted. Use the following annotation
+   keys to configure features on a Service:
+diff --git b/website/docs/r/cloud_scheduler_job.html.markdown a/website/docs/r/cloud_scheduler_job.html.markdown
+index c359fce15..c4c5a2984 100644
+--- b/website/docs/r/cloud_scheduler_job.html.markdown
++++ a/website/docs/r/cloud_scheduler_job.html.markdown
+@@ -272,7 +272,7 @@ The following arguments are supported:
+ 
+ * `region` -
+   (Optional)
+-  Region where the scheduler job resides. If it is not provided, Terraform will use the provider default.
++  Region where the scheduler job resides. If it is not provided, this provider will use the provider default.
+ 
+ * `project` - (Optional) The ID of the project in which the resource belongs.
+     If it is not provided, the provider project is used.
+diff --git b/website/docs/r/composer_environment.html.markdown a/website/docs/r/composer_environment.html.markdown
+index 7a7d97ff9..117a8ec6e 100644
+--- b/website/docs/r/composer_environment.html.markdown
++++ a/website/docs/r/composer_environment.html.markdown
+@@ -27,17 +27,18 @@ To get more information about Environments, see:
+ ~> **Warning:** We **STRONGLY** recommend you read the [GCP
+ guides](https://cloud.google.com/composer/docs/how-to) as the Environment resource requires a long
+ deployment process and involves several layers of GCP infrastructure, including a Kubernetes Engine
+-cluster, Cloud Storage, and Compute networking resources. Due to limitations of the API, Terraform
++cluster, Cloud Storage, and Compute networking resources. Due to limitations of the API, this provider
+ will not be able to automatically find or manage many of these underlying resources. In particular:
++
+ * It can take up to one hour to create or update an environment resource. In addition, GCP may only
+   detect some errors in configuration when they are used (e.g. ~40-50 minutes into the creation
+   process), and is prone to limited error reporting. If you encounter confusing or uninformative
+   errors, please verify your configuration is valid against GCP Cloud Composer before filing bugs
+-  against the Terraform provider. * **Environments create Google Cloud Storage buckets that do not get
++  against the provider. ***Environments create Google Cloud Storage buckets that do not get
+   cleaned up automatically** on environment deletion. [More about Composer's use of Cloud
+-  Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage). * Please review the [known
++Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage).* Please review the [known
+   issues](https://cloud.google.com/composer/docs/known-issues) for Composer if you are having
+-  problems.
++  problems.***
+ 
+ ## Example Usage
+ 
+@@ -312,7 +313,7 @@ The following arguments are supported:
+   dependencies.
+ 
+ * `maintenance_window` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The configuration settings for Cloud Composer maintenance windows.
+ 
+ * `master_authorized_networks_config` -
+@@ -388,8 +389,7 @@ The following arguments are supported:
+   Cannot be updated.
+ 
+ * `max_pods_per_node` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html),
+-  Cloud Composer 1 only)
++  (Optional)
+   The maximum pods per node in the GKE cluster allocated during environment
+   creation. Lowering this value reduces IP address consumption by the Cloud
+   Composer Kubernetes cluster. This value can only be set if the environment is VPC-Native.
+@@ -588,7 +588,7 @@ The `web_server_network_access_control` supports:
+ 
+ * `recurrence` -
+   (Required)
+-  Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
++  Maintenance window recurrence. Format is a subset of RFC-5545 (<https://tools.ietf.org/html/rfc5545>) 'RRULE'.
+   The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
+   Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.
+ 
+@@ -598,7 +598,7 @@ The `web_server_network_access_control` supports:
+   Whether or not master authorized networks is enabled.
+ 
+ * `cidr_blocks` -
+-  `cidr_blocks `define up to 50 external networks that could access Kubernetes master through HTTPS. Structure is [documented below](#nested_cidr_blocks).
++  `cidr_blocks`define up to 50 external networks that could access Kubernetes master through HTTPS. Structure is [documented below](#nested_cidr_blocks).
+ 
+ <a name="nested_cidr_blocks"></a>The `cidr_blocks` supports:
+ 
+@@ -892,7 +892,7 @@ The `ip_allocation_policy` block supports:
+ 
+ * `recurrence` -
+   (Required)
+-  Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
++  Maintenance window recurrence. Format is a subset of RFC-5545 (<https://tools.ietf.org/html/rfc5545>) 'RRULE'.
+   The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
+   Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.
+ 
+diff --git b/website/docs/r/compute_address.html.markdown a/website/docs/r/compute_address.html.markdown
+index 03baa5d90..22e3577f0 100644
+--- b/website/docs/r/compute_address.html.markdown
++++ a/website/docs/r/compute_address.html.markdown
+@@ -226,7 +226,7 @@ The following arguments are supported:
+   GCE_ENDPOINT/DNS_RESOLVER purposes.
+ 
+ * `labels` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Labels to apply to this address.  A list of key->value pairs.
+ 
+ * `network` -
+diff --git b/website/docs/r/compute_attached_disk.html.markdown a/website/docs/r/compute_attached_disk.html.markdown
+index fa57b98d4..d64a8473b 100644
+--- b/website/docs/r/compute_attached_disk.html.markdown
++++ a/website/docs/r/compute_attached_disk.html.markdown
+@@ -6,8 +6,8 @@ description: |-
+ 
+ # google\_compute\_attached\_disk
+ 
+-Persistent disks can be attached to a compute instance using [the `attached_disk`
+-section within the compute instance configuration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#attached_disk).
++Persistent disks can be attached to a compute instance using the `attached_disk`
++section within the compute instance configuration.
+ However there may be situations where managing the attached disks via the compute
+ instance config isn't preferable or possible, such as attaching dynamic
+ numbers of disks using the `count` variable.
+@@ -16,7 +16,6 @@ numbers of disks using the `count` variable.
+ To get more information about attaching disks, see:
+ 
+ * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/instances/attachDisk)
+-* [Resource: google_compute_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk)
+ * How-to Guides
+     * [Adding a persistent disk](https://cloud.google.com/compute/docs/disks/add-persistent-disk)
+ 
+diff --git b/website/docs/r/compute_autoscaler.html.markdown a/website/docs/r/compute_autoscaler.html.markdown
+index 55b4e542c..3ccc8e511 100644
+--- b/website/docs/r/compute_autoscaler.html.markdown
++++ a/website/docs/r/compute_autoscaler.html.markdown
+@@ -255,7 +255,7 @@ The following arguments are supported:
+   Possible values are: `OFF`, `ONLY_UP`, `ON`.
+ 
+ * `scale_down_control` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Defines scale down controls to reduce the risk of response latency
+   and outages due to abrupt scale-in events
+   Structure is [documented below](#nested_scale_down_control).
+@@ -370,7 +370,7 @@ The following arguments are supported:
+   The metric must have a value type of INT64 or DOUBLE.
+ 
+ * `single_instance_assignment` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   If scaling is based on a per-group metric value that represents the
+   total amount of work to be done or resource usage, set this value to
+   an amount assigned for a single instance of the scaled group.
+@@ -404,7 +404,7 @@ The following arguments are supported:
+   Possible values are: `GAUGE`, `DELTA_PER_SECOND`, `DELTA_PER_MINUTE`.
+ 
+ * `filter` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   A filter string to be used as the filter string for
+   a Stackdriver Monitoring TimeSeries.list API call.
+   This filter is used to select a specific TimeSeries for
+diff --git b/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown a/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
+index 9bce1ba3a..f937568e0 100644
+--- b/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
++++ a/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
+@@ -28,9 +28,8 @@ To get more information about BackendBucketSignedUrlKey, see:
+ * How-to Guides
+     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `key_value`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `key_value` will be stored in the raw
++state as plain-text.
+ 
+ ## Example Usage - Backend Bucket Signed Url Key
+ 
+diff --git b/website/docs/r/compute_backend_service.html.markdown a/website/docs/r/compute_backend_service.html.markdown
+index 6112d056d..22c96230e 100644
+--- b/website/docs/r/compute_backend_service.html.markdown
++++ a/website/docs/r/compute_backend_service.html.markdown
+@@ -34,9 +34,8 @@ To get more information about BackendService, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=backend_service_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -655,7 +654,7 @@ The following arguments are supported:
+ <a name="nested_circuit_breakers"></a>The `circuit_breakers` block supports:
+ 
+ * `connect_timeout` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The timeout for new network connections to hosts.
+   Structure is [documented below](#nested_connect_timeout).
+ 
+diff --git b/website/docs/r/compute_backend_service_signed_url_key.html.markdown a/website/docs/r/compute_backend_service_signed_url_key.html.markdown
+index af6522a4f..a1fef9b4e 100644
+--- b/website/docs/r/compute_backend_service_signed_url_key.html.markdown
++++ a/website/docs/r/compute_backend_service_signed_url_key.html.markdown
+@@ -28,9 +28,8 @@ To get more information about BackendServiceSignedUrlKey, see:
+ * How-to Guides
+     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `key_value`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `key_value` will be stored in the raw
++state as plain-text.
+ 
+ ## Example Usage - Backend Service Signed Url Key
+ 
+diff --git b/website/docs/r/compute_disk.html.markdown a/website/docs/r/compute_disk.html.markdown
+index c58052e7f..929d8eb6d 100644
+--- b/website/docs/r/compute_disk.html.markdown
++++ a/website/docs/r/compute_disk.html.markdown
+@@ -43,9 +43,6 @@ To get more information about Disk, see:
+ * How-to Guides
+     * [Adding a persistent disk](https://cloud.google.com/compute/docs/disks/add-persistent-disk)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `disk_encryption_key.raw_key`, `disk_encryption_key.rsa_encrypted_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -172,7 +169,7 @@ The following arguments are supported:
+   If you specify this field along with `image` or `snapshot`,
+   the value must not be less than the size of the image
+   or the size of the snapshot.
+-  ~>**NOTE** If you change the size, Terraform updates the disk size
++  ~>**NOTE** If you change the size, the provider updates the disk size
+   if upsizing is detected but recreates the disk if downsizing is requested.
+   You can add `lifecycle.prevent_destroy` in the config to prevent destroying
+   and recreating.
+@@ -186,7 +183,7 @@ The following arguments are supported:
+   the supported values for the caller's project.
+ 
+ * `interface` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI.
+ 
+ * `source_disk` -
+@@ -218,16 +215,16 @@ The following arguments are supported:
+   These images can be referred by family name here.
+ 
+ * `resource_policies` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Resource policies applied to this disk for automatic snapshot creations.
+   ~>**NOTE** This value does not support updating the
+   resource policy, as resource policies can not be updated more than
+   one at a time. Use
+-  [`google_compute_disk_resource_policy_attachment`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk_resource_policy_attachment)
++  `google_compute_disk_resource_policy_attachment`
+   to allow for updating the resource policy attached to the disk.
+ 
+ * `multi_writer` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Indicates whether or not the disk can be read/write attached to more than one instance.
+ 
+ * `provisioned_iops` -
+diff --git b/website/docs/r/compute_disk_resource_policy_attachment.html.markdown a/website/docs/r/compute_disk_resource_policy_attachment.html.markdown
+index a6e6a6f3e..163b7542f 100644
+--- b/website/docs/r/compute_disk_resource_policy_attachment.html.markdown
++++ a/website/docs/r/compute_disk_resource_policy_attachment.html.markdown
+@@ -22,16 +22,17 @@ description: |-
+ Adds existing resource policies to a disk. You can only add one policy
+ which will be applied to this disk for scheduling snapshot creation.
+ 
+-~> **Note:** This resource does not support regional disks (`google_compute_region_disk`). For regional disks, please refer to [`google_compute_region_disk_resource_policy_attachment`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_disk_resource_policy_attachment)
+-
+-
++~> **Note:** This resource does not support regional disks (`google_compute_region_disk`). For regional disks, please refer to the `google_compute_region_disk_resource_policy_attachment` resource.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=disk_resource_policy_attachment_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+   </a>
+ </div>
+-## Example Usage - Disk Resource Policy Attachment Basic
++
++## Example Usage 
++
++### Disk Resource Policy Attachment Basic
+ 
+ 
+ ```hcl
+diff --git b/website/docs/r/compute_global_address.html.markdown a/website/docs/r/compute_global_address.html.markdown
+index d2c34da69..345d23b1f 100644
+--- b/website/docs/r/compute_global_address.html.markdown
++++ a/website/docs/r/compute_global_address.html.markdown
+@@ -97,7 +97,7 @@ The following arguments are supported:
+   An optional description of this resource.
+ 
+ * `labels` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Labels to apply to this address.  A list of key->value pairs.
+ 
+ * `ip_version` -
+@@ -124,7 +124,7 @@ The following arguments are supported:
+   (Optional)
+   The purpose of the resource. Possible values include:
+   * VPC_PEERING - for peer networks
+-  * PRIVATE_SERVICE_CONNECT - for ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Private Service Connect networks
++  * PRIVATE_SERVICE_CONNECT - for Private Service Connect networks
+ 
+ * `network` -
+   (Optional)
+diff --git b/website/docs/r/compute_image_iam.html.markdown a/website/docs/r/compute_image_iam.html.markdown
+index c3c7a08e5..afe1e7197 100644
+--- b/website/docs/r/compute_image_iam.html.markdown
++++ a/website/docs/r/compute_image_iam.html.markdown
+@@ -179,8 +179,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/compute_instance.html.markdown a/website/docs/r/compute_instance.html.markdown
+index 1c66ac038..df95acc55 100644
+--- b/website/docs/r/compute_instance.html.markdown
++++ a/website/docs/r/compute_instance.html.markdown
+@@ -87,7 +87,7 @@ The following arguments are supported:
+ 
+ - - -
+ 
+-* `allow_stopping_for_update` - (Optional) If true, allows Terraform to stop the instance to update its properties.
++* `allow_stopping_for_update` - (Optional) If true, allows this prvider to stop the instance to update its properties.
+   If you try to update a property that requires stopping the instance without setting this field, the update will fail.
+ 
+ * `attached_disk` - (Optional) Additional disks to attach to the instance. Can be repeated multiple times for multiple disks. Structure is [documented below](#nested_attached_disk).
+@@ -102,7 +102,7 @@ The following arguments are supported:
+ `"RUNNING"` or `"TERMINATED"`.
+ 
+ * `deletion_protection` - (Optional) Enable deletion protection on this instance. Defaults to false.
+-    **Note:** you must disable deletion protection before removing the resource (e.g., via `terraform destroy`), or the instance cannot be deleted and the Terraform run will not complete successfully.
++    **Note:** you must disable deletion protection before removing the resource (e.g., via `pulumi destroy`), or the instance cannot be deleted and the provider run will not complete successfully.
+ 
+ * `hostname` - (Optional) A custom hostname for the instance. Must be a fully qualified DNS name and RFC-1035-valid.
+   Valid format is a series of labels 1-63 characters long matching the regular expression `[a-z]([-a-z0-9]*[a-z0-9])`, concatenated with periods.
+@@ -110,11 +110,6 @@ The following arguments are supported:
+ 
+ * `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure [documented below](#nested_guest_accelerator).
+     **Note:** GPU accelerators can only be used with [`on_host_maintenance`](#on_host_maintenance) option set to TERMINATE.
+-    **Note**: This field uses [attr-as-block mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) to avoid
+-    breaking users during the 0.12 upgrade. To explicitly send a list
+-    of zero objects you must use the following syntax:
+-    `example=[]`
+-    For more details about this behavior, see [this section](https://www.terraform.io/docs/configuration/attr-as-blocks.html#defining-a-fixed-object-collection-value).
+ 
+ * `labels` - (Optional) A map of key/value label pairs to assign to the instance.
+ 
+@@ -141,8 +136,7 @@ only distinction is that this separate attribute will cause a recreate on
+ modification.  On import, `metadata_startup_script` will not be set - if you
+ choose to specify it you will see a diff immediately after import causing a
+ destroy/recreate operation. If importing an instance and specifying this value
+-is desired, you will need to modify your state file manually using
+-`terraform state` commands.
++is desired, you will need to modify your state file.
+ 
+ * `min_cpu_platform` - (Optional) Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms, such as
+ `Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).
+diff --git b/website/docs/r/compute_instance_from_machine_image.html.markdown a/website/docs/r/compute_instance_from_machine_image.html.markdown
+index f3f680e65..90c7ec52e 100644
+--- b/website/docs/r/compute_instance_from_machine_image.html.markdown
++++ a/website/docs/r/compute_instance_from_machine_image.html.markdown
+@@ -4,9 +4,6 @@ description: |-
+   Manages a VM instance resource within GCE.
+ ---
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ # google\_compute\_instance\_from\_machine\_image
+ 
+ Manages a VM instance resource within GCE. For more information see
+@@ -61,8 +58,6 @@ from `google_compute_instance` are likewise exported here.
+ ## Attributes Reference
+ 
+ All exported attributes from `google_compute_instance` are exported here.
+-See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#attributes-reference
+-for details.
+ 
+ ## Timeouts
+ 
+diff --git b/website/docs/r/compute_instance_from_template.html.markdown a/website/docs/r/compute_instance_from_template.html.markdown
+index 5d8c8103d..93e4af680 100644
+--- b/website/docs/r/compute_instance_from_template.html.markdown
++++ a/website/docs/r/compute_instance_from_template.html.markdown
+@@ -75,21 +75,9 @@ In addition to these, all arguments from `google_compute_instance` are supported
+ as a way to override the properties in the template. All exported attributes
+ from `google_compute_instance` are likewise exported here.
+ 
+-To support removal of Optional/Computed fields in Terraform 0.12 the following fields
+-are marked [Attributes as Blocks](/docs/configuration/attr-as-blocks.html):
+-
+-* `attached_disk`
+-* `guest_accelerator`
+-* `service_account`
+-* `scratch_disk`
+-* `network_interface.alias_ip_range`
+-* `network_interface.access_config`
+-
+ ## Attributes Reference
+ 
+ All exported attributes from `google_compute_instance` are exported here.
+-See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#attributes-reference
+-for details.
+ 
+ ## Import
+ 
+diff --git b/website/docs/r/compute_instance_group.html.markdown a/website/docs/r/compute_instance_group.html.markdown
+index ceb3b5c1a..84b319b75 100644
+--- b/website/docs/r/compute_instance_group.html.markdown
++++ a/website/docs/r/compute_instance_group.html.markdown
+@@ -10,16 +10,13 @@ Creates a group of dissimilar Compute Engine virtual machine instances.
+ For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)
+ and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroups)
+ 
+--> Recreating an instance group that's in use by another resource will give a
+-`resourceInUseByAnotherResource` error. You can avoid this error with a
+-Terraform `lifecycle` block as outlined in the example below.
+ 
+ ## Example Usage - Empty instance group
+ 
+ ```hcl
+ resource "google_compute_instance_group" "test" {
+-  name        = "terraform-test"
+-  description = "Terraform test instance group"
++  name        = "test"
++  description = "Test instance group"
+   zone        = "us-central1-a"
+   network     = google_compute_network.default.id
+ }
+@@ -29,8 +26,8 @@ resource "google_compute_instance_group" "test" {
+ 
+ ```hcl
+ resource "google_compute_instance_group" "webservers" {
+-  name        = "terraform-webservers"
+-  description = "Terraform test instance group"
++  name        = "webservers"
++  description = "Test instance group"
+ 
+   instances = [
+     google_compute_instance.test.id,
+diff --git b/website/docs/r/compute_instance_group_manager.html.markdown a/website/docs/r/compute_instance_group_manager.html.markdown
+index db82546f9..2953bc1b9 100644
+--- b/website/docs/r/compute_instance_group_manager.html.markdown
++++ a/website/docs/r/compute_instance_group_manager.html.markdown
+@@ -139,7 +139,7 @@ The following arguments are supported:
+     not affect existing instances.
+ 
+ * `wait_for_instances` - (Optional) Whether to wait for all instances to be created/updated before
+-    returning. Note that if this is set to true and the operation does not succeed, Terraform will
++    returning. Note that if this is set to true and the operation does not succeed, this provider will
+     continue trying until it times out.
+ 
+ * `wait_for_instances_status` - (Optional) When used with `wait_for_instances` it specifies the status to wait for.
+diff --git b/website/docs/r/compute_instance_iam.html.markdown a/website/docs/r/compute_instance_iam.html.markdown
+index 3f6b49891..6044e7982 100644
+--- b/website/docs/r/compute_instance_iam.html.markdown
++++ a/website/docs/r/compute_instance_iam.html.markdown
+@@ -188,8 +188,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/compute_instance_template.html.markdown a/website/docs/r/compute_instance_template.html.markdown
+index b995f223b..d89b34178 100644
+--- b/website/docs/r/compute_instance_template.html.markdown
++++ a/website/docs/r/compute_instance_template.html.markdown
+@@ -181,12 +181,11 @@ resource "google_compute_instance_template" "foobar" {
+ ## Using with Instance Group Manager
+ 
+ Instance Templates cannot be updated after creation with the Google
+-Cloud Platform API. In order to update an Instance Template, Terraform will
+-destroy the existing resource and create a replacement. In order to effectively
+-use an Instance Template resource with an [Instance Group Manager resource][1],
+-it's recommended to specify `create_before_destroy` in a [lifecycle][2] block.
++Cloud Platform API. In order to update an Instance Template, this provider will
++create a replacement. In order to effectively
++use an Instance Template resource with an [Instance Group Manager resource][1].
+ Either omit the Instance Template `name` attribute, or specify a partial name
+-with `name_prefix`.  Example:
++with `name_prefix`. Example:
+ 
+ ```hcl
+ resource "google_compute_instance_template" "instance_template" {
+@@ -218,7 +217,7 @@ resource "google_compute_instance_group_manager" "instance_group_manager" {
+ }
+ ```
+ 
+-With this setup Terraform generates a unique name for your Instance
++With this setup, this provider generates a unique name for your Instance
+ Template and can then update the Instance Group manager without conflict before
+ destroying the previous Instance Template.
+ 
+@@ -226,17 +225,17 @@ destroying the previous Instance Template.
+ 
+ A common way to use instance templates and managed instance groups is to deploy the
+ latest image in a family, usually the latest build of your application. There are two
+-ways to do this in Terraform, and they have their pros and cons. The difference ends
++ways to do this in the provider, and they have their pros and cons. The difference ends
+ up being in how "latest" is interpreted. You can either deploy the latest image available
+-when Terraform runs, or you can have each instance check what the latest image is when
++when the provider runs, or you can have each instance check what the latest image is when
+ it's being created, either as part of a scaling event or being rebuilt by the instance
+ group manager.
+ 
+-If you're not sure, we recommend deploying the latest image available when Terraform runs,
++If you're not sure, we recommend deploying the latest image available when the provider runs,
+ because this means all the instances in your group will be based on the same image, always,
+-and means that no upgrades or changes to your instances happen outside of a `terraform apply`.
+-You can achieve this by using the [`google_compute_image`](../d/compute_image.html)
+-data source, which will retrieve the latest image on every `terraform apply`, and will update
++and means that no upgrades or changes to your instances happen outside of a `pulumi up`.
++You can achieve this by using the `google_compute_image`
++data source, which will retrieve the latest image on every `pulumi apply`, and will update
+ the template to use that specific image:
+ 
+ ```tf
+@@ -289,8 +288,9 @@ The following arguments are supported:
+     To create a machine with a [custom type][custom-vm-types] (such as extended memory), format the value like `custom-VCPUS-MEM_IN_MB` like `custom-6-20480` for 6 vCPU and 20GB of RAM.
+ 
+ - - -
++
+ * `name` - (Optional) The name of the instance template. If you leave
+-  this blank, Terraform will auto-generate a unique name.
++  this blank, the provider will auto-generate a unique name.
+ 
+ * `name_prefix` - (Optional) Creates a unique name beginning with the specified
+   prefix. Conflicts with `name`.
+@@ -480,7 +480,7 @@ The following arguments are supported:
+ * `access_config` - (Optional) Access configurations, i.e. IPs via which this
+     instance can be accessed via the Internet. Omit to ensure that the instance
+     is not accessible from the Internet (this means that ssh provisioners will
+-    not work unless you are running Terraform can send traffic to the instance's
++    not work unless you can send traffic to the instance's
+     network (e.g. via tunnel or because it is running on another cloud instance
+     on that network). This block can be repeated multiple times. Structure [documented below](#nested_access_config).
+ 
+@@ -564,7 +564,7 @@ specified, then this instance will have no external IPv6 Internet access. Struct
+     
+ * `instance_termination_action` - (Optional) Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot) 
+ 
+-* `max_run_duration` -  (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) The duration of the instance. Instance will run and be terminated after then, the termination action could be defined in `instance_termination_action`. Only support `DELETE` `instance_termination_action` at this point. Structure is [documented below](#nested_max_run_duration).
++* `max_run_duration` -  (Optional) Beta - The duration of the instance. Instance will run and be terminated after then, the termination action could be defined in `instance_termination_action`. Only support `DELETE` `instance_termination_action` at this point. Structure is [documented below](#nested_max_run_duration).
+ <a name="nested_max_run_duration"></a>The `max_run_duration` block supports:
+ 
+ * `nanos` - (Optional) Span of time that's a fraction of a second at nanosecond
+diff --git b/website/docs/r/compute_machine_image.html.markdown a/website/docs/r/compute_machine_image.html.markdown
+index f4181c71c..ec39d570c 100644
+--- b/website/docs/r/compute_machine_image.html.markdown
++++ a/website/docs/r/compute_machine_image.html.markdown
+@@ -23,9 +23,6 @@ Represents a Machine Image resource. Machine images store all the configuration,
+ metadata, permissions, and data from one or more disks required to create a
+ Virtual machine (VM) instance.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about MachineImage, see:
+ 
+ * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/machineImages)
+diff --git b/website/docs/r/compute_machine_image_iam.html.markdown a/website/docs/r/compute_machine_image_iam.html.markdown
+index f3d525436..a368d0a48 100644
+--- b/website/docs/r/compute_machine_image_iam.html.markdown
++++ a/website/docs/r/compute_machine_image_iam.html.markdown
+@@ -33,11 +33,6 @@ A data source can be used to retrieve policy data in advent you do not need crea
+ ~> **Note:** `google_compute_machine_image_iam_binding` resources **can be** used in conjunction with `google_compute_machine_image_iam_member` resources **only if** they do not grant privilege to the same role.
+ 
+ ~> **Note:**  This resource supports IAM Conditions but they have some known limitations which can be found [here](https://cloud.google.com/iam/docs/conditions-overview#limitations). Please review this article if you are having issues with IAM Conditions.
+-
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+-
+ ## google\_compute\_machine\_image\_iam\_policy
+ 
+ ```hcl
+@@ -189,9 +184,6 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
+-  consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+ In addition to the arguments listed above, the following computed attributes are
+diff --git b/website/docs/r/compute_node_group.html.markdown a/website/docs/r/compute_node_group.html.markdown
+index a38996a97..7f446ccfe 100644
+--- b/website/docs/r/compute_node_group.html.markdown
++++ a/website/docs/r/compute_node_group.html.markdown
+@@ -28,10 +28,10 @@ To get more information about NodeGroup, see:
+ * How-to Guides
+     * [Sole-Tenant Nodes](https://cloud.google.com/compute/docs/nodes/)
+ 
+-~> **Warning:** Due to limitations of the API, Terraform cannot update the
++~> **Warning:** Due to limitations of the API, this provider cannot update the
+ number of nodes in a node group and changes to node group size either
+-through Terraform config or through external changes will cause
+-Terraform to delete and recreate the node group.
++through provider config or through external changes will cause
++the provider to delete and recreate the node group.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=node_group_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -50,8 +50,8 @@ resource "google_compute_node_template" "soletenant-tmpl" {
+ 
+ resource "google_compute_node_group" "nodes" {
+   name        = "soletenant-group"
+-  zone        = "us-central1-f"
+-  description = "example google_compute_node_group for Terraform Google Provider"
++  zone        = "us-central1-a"
++  description = "example google_compute_node_group for the Google Provider"
+ 
+   size          = 1
+   node_template = google_compute_node_template.soletenant-tmpl.id
+@@ -74,8 +74,8 @@ resource "google_compute_node_template" "soletenant-tmpl" {
+ 
+ resource "google_compute_node_group" "nodes" {
+   name        = "soletenant-group"
+-  zone        = "us-central1-f"
+-  description = "example google_compute_node_group for Terraform Google Provider"
++  zone        = "us-central1-a"
++  description = "example google_compute_node_group for Google Provider"
+   maintenance_policy = "RESTART_IN_PLACE"
+   maintenance_window {
+     start_time = "08:00"
+diff --git b/website/docs/r/compute_organization_security_policy.html.markdown a/website/docs/r/compute_organization_security_policy.html.markdown
+index 7f494f007..5079531c9 100644
+--- b/website/docs/r/compute_organization_security_policy.html.markdown
++++ a/website/docs/r/compute_organization_security_policy.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ Organization security policies are used to control incoming/outgoing traffic.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about OrganizationSecurityPolicy, see:
+ 
+ * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/organizationSecurityPolicies)
+@@ -36,7 +33,7 @@ To get more information about OrganizationSecurityPolicy, see:
+ ```hcl
+ resource "google_compute_organization_security_policy" "policy" {
+   provider = google-beta
+-  display_name = "tf-test%{random_suffix}"
++  display_name = "tf-test"
+   parent       = "organizations/123456789"
+ }
+ ```
+diff --git b/website/docs/r/compute_organization_security_policy_association.html.markdown a/website/docs/r/compute_organization_security_policy_association.html.markdown
+index 19a2aba18..b70b12789 100644
+--- b/website/docs/r/compute_organization_security_policy_association.html.markdown
++++ a/website/docs/r/compute_organization_security_policy_association.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ An association for the OrganizationSecurityPolicy.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about OrganizationSecurityPolicyAssociation, see:
+ 
+ * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/organizationSecurityPolicies/addAssociation)
+@@ -36,13 +33,13 @@ To get more information about OrganizationSecurityPolicyAssociation, see:
+ ```hcl
+ resource "google_folder" "security_policy_target" {
+   provider     = google-beta
+-  display_name = "tf-test-secpol-%{random_suffix}"
++  display_name = "tf-test-secpol"
+   parent       = "organizations/123456789"
+ }
+ 
+ resource "google_compute_organization_security_policy" "policy" {
+   provider = google-beta
+-  display_name = "tf-test%{random_suffix}"
++  display_name = "tf-test"
+   parent       = google_folder.security_policy_target.name
+ }
+ 
+@@ -70,7 +67,7 @@ resource "google_compute_organization_security_policy_rule" "policy" {
+ 
+ resource "google_compute_organization_security_policy_association" "policy" {
+   provider = google-beta
+-  name          = "tf-test%{random_suffix}"
++  name          = "tf-test"
+   attachment_id = google_compute_organization_security_policy.policy.parent
+   policy_id     = google_compute_organization_security_policy.policy.id
+ }
+diff --git b/website/docs/r/compute_organization_security_policy_rule.html.markdown a/website/docs/r/compute_organization_security_policy_rule.html.markdown
+index 39f8032b9..d92d60fbd 100644
+--- b/website/docs/r/compute_organization_security_policy_rule.html.markdown
++++ a/website/docs/r/compute_organization_security_policy_rule.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ A rule for the OrganizationSecurityPolicy.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about OrganizationSecurityPolicyRule, see:
+ 
+ * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/organizationSecurityPolicies/addRule)
+@@ -36,7 +33,7 @@ To get more information about OrganizationSecurityPolicyRule, see:
+ ```hcl
+ resource "google_compute_organization_security_policy" "policy" {
+   provider = google-beta
+-  display_name = "tf-test%{random_suffix}"
++  display_name = "tf-test"
+   parent       = "organizations/123456789"
+ }
+ 
+diff --git b/website/docs/r/compute_per_instance_config.html.markdown a/website/docs/r/compute_per_instance_config.html.markdown
+index 8c6749dfb..bc7d66972 100644
+--- b/website/docs/r/compute_per_instance_config.html.markdown
++++ a/website/docs/r/compute_per_instance_config.html.markdown
+@@ -60,7 +60,7 @@ resource "google_compute_instance_template" "igm-basic" {
+ }
+ 
+ resource "google_compute_instance_group_manager" "igm-no-tp" {
+-  description = "Terraform test instance group manager"
++  description = "Test instance group manager"
+   name        = "my-igm"
+ 
+   version {
+diff --git b/website/docs/r/compute_project_metadata_item.html.markdown a/website/docs/r/compute_project_metadata_item.html.markdown
+index 6db989502..4df438e14 100644
+--- b/website/docs/r/compute_project_metadata_item.html.markdown
++++ a/website/docs/r/compute_project_metadata_item.html.markdown
+@@ -8,7 +8,7 @@ description: |-
+ 
+ Manages a single key/value pair on metadata common to all instances for
+ a project in GCE. Using `google_compute_project_metadata_item` lets you
+-manage a single key/value setting in Terraform rather than the entire
++manage a single key/value setting in the provider rather than the entire
+ project metadata map.
+ 
+ ## Example Usage
+diff --git b/website/docs/r/compute_region_autoscaler.html.markdown a/website/docs/r/compute_region_autoscaler.html.markdown
+index 0a2164f8f..aae0493c0 100644
+--- b/website/docs/r/compute_region_autoscaler.html.markdown
++++ a/website/docs/r/compute_region_autoscaler.html.markdown
+@@ -174,7 +174,7 @@ The following arguments are supported:
+   Possible values are: `OFF`, `ONLY_UP`, `ON`.
+ 
+ * `scale_down_control` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Defines scale down controls to reduce the risk of response latency
+   and outages due to abrupt scale-in events
+   Structure is [documented below](#nested_scale_down_control).
+@@ -289,7 +289,7 @@ The following arguments are supported:
+   The metric must have a value type of INT64 or DOUBLE.
+ 
+ * `single_instance_assignment` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   If scaling is based on a per-group metric value that represents the
+   total amount of work to be done or resource usage, set this value to
+   an amount assigned for a single instance of the scaled group.
+@@ -323,7 +323,7 @@ The following arguments are supported:
+   Possible values are: `GAUGE`, `DELTA_PER_SECOND`, `DELTA_PER_MINUTE`.
+ 
+ * `filter` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   A filter string to be used as the filter string for
+   a Stackdriver Monitoring TimeSeries.list API call.
+   This filter is used to select a specific TimeSeries for
+diff --git b/website/docs/r/compute_region_backend_service.html.markdown a/website/docs/r/compute_region_backend_service.html.markdown
+index 159affebe..805e88da4 100644
+--- b/website/docs/r/compute_region_backend_service.html.markdown
++++ a/website/docs/r/compute_region_backend_service.html.markdown
+@@ -304,11 +304,7 @@ resource "google_compute_subnetwork" "default" {
+   network       = google_compute_network.default.id
+ }
+ ```
+-<div class = "oics-button" style="float: right; margin: 0 0 -15px">
+-  <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_backend_service_connection_tracking&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+-    <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+-  </a>
+-</div>
++
+ ## Example Usage - Region Backend Service Connection Tracking
+ 
+ 
+@@ -519,7 +515,7 @@ The following arguments are supported:
+   Possible values are: `NONE`, `CLIENT_IP`, `CLIENT_IP_PORT_PROTO`, `CLIENT_IP_PROTO`, `GENERATED_COOKIE`, `HEADER_FIELD`, `HTTP_COOKIE`, `CLIENT_IP_NO_DESTINATION`.
+ 
+ * `connection_tracking_policy` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Connection Tracking configuration for this BackendService.
+   This is available only for Layer 4 Internal Load Balancing and
+   Network Load Balancing.
+@@ -668,7 +664,7 @@ The following arguments are supported:
+ <a name="nested_circuit_breakers"></a>The `circuit_breakers` block supports:
+ 
+ * `connect_timeout` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The timeout for new network connections to hosts.
+   Structure is [documented below](#nested_connect_timeout).
+ 
+@@ -869,7 +865,7 @@ The following arguments are supported:
+   can be specified as values, and you cannot specify a status code more than once.
+ 
+ * `ttl` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
+   (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
+ 
+diff --git b/website/docs/r/compute_region_disk.html.markdown a/website/docs/r/compute_region_disk.html.markdown
+index 22510d9c2..aae435979 100644
+--- b/website/docs/r/compute_region_disk.html.markdown
++++ a/website/docs/r/compute_region_disk.html.markdown
+@@ -43,9 +43,8 @@ To get more information about RegionDisk, see:
+ * How-to Guides
+     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `disk_encryption_key.raw_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_disk_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -204,7 +203,7 @@ The following arguments are supported:
+   create the disk. Provide this when creating the disk.
+ 
+ * `interface` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI.
+ 
+ * `source_disk` -
+@@ -309,7 +308,7 @@ The following arguments are supported:
+   RFC 4648 base64 to either encrypt or decrypt this resource.
+ 
+ * `kms_key_name` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The name of the encryption key that is stored in Google Cloud KMS.
+ 
+ * `sha256` -
+diff --git b/website/docs/r/compute_region_disk_resource_policy_attachment.html.markdown a/website/docs/r/compute_region_disk_resource_policy_attachment.html.markdown
+index 82f60e469..71e438742 100644
+--- b/website/docs/r/compute_region_disk_resource_policy_attachment.html.markdown
++++ a/website/docs/r/compute_region_disk_resource_policy_attachment.html.markdown
+@@ -22,7 +22,7 @@ description: |-
+ Adds existing resource policies to a disk. You can only add one policy
+ which will be applied to this disk for scheduling snapshot creation.
+ 
+-~> **Note:** This resource does not support zonal disks (`google_compute_disk`). For zonal disks, please refer to [`google_compute_disk_resource_policy_attachment`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk_resource_policy_attachment)
++~> **Note:** This resource does not support zonal disks (`google_compute_disk`). For zonal disks, please refer to the `google_compute_disk_resource_policy_attachment` resource.
+ 
+ 
+ 
+@@ -31,7 +31,10 @@ which will be applied to this disk for scheduling snapshot creation.
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+   </a>
+ </div>
+-## Example Usage - Region Disk Resource Policy Attachment Basic
++
++## Example Usage
++
++### Region Disk Resource Policy Attachment Basic
+ 
+ 
+ ```hcl
+diff --git b/website/docs/r/compute_region_instance_group_manager.html.markdown a/website/docs/r/compute_region_instance_group_manager.html.markdown
+index 45e90554b..e63aa275c 100644
+--- b/website/docs/r/compute_region_instance_group_manager.html.markdown
++++ a/website/docs/r/compute_region_instance_group_manager.html.markdown
+@@ -141,7 +141,7 @@ The following arguments are supported:
+     not affect existing instances.
+ 
+ * `wait_for_instances` - (Optional) Whether to wait for all instances to be created/updated before
+-    returning. Note that if this is set to true and the operation does not succeed, Terraform will
++    returning. Note that if this is set to true and the operation does not succeed, the provider will
+     continue trying until it times out.
+ 
+ * `wait_for_instances_status` - (Optional) When used with `wait_for_instances` it specifies the status to wait for.
+diff --git b/website/docs/r/compute_region_network_endpoint_group.html.markdown a/website/docs/r/compute_region_network_endpoint_group.html.markdown
+index 5ee375c79..e1e3dde78 100644
+--- b/website/docs/r/compute_region_network_endpoint_group.html.markdown
++++ a/website/docs/r/compute_region_network_endpoint_group.html.markdown
+@@ -21,11 +21,6 @@ description: |-
+ 
+ A regional NEG that can support Serverless Products.
+ 
+-Recreating a region network endpoint group that's in use by another resource will give a
+-`resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
+-to avoid this type of error.
+-
+-
+ To get more information about RegionNetworkEndpointGroup, see:
+ 
+ * [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/regionNetworkEndpointGroups)
+diff --git b/website/docs/r/compute_region_per_instance_config.html.markdown a/website/docs/r/compute_region_per_instance_config.html.markdown
+index 180177c7b..4ca8e0b35 100644
+--- b/website/docs/r/compute_region_per_instance_config.html.markdown
++++ a/website/docs/r/compute_region_per_instance_config.html.markdown
+@@ -61,7 +61,7 @@ resource "google_compute_instance_template" "igm-basic" {
+ }
+ 
+ resource "google_compute_region_instance_group_manager" "rigm" {
+-  description = "Terraform test instance group manager"
++  description = "Demo test instance group manager"
+   name        = "my-rigm"
+ 
+   version {
+diff --git b/website/docs/r/compute_region_ssl_certificate.html.markdown a/website/docs/r/compute_region_ssl_certificate.html.markdown
+index 0c282dd0e..b6288f822 100644
+--- b/website/docs/r/compute_region_ssl_certificate.html.markdown
++++ a/website/docs/r/compute_region_ssl_certificate.html.markdown
+@@ -30,9 +30,8 @@ To get more information about RegionSslCertificate, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `certificate`, `private_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -102,7 +101,7 @@ resource "random_id" "certificate" {
+ // Using with Region Target HTTPS Proxies
+ //
+ // SSL certificates cannot be updated after creation. In order to apply
+-// the specified configuration, Terraform will destroy the existing
++// the specified configuration, the provider will destroy the existing
+ // resource and create a replacement. To effectively use an SSL
+ // certificate resource with a Target HTTPS Proxy resource, it's
+ // recommended to specify create_before_destroy in a lifecycle block.
+diff --git b/website/docs/r/compute_security_policy.html.markdown a/website/docs/r/compute_security_policy.html.markdown
+index 0b267ef52..e7d4e512b 100644
+--- b/website/docs/r/compute_security_policy.html.markdown
++++ a/website/docs/r/compute_security_policy.html.markdown
+@@ -10,7 +10,7 @@ A Security Policy defines an IP blacklist or whitelist that protects load balanc
+ see the [official documentation](https://cloud.google.com/armor/docs/configure-security-policies)
+ and the [API](https://cloud.google.com/compute/docs/reference/rest/beta/securityPolicies).
+ 
+-Security Policy is used by [`google_compute_backend_service`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service#security_policy).
++Security Policy is used by google_compute_backend_service.
+ 
+ ## Example Usage
+ 
+@@ -414,14 +414,4 @@ exported:
+ 
+ * `fingerprint` - Fingerprint of this resource.
+ 
+-* `self_link` - The URI of the created resource.
+-
+-## Import
+-
+-Security policies can be imported using any of the following formats
+-
+-```
+-$ terraform import google_compute_security_policy.policy projects/{{project}}/global/securityPolicies/{{name}}
+-$ terraform import google_compute_security_policy.policy {{project}}/{{name}}
+-$ terraform import google_compute_security_policy.policy {{name}}
+-```
++* `self_link` - The URI of the created resourc
+diff --git b/website/docs/r/compute_snapshot.html.markdown a/website/docs/r/compute_snapshot.html.markdown
+index 4c9ac8c2a..657c1f973 100644
+--- b/website/docs/r/compute_snapshot.html.markdown
++++ a/website/docs/r/compute_snapshot.html.markdown
+@@ -39,9 +39,8 @@ To get more information about Snapshot, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `snapshot_encryption_key.raw_key`, `source_disk_encryption_key.raw_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=snapshot_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+diff --git b/website/docs/r/compute_ssl_certificate.html.markdown a/website/docs/r/compute_ssl_certificate.html.markdown
+index 386f98f6b..69f2b40dd 100644
+--- b/website/docs/r/compute_ssl_certificate.html.markdown
++++ a/website/docs/r/compute_ssl_certificate.html.markdown
+@@ -30,9 +30,8 @@ To get more information about SslCertificate, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `certificate`, `private_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_certificate_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -99,12 +98,8 @@ resource "random_id" "certificate" {
+ // Using with Target HTTPS Proxies
+ //
+ // SSL certificates cannot be updated after creation. In order to apply
+-// the specified configuration, Terraform will destroy the existing
+-// resource and create a replacement. To effectively use an SSL
+-// certificate resource with a Target HTTPS Proxy resource, it's
+-// recommended to specify create_before_destroy in a lifecycle block.
+-// Either omit the Instance Template name attribute, specify a partial
+-// name with name_prefix, or use random_id resource. Example:
++// the specified configuration, the provider will destroy the existing
++// resource and create a replacement. Example:
+ 
+ resource "google_compute_ssl_certificate" "default" {
+   name_prefix = "my-certificate-"
+diff --git b/website/docs/r/compute_subnetwork.html.markdown a/website/docs/r/compute_subnetwork.html.markdown
+index ef8dccec4..08bd09e8b 100644
+--- b/website/docs/r/compute_subnetwork.html.markdown
++++ a/website/docs/r/compute_subnetwork.html.markdown
+@@ -244,11 +244,6 @@ The following arguments are supported:
+   contained in this subnetwork. The primary IP of such VM must belong
+   to the primary ipCidrRange of the subnetwork. The alias IPs may belong
+   to either primary or secondary ranges.
+-  **Note**: This field uses [attr-as-block mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) to avoid
+-  breaking users during the 0.12 upgrade. To explicitly send a list
+-  of zero objects you must use the following syntax:
+-  `example=[]`
+-  For more details about this behavior, see [this section](https://www.terraform.io/docs/configuration/attr-as-blocks.html#defining-a-fixed-object-collection-value).
+   Structure is [documented below](#nested_secondary_ip_range).
+ 
+ * `private_ip_google_access` -
+diff --git b/website/docs/r/compute_subnetwork_iam.html.markdown a/website/docs/r/compute_subnetwork_iam.html.markdown
+index eb5da7961..64556a5d4 100644
+--- b/website/docs/r/compute_subnetwork_iam.html.markdown
++++ a/website/docs/r/compute_subnetwork_iam.html.markdown
+@@ -189,8 +189,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/compute_target_instance.html.markdown a/website/docs/r/compute_target_instance.html.markdown
+index f70e08bb9..fe57068e9 100644
+--- b/website/docs/r/compute_target_instance.html.markdown
++++ a/website/docs/r/compute_target_instance.html.markdown
+@@ -143,7 +143,7 @@ The following arguments are supported:
+ 
+ 
+ * `network` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The URL of the network this target instance uses to forward traffic. If not specified, the traffic will be forwarded to the network that the default network interface belongs to.
+ 
+ * `description` -
+diff --git b/website/docs/r/compute_target_pool.html.markdown a/website/docs/r/compute_target_pool.html.markdown
+index 52f8d5b06..1d39beb3a 100644
+--- b/website/docs/r/compute_target_pool.html.markdown
++++ a/website/docs/r/compute_target_pool.html.markdown
+@@ -60,7 +60,7 @@ The following arguments are supported:
+ * `instances` - (Optional) List of instances in the pool. They can be given as
+     URLs, or in the form of "zone/name". Note that the instances need not exist
+     at the time of target pool creation, so there is no need to use the
+-    Terraform interpolators to create a dependency on the instances from the
++    interpolation to create a dependency on the instances from the
+     target pool.
+ 
+ * `project` - (Optional) The ID of the project in which the resource belongs. If it
+diff --git b/website/docs/r/compute_vpn_tunnel.html.markdown a/website/docs/r/compute_vpn_tunnel.html.markdown
+index 6513d8850..98eba8f47 100644
+--- b/website/docs/r/compute_vpn_tunnel.html.markdown
++++ a/website/docs/r/compute_vpn_tunnel.html.markdown
+@@ -29,9 +29,8 @@ To get more information about VpnTunnel, see:
+     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
+     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `shared_secret`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `shared_secret` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=vpn_tunnel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -276,7 +275,7 @@ The following arguments are supported:
+   Only IPv4 is supported.
+ 
+ * `labels` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Labels to apply to this VpnTunnel.
+ 
+ * `region` -
+diff --git b/website/docs/r/container_cluster.html.markdown a/website/docs/r/container_cluster.html.markdown
+index 5075773a1..b02d05c7a 100644
+--- b/website/docs/r/container_cluster.html.markdown
++++ a/website/docs/r/container_cluster.html.markdown
+@@ -6,19 +6,13 @@ description: |-
+ 
+ # google\_container\_cluster
+ 
+--> Visit the [Provision a GKE Cluster (Google Cloud)](https://learn.hashicorp.com/tutorials/terraform/gke?in=terraform/kubernetes&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) Learn tutorial to learn how to provision and interact
+-with a GKE cluster.
+-
+--> See the [Using GKE with Terraform](/docs/providers/google/guides/using_gke_with_terraform.html)
+-guide for more information about using GKE with Terraform.
+-
+ Manages a Google Kubernetes Engine (GKE) cluster. For more information see
+ [the official documentation](https://cloud.google.com/container-engine/docs/clusters)
+ and [the API reference](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters).
+ 
+ ~> **Warning:** All arguments and attributes, including basic auth username and
+ passwords as well as certificate outputs will be stored in the raw state as
+-plaintext. [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++plaintext. [Read more about secrets in state](https://www.pulumi.com/docs/intro/concepts/programming-model/#secrets).
+ 
+ ## Example Usage - with a separately managed node pool (recommended)
+ 
+@@ -92,6 +86,25 @@ resource "google_container_cluster" "primary" {
+ }
+ ```
+ 
++## Example Usage - autopilot
++
++```hcl
++resource "google_service_account" "default" {
++  account_id   = "service-account-id"
++  display_name = "Service Account"
++}
++
++resource "google_container_cluster" "primary" {
++  name             = "marcellus-wallace"
++  location         = "us-central1-a"
++  enable_autopilot = true
++  timeouts {
++    create = "30m"
++    update = "40m"
++  }
++}
++```
++
+ ## Argument Reference
+ 
+ * `name` - (Required) The name of the cluster, unique within the project and
+@@ -220,8 +233,7 @@ Structure is [documented below](#nested_master_auth).
+     If unset, the cluster's version will be set by GKE to the version of the most recent
+     official release (which is not necessarily the latest version).  Most users will find
+     the `google_container_engine_versions` data source useful - it indicates which versions
+-    are available, and can be use to approximate fuzzy versions in a
+-    Terraform-compatible way. If you intend to specify versions manually,
++    are available. If you intend to specify versions manually,
+     [the docs](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#specifying_cluster_version)
+     describe the various acceptable formats for this field.
+ 
+@@ -251,8 +263,11 @@ region are guaranteed to support the same version.
+ * `node_config` -  (Optional) Parameters used in creating the default node pool.
+     Generally, this field should not be used at the same time as a
+     `google_container_node_pool` or a `node_pool` block; this configuration
+-    manages the default node pool, which isn't recommended to be used with
+-    Terraform. Structure is [documented below](#nested_node_config).
++    manages the default node pool, which isn't recommended to be used.
++    Structure is [documented below](#nested_node_config).
++
++* `network_config` -  (Optional) Configuration for
++   [Adding Pod IP address ranges](https://cloud.google.com/kubernetes-engine/docs/how-to/multi-pod-cidr)) to the node pool. Structure is [documented below](#nested_network_config)
+ 
+ * `node_pool` - (Optional) List of node pools associated with this cluster.
+     See [google_container_node_pool](container_node_pool.html) for schema.
+@@ -271,9 +286,9 @@ region are guaranteed to support the same version.
+     or set to the same value as `min_master_version` on create. Defaults to the default
+     version set by GKE which is not necessarily the latest version. This only affects
+     nodes in the default node pool. While a fuzzy version can be specified, it's
+-    recommended that you specify explicit versions as Terraform will see spurious diffs
++    recommended that you specify explicit versions as the provider will see spurious diffs
+     when fuzzy versions are used. See the `google_container_engine_versions` data source's
+-    `version_prefix` field to approximate fuzzy versions in a Terraform-compatible way.
++    `version_prefix` field to approximate fuzzy versions.
+     To update nodes in other node pools, use the `version` attribute on the node pool.
+ 
+ * `notification_config` - (Optional) Configuration for the [cluster upgrade notifications](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-upgrade-notifications) feature. Structure is [documented below](#nested_notification_config).
+@@ -291,7 +306,7 @@ region are guaranteed to support the same version.
+ * `private_cluster_config` - (Optional) Configuration for [private clusters](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters),
+ clusters with private nodes. Structure is [documented below](#nested_private_cluster_config).
+ 
+-* `cluster_telemetry` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for
++* `cluster_telemetry` - (Optional) Configuration for
+    [ClusterTelemetry](https://cloud.google.com/monitoring/kubernetes-engine/installing#controlling_the_collection_of_application_logs) feature,
+    Structure is [documented below](#nested_cluster_telemetry).
+ 
+@@ -305,7 +320,7 @@ When updating this field, GKE imposes specific version requirements. See
+ [Selecting a new release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels#selecting_a_new_release_channel)
+ for more details; the `google_container_engine_versions` datasource can provide
+ the default version for a channel. Note that removing the `release_channel`
+-field from your config will cause Terraform to stop managing your cluster's
++field from your config will cause the provider to stop managing your cluster's
+ release channel, but will not unenroll it. Instead, use the `"UNSPECIFIED"`
+ channel. Structure is [documented below](#nested_release_channel).
+ 
+@@ -339,7 +354,7 @@ subnetwork in which the cluster's instances are launched.
+ * `enable_intranode_visibility` - (Optional)
+     Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.
+ 
+-* `enable_l4_ilb_subsetting` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++* `enable_l4_ilb_subsetting` - (Optional)
+     Whether L4ILB Subsetting is enabled for this cluster.
+ 
+ * `private_ipv6_google_access` - (Optional)
+@@ -397,10 +412,10 @@ subnetwork in which the cluster's instances are launched.
+ 
+ * `cloudrun_config` - (Optional). Structure is [documented below](#nested_cloudrun_config).
+ 
+-* `istio_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
++* `istio_config` - (Optional).
+     Structure is [documented below](#nested_istio_config).
+ 
+-* `identity_service_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)). Structure is [documented below](#nested_identity_service_config).
++* `identity_service_config` - (Optional). Structure is [documented below](#nested_identity_service_config).
+ 
+ * `dns_cache_config` - (Optional).
+     The status of the NodeLocal DNSCache addon. It is disabled by default.
+@@ -415,7 +430,7 @@ subnetwork in which the cluster's instances are launched.
+ *  `gke_backup_agent_config` -  (Optional).
+     The status of the Backup for GKE agent addon. It is disabled by default; Set `enabled = true` to enable.
+ 
+-* `kalm_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
++* `kalm_config` - (Optional).
+     Configuration for the KALM addon, which manages the lifecycle of k8s. It is disabled by default; Set `enabled = true` to enable.
+ 
+ *  `config_connector_config` -  (Optional).
+@@ -489,7 +504,7 @@ in addition to node auto-provisioning. Structure is [documented below](#nested_r
+ GKE Autopilot clusters.
+ Structure is [documented below](#nested_auto_provisioning_defaults).
+ 
+-* `autoscaling_profile` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Configuration
++* `autoscaling_profile` - (Optional)) Configuration
+ options for the [Autoscaling profile](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler#autoscaling_profiles)
+ feature, which lets you choose whether the cluster autoscaler should optimize for resource utilization or resource availability
+ when deciding to remove nodes from a cluster. Can be `BALANCED` or `OPTIMIZE_UTILIZATION`. Defaults to `BALANCED`.
+@@ -506,7 +521,7 @@ for a list of types.
+ 
+ <a name="nested_auto_provisioning_defaults"></a>The `auto_provisioning_defaults` block supports:
+ 
+-* `min_cpu_platform` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++* `min_cpu_platform` - (Optional)
+ Minimum CPU platform to be used for NAP created node pools. The instance may be scheduled on the
+ specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such
+ as "Intel Haswell" or "Intel Sandy Bridge".
+@@ -790,8 +805,6 @@ gvnic {
+ 
+ * `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance.
+     Structure [documented below](#nested_guest_accelerator).
+-    To support removal of guest_accelerators in Terraform 0.12 this field is an
+-    [Attribute as Block](/docs/configuration/attr-as-blocks.html)
+ 
+ * `image_type` - (Optional) The image type to use for this node. Note that changing the image type
+     will delete and recreate all nodes in the node pool.
+@@ -812,7 +825,7 @@ gvnic {
+ * `metadata` - (Optional) The metadata key/value pairs assigned to instances in
+     the cluster. From GKE `1.12` onwards, `disable-legacy-endpoints` is set to
+     `true` by the API; if `metadata` is set but that default value is not
+-    included, Terraform will attempt to unset the value. To avoid this, set the
++    included, the provider will attempt to unset the value. To avoid this, set the
+     value in your config.
+ 
+ * `min_cpu_platform` - (Optional) Minimum CPU platform to be used by this instance.
+@@ -837,10 +850,7 @@ gvnic {
+     See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms)
+     for more information. Defaults to false.
+ 
+-* `sandbox_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods) configuration. When enabling this feature you must specify `image_type = "COS_CONTAINERD"` and `node_version = "1.12.7-gke.17"` or later to use it.
+-    Structure is [documented below](#nested_sandbox_config).
+-
+-* `boot_disk_kms_key` - (Optional) The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool. This should be of the form projects/[KEY_PROJECT_ID]/locations/[LOCATION]/keyRings/[RING_NAME]/cryptoKeys/[KEY_NAME]. For more information about protecting resources with Cloud KMS Keys please see: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
++* `boot_disk_kms_key` - (Optional) The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool. This should be of the form projects/[KEY_PROJECT_ID]/locations/[LOCATION]/keyRings/[RING_NAME]/cryptoKeys/[KEY_NAME]. For more information about protecting resources with Cloud KMS Keys please see: <https://cloud.google.com/compute/docs/disks/customer-managed-encryption>
+ 
+ * `service_account` - (Optional) The service account to be used by the Node VMs.
+     If not specified, the "default" service account is used.
+@@ -853,7 +863,7 @@ gvnic {
+ * `taint` - (Optional) A list of [Kubernetes taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+ to apply to nodes. GKE's API can only set this field on cluster creation.
+ However, GKE will add taints to your nodes if you enable certain features such
+-as GPUs. If this field is set, any diffs on this field will cause Terraform to
++as GPUs. If this field is set, any diffs on this field will cause the provider to
+ recreate the underlying resource. Taint values can be updated safely in
+ Kubernetes (eg. through `kubectl`), and it's recommended that you do not use
+ this field to manage taints. If you do, `lifecycle.ignore_changes` is
+@@ -898,6 +908,14 @@ linux_node_config {
+ 
+ * `threads_per_core` - (Required) The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.
+ 
++<a name="nested_network_config"></a>The `network_config` block supports:
++
++* `create_pod_range` - (Optional) Whether to create a new range for pod IPs in this node pool. Defaults are provided for `pod_range` and `pod_ipv4_cidr_block` if they are not specified.
++
++* `pod_ipv4_cidr_block` - (Optional) The IP address range for pod IPs in this node pool. Only applicable if createPodRange is true. Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14) to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14) to pick a specific range to use.
++
++* `pod_range` - (Optional) The ID of the secondary range for pod IPs. If `create_pod_range` is true, this ID is used for the new range. If `create_pod_range` is false, uses an existing secondary range with this ID.
++
+ <a name="nested_ephemeral_storage_config"></a>The `ephemeral_storage_config` block supports:
+ 
+ * `local_ssd_count` (Required) - Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD is 375 GB in size. If zero, it means to disable using local SSDs as ephemeral storage.
+@@ -1027,7 +1045,7 @@ for more details. This field only applies to private clusters, when
+ `enable_private_nodes` is `true`.
+ 
+ * `master_global_access_config` (Optional) - Controls cluster master global
+-access settings. If unset, Terraform will no longer manage this field and will
++access settings. If unset, the provider will no longer manage this field and will
+ not modify the previously-set value. Structure is [documented below](#nested_master_global_access_config).
+ 
+ In addition, the `private_cluster_config` allows access to the following read-only fields:
+@@ -1130,9 +1148,9 @@ Enables monitoring and attestation of the boot integrity of the instance. The at
+ 
+ * `mode` (Required) How to expose the node metadata to the workload running on the node.
+     Accepted values are:
+-    * MODE_UNSPECIFIED: Not Set
+-    * GCE_METADATA: Expose all Compute Engine metadata to pods.
+-    * GKE_METADATA: Run the GKE Metadata Server on this node. The GKE Metadata Server exposes a metadata API to workloads that is compatible with the V1 Compute Metadata APIs exposed by the Compute Engine and App Engine Metadata Servers. This feature can only be enabled if [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) is enabled at the cluster level.
++  * UNSPECIFIED: Not Set
++  * GCE_METADATA: Expose all Compute Engine metadata to pods.
++  * GKE_METADATA: Run the GKE Metadata Server on this node. The GKE Metadata Server exposes a metadata API to workloads that is compatible with the V1 Compute Metadata APIs exposed by the Compute Engine and App Engine Metadata Servers. This feature can only be enabled if [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) is enabled at the cluster level.
+ 
+ <a name="nested_kubelet_config"></a>The `kubelet_config` block supports:
+ 
+diff --git b/website/docs/r/container_node_pool.html.markdown a/website/docs/r/container_node_pool.html.markdown
+index 9456e67ef..5cd652978 100644
+--- b/website/docs/r/container_node_pool.html.markdown
++++ a/website/docs/r/container_node_pool.html.markdown
+@@ -6,14 +6,11 @@ description: |-
+ 
+ # google\_container\_node\_pool
+ 
+--> See the [Using GKE with Terraform](/docs/providers/google/guides/using_gke_with_terraform.html)
+-guide for more information about using GKE with Terraform.
+-
+ Manages a node pool in a Google Kubernetes Engine (GKE) cluster separately from
+ the cluster control plane. For more information see [the official documentation](https://cloud.google.com/container-engine/docs/node-pools)
+ and [the API reference](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters.nodePools).
+ 
+-### Example Usage - using a separately managed node pool (recommended)
++## Example Usage - using a separately managed node pool (recommended)
+ 
+ ```hcl
+ resource "google_service_account" "default" {
+@@ -50,7 +47,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
+ }
+ ```
+ 
+-### Example Usage - 2 node pools, 1 separately managed + the default node pool
++## Example Usage - 2 node pools, 1 separately managed + the default node pool
+ 
+ ```hcl
+ resource "google_service_account" "default" {
+@@ -115,9 +112,9 @@ resource "google_container_cluster" "primary" {
+     regional or multi-zonal clusters, this is the number of nodes per zone. Changing
+     this will force recreation of the resource. WARNING: Resizing your node pool manually
+     may change this value in your existing cluster, which will trigger destruction
+-    and recreation on the next Terraform run (to rectify the discrepancy).  If you don't
+-    need this value, don't set it.  If you do need it, you can [use a lifecycle block to
+-    ignore subsequent changes to this field](https://github.com/hashicorp/terraform-provider-google/issues/6901#issuecomment-667369691).
++    and recreation on the next provider run (to rectify the discrepancy).  If you don't
++    need this value, don't set it.  If you do need it, you can use a lifecycle block to
++    ignore subsqeuent changes to this field.
+ 
+ * `management` - (Optional) Node management configuration, wherein auto-repair and
+     auto-upgrade is configured. Structure is [documented below](#nested_management).
+@@ -138,7 +135,7 @@ cluster's zone for zonal clusters. If unspecified, the cluster-level
+ upon being unset. You must manually reconcile the list of zones with your
+ cluster.
+ 
+-* `name` - (Optional) The name of the node pool. If left blank, Terraform will
++* `name` - (Optional) The name of the node pool. If left blank, the provider will
+     auto-generate a unique name.
+ 
+ * `name_prefix` - (Optional) Creates a unique name for the node pool beginning
+@@ -163,9 +160,9 @@ cluster.
+ * `version` - (Optional) The Kubernetes version for the nodes in this pool. Note that if this field
+     and `auto_upgrade` are both specified, they will fight each other for what the node version should
+     be, so setting both is highly discouraged. While a fuzzy version can be specified, it's
+-    recommended that you specify explicit versions as Terraform will see spurious diffs
++    recommended that you specify explicit versions as the provider will see spurious diffs
+     when fuzzy versions are used. See the `google_container_engine_versions` data source's
+-    `version_prefix` field to approximate fuzzy versions in a Terraform-compatible way.
++    `version_prefix` field to approximate fuzzy versions in a provider-compatible way.
+ 
+ * `placement_policy` - (Optional) Specifies a custom placement policy for the
+   nodes.
+diff --git b/website/docs/r/data_catalog_entry_group.html.markdown a/website/docs/r/data_catalog_entry_group.html.markdown
+index d43084587..9a40b4120 100644
+--- b/website/docs/r/data_catalog_entry_group.html.markdown
++++ a/website/docs/r/data_catalog_entry_group.html.markdown
+@@ -53,8 +53,8 @@ resource "google_data_catalog_entry_group" "basic_entry_group" {
+ resource "google_data_catalog_entry_group" "basic_entry_group" {
+   entry_group_id = "my_group"
+ 
+-  display_name = "terraform entry group"
+-  description = "entry group created by Terraform"
++  display_name = "entry group"
++  description = "example entry group"
+ }
+ ```
+ 
+diff --git b/website/docs/r/dataflow_flex_template_job.html.markdown a/website/docs/r/dataflow_flex_template_job.html.markdown
+index 5e81a137b..0f1495936 100644
+--- b/website/docs/r/dataflow_flex_template_job.html.markdown
++++ a/website/docs/r/dataflow_flex_template_job.html.markdown
+@@ -29,7 +29,7 @@ There are many types of Dataflow jobs.  Some Dataflow jobs run constantly,
+ getting new data from (e.g.) a GCS bucket, and outputting data continuously.
+ Some jobs process a set amount of data then terminate. All jobs can fail while
+ running due to programming errors or other issues. In this way, Dataflow jobs
+-are different from most other Terraform / Google resources.
++are different from most other provider / Google resources.
+ 
+ The Dataflow resource is considered 'existing' while it is in a nonterminal
+ state.  If it reaches a terminal state (e.g. 'FAILED', 'COMPLETE',
+@@ -42,7 +42,7 @@ A Dataflow job which is 'destroyed' may be "cancelled" or "drained".  If
+ new data will be processed.  If "drained", no new data will enter the pipeline,
+ but any data currently in the pipeline will finish being processed.  The default
+ is "cancelled", but if a user sets `on_delete` to `"drain"` in the
+-configuration, you may experience a long wait for your `terraform destroy` to
++configuration, you may experience a long wait for your `pulumi destroy` to
+ complete.
+ 
+ You can potentially short-circuit the wait by setting `skip_wait_on_job_termination`
+@@ -94,13 +94,14 @@ such as `serviceAccount`, `workerMachineType`, etc can be specified here.
+ 
+ * `labels` - (Optional) User labels to be specified for the job. Keys and values
+ should follow the restrictions specified in the [labeling restrictions](https://cloud.google.com/compute/docs/labeling-resources#restrictions)
+-page. 
++page. **Note**: This field is marked as deprecated as the API does not currently
++support adding labels.
+ **NOTE**: Google-provided Dataflow templates often provide default labels
+ that begin with `goog-dataflow-provided`. Unless explicitly set in config, these
+ labels will be ignored to prevent diffs on re-apply.
+ 
+ * `on_delete` - (Optional) One of "drain" or "cancel". Specifies behavior of
+-deletion during `terraform destroy`.  See above note.
++deletion during `pulumi destroy`.  See above note.
+ 
+ * `skip_wait_on_job_termination` - (Optional)  If set to `true`, terraform will
+ treat `DRAINING` and `CANCELLING` as terminal states when deleting the resource,
+diff --git b/website/docs/r/dataflow_job.html.markdown a/website/docs/r/dataflow_job.html.markdown
+index 6000b9649..7b7e73453 100644
+--- b/website/docs/r/dataflow_job.html.markdown
++++ a/website/docs/r/dataflow_job.html.markdown
+@@ -23,44 +23,47 @@ resource "google_dataflow_job" "big_data_job" {
+   }
+ }
+ ```
++
+ ## Example Usage - Streaming Job
++
+ ```hcl
+ resource "google_pubsub_topic" "topic" {
+-	name     = "dataflow-job1"
++ name     = "dataflow-job1"
+ }
+ resource "google_storage_bucket" "bucket1" {
+-	name          = "tf-test-bucket1"
+-	location      = "US"
+-	force_destroy = true
++ name          = "tf-test-bucket1"
++ location      = "US"
++ force_destroy = true
+ }
+ resource "google_storage_bucket" "bucket2" {
+-	name          = "tf-test-bucket2"
+-	location      = "US"
+-	force_destroy = true
++ name          = "tf-test-bucket2"
++ location      = "US"
++ force_destroy = true
+ }
+ resource "google_dataflow_job" "pubsub_stream" {
+-	name = "tf-test-dataflow-job1"
+-	template_gcs_path = "gs://my-bucket/templates/template_file"
+-	temp_gcs_location = "gs://my-bucket/tmp_dir"
+-	enable_streaming_engine = true
+-	parameters = {
+-	  inputFilePattern = "${google_storage_bucket.bucket1.url}/*.json"
+-	  outputTopic    = google_pubsub_topic.topic.id
+-	}
+-	transform_name_mapping = {
+-		name = "test_job"
+-		env = "test"
+-	}
+-	on_delete = "cancel"
++ name = "tf-test-dataflow-job1"
++ template_gcs_path = "gs://my-bucket/templates/template_file"
++ temp_gcs_location = "gs://my-bucket/tmp_dir"
++ enable_streaming_engine = true
++ parameters = {
++   inputFilePattern = "${google_storage_bucket.bucket1.url}/*.json"
++   outputTopic    = google_pubsub_topic.topic.id
++ }
++ transform_name_mapping = {
++  name = "test_job"
++  env = "test"
++ }
++ on_delete = "cancel"
+ }
+ ```
+ 
+ ## Note on "destroy" / "apply"
+-There are many types of Dataflow jobs.  Some Dataflow jobs run constantly, getting new data from (e.g.) a GCS bucket, and outputting data continuously.  Some jobs process a set amount of data then terminate.  All jobs can fail while running due to programming errors or other issues.  In this way, Dataflow jobs are different from most other Terraform / Google resources.
++
++There are many types of Dataflow jobs.  Some Dataflow jobs run constantly, getting new data from (e.g.) a GCS bucket, and outputting data continuously.  Some jobs process a set amount of data then terminate.  All jobs can fail while running due to programming errors or other issues.  In this way, Dataflow jobs are different from most other Google resources.
+ 
+ The Dataflow resource is considered 'existing' while it is in a nonterminal state.  If it reaches a terminal state (e.g. 'FAILED', 'COMPLETE', 'CANCELLED'), it will be recreated on the next 'apply'.  This is as expected for jobs which run continuously, but may surprise users who use this resource for other kinds of Dataflow jobs.
+ 
+-A Dataflow job which is 'destroyed' may be "cancelled" or "drained".  If "cancelled", the job terminates - any data written remains where it is, but no new data will be processed.  If "drained", no new data will enter the pipeline, but any data currently in the pipeline will finish being processed.  The default is "drain". When `on_delete` is set to `"drain"` in the configuration, you may experience a long wait for your `terraform destroy` to complete.
++A Dataflow job which is 'destroyed' may be "cancelled" or "drained".  If "cancelled", the job terminates - any data written remains where it is, but no new data will be processed.  If "drained", no new data will enter the pipeline, but any data currently in the pipeline will finish being processed.  The default is "drain". When `on_delete` is set to `"drain"` in the configuration, you may experience a long wait for your `pulumi destroy` to complete.
+ 
+ You can potentially short-circuit the wait by setting `skip_wait_on_job_termination` to `true`, but beware that unless you take active steps to ensure that the job `name` parameter changes between instances, the name will conflict and the launch of the new job will fail. One way to do this is with a [random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) resource, for example:
+ 
+@@ -106,8 +109,8 @@ The following arguments are supported:
+    Unless explicitly set in config, these labels will be ignored to prevent diffs on re-apply.
+ * `transform_name_mapping` - (Optional) Only applicable when updating a pipeline. Map of transform name prefixes of the job to be replaced with the corresponding name prefixes of the new job. This field is not used outside of update.
+ * `max_workers` - (Optional) The number of workers permitted to work on the job.  More workers may improve processing speed at additional cost.
+-* `on_delete` - (Optional) One of "drain" or "cancel".  Specifies behavior of deletion during `terraform destroy`.  See above note.
+-* `skip_wait_on_job_termination` - (Optional)  If set to `true`, terraform will treat `DRAINING` and `CANCELLING` as terminal states when deleting the resource, and will remove the resource from terraform state and move on.  See above note.
++* `on_delete` - (Optional) One of "drain" or "cancel".  Specifies behavior of deletion during `pulumi destroy`.  See above note.
++* `skip_wait_on_job_termination` - (Optional)  If set to `true`, Pulumi will treat `DRAINING` and `CANCELLING` as terminal states when deleting the resource, and will remove the resource from Pulumi state and move on.  See above note.
+ * `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
+ * `zone` - (Optional) The zone in which the created job should run. If it is not provided, the provider zone is used.
+ * `region` - (Optional) The region in which the created job should run.
+diff --git b/website/docs/r/dataproc_cluster.html.markdown a/website/docs/r/dataproc_cluster.html.markdown
+index 1aa6310d0..8b89bb68a 100644
+--- b/website/docs/r/dataproc_cluster.html.markdown
++++ a/website/docs/r/dataproc_cluster.html.markdown
+@@ -139,7 +139,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
+ * `cluster_config` - (Optional) Allows you to configure various aspects of the cluster.
+    Structure [defined below](#nested_cluster_config).
+ 
+-* `graceful_decommission_timeout` - (Optional) Allows graceful decomissioning when you change the number of worker nodes directly through a terraform apply.
++* `graceful_decommission_timout` - (Optional) Allows graceful decomissioning when you change the number of worker nodes directly through an apply.
+       Does not affect auto scaling decomissioning from an autoscaling policy.
+       Graceful decommissioning allows removing nodes from the cluster without interrupting jobs in progress.
+       Timeout specifies how long to wait for jobs in progress to finish before forcefully removing nodes (and potentially interrupting jobs).
+@@ -614,7 +614,6 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
+   * PREEMPTIBILITY_UNSPECIFIED
+   * NON_PREEMPTIBLE
+   * PREEMPTIBLE
+-  * SPOT
+ 
+ * `disk_config` (Optional) Disk Config
+ 
+diff --git b/website/docs/r/dataproc_cluster_iam.html.markdown a/website/docs/r/dataproc_cluster_iam.html.markdown
+index e71b4fc38..4f372bfac 100644
+--- b/website/docs/r/dataproc_cluster_iam.html.markdown
++++ a/website/docs/r/dataproc_cluster_iam.html.markdown
+@@ -85,10 +85,10 @@ For `google_dataproc_cluster_iam_member` or `google_dataproc_cluster_iam_binding
+ - - -
+ 
+ * `project` - (Optional) The project in which the cluster belongs. If it
+-    is not provided, Terraform will use the provider default.
++    is not provided, the provider will use a default.
+ 
+ * `region` - (Optional) The region in which the cluster belongs. If it
+-    is not provided, Terraform will use the provider default.
++    is not provided, the provider will use a default.
+ 
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/dataproc_job_iam.html.markdown a/website/docs/r/dataproc_job_iam.html.markdown
+index 277b7072c..6ba67959e 100644
+--- b/website/docs/r/dataproc_job_iam.html.markdown
++++ a/website/docs/r/dataproc_job_iam.html.markdown
+@@ -85,10 +85,10 @@ For `google_dataproc_job_iam_member` or `google_dataproc_job_iam_binding`:
+ - - -
+ 
+ * `project` - (Optional) The project in which the job belongs. If it
+-    is not provided, Terraform will use the provider default.
++    is not provided, the provider will use a default.
+ 
+ * `region` - (Optional) The region in which the job belongs. If it
+-    is not provided, Terraform will use the provider default.
++    is not provided, the provider will use a default.
+ 
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/deployment_manager_deployment.html.markdown a/website/docs/r/deployment_manager_deployment.html.markdown
+index f4636a482..ea7631b87 100644
+--- b/website/docs/r/deployment_manager_deployment.html.markdown
++++ a/website/docs/r/deployment_manager_deployment.html.markdown
+@@ -25,15 +25,13 @@ a configuration file
+ 
+ 
+ 
+-~> **Warning:** Deployment Manager shares similar behavior with Terraform as both
+-products manage GCP resource lifecycle and state. This Terraform
+-resource is intended only to manage a Deployment resource,
+-and attempts to manage the Deployment's resources in Terraform as well
++~> **Warning:** This resource is intended only to manage a Deployment resource,
++and attempts to manage the Deployment's resources in the provider as well
+ will likely result in errors or unexpected behavior as the two tools
+ fight over ownership. We strongly discourage doing so unless you are an
+ experienced user of both tools.
+ 
+-In addition, due to limitations of the API, Terraform will treat
++In addition, due to limitations of the API, the provider will treat
+ deployments in preview as recreate-only for any update operation other
+ than actually deploying an in-preview deployment (i.e. `preview=true` to
+ `preview=false`).
+@@ -181,7 +179,7 @@ The following arguments are supported:
+   with real resources.
+    ~>**NOTE:** Deployment Manager does not allow update
+   of a deployment in preview (unless updating to preview=false). Thus,
+-  Terraform will force-recreate deployments if either preview is updated
++  the provider will force-recreate deployments if either preview is updated
+   to true or if other fields are updated while preview is true.
+ 
+ * `project` - (Optional) The ID of the project in which the resource belongs.
+diff --git b/website/docs/r/dialogflow_agent.html.markdown a/website/docs/r/dialogflow_agent.html.markdown
+index 777daec36..4e44a4540 100644
+--- b/website/docs/r/dialogflow_agent.html.markdown
++++ a/website/docs/r/dialogflow_agent.html.markdown
+@@ -130,8 +130,7 @@ The following arguments are supported:
+   * TIER_ENTERPRISE: Enterprise tier (Essentials).
+   * TIER_ENTERPRISE_PLUS: Enterprise tier (Plus).
+   NOTE: Due to consistency issues, the provider will not read this field from the API. Drift is possible between
+-  the Terraform state and Dialogflow if the agent tier is changed outside of Terraform.
+-  Possible values are: `TIER_STANDARD`, `TIER_ENTERPRISE`, `TIER_ENTERPRISE_PLUS`.
++  the the provider state and Dialogflow if the agent tier is changed outside of the provider.
+ 
+ * `project` - (Optional) The ID of the project in which the resource belongs.
+     If it is not provided, the provider project is used.
+diff --git b/website/docs/r/dns_managed_zone.html.markdown a/website/docs/r/dns_managed_zone.html.markdown
+index 33ad1abf3..1eac523d3 100644
+--- b/website/docs/r/dns_managed_zone.html.markdown
++++ a/website/docs/r/dns_managed_zone.html.markdown
+@@ -42,16 +42,12 @@ To get more information about ManagedZone, see:
+ ```hcl
+ resource "google_dns_managed_zone" "example-zone" {
+   name        = "example-zone"
+-  dns_name    = "example-${random_id.rnd.hex}.com."
++  dns_name    = "my-domain.com."
+   description = "Example DNS zone"
+   labels = {
+     foo = "bar"
+   }
+ }
+-
+-resource "random_id" "rnd" {
+-  byte_length = 4
+-}
+ ```
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dns_managed_zone_private&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -92,8 +88,8 @@ resource "google_compute_network" "network-2" {
+   auto_create_subnetworks = false
+ }
+ ```
+-## Example Usage - Dns Managed Zone Private Forwarding
+ 
++## Example Usage - Dns Managed Zone Private Forwarding
+ 
+ ```hcl
+ resource "google_dns_managed_zone" "private-zone" {
+@@ -330,13 +326,11 @@ The following arguments are supported:
+   User assigned name for this resource.
+   Must be unique within the project.
+ 
+-
+ - - -
+ 
+-
+ * `description` -
+   (Optional)
+-  A textual description field. Defaults to 'Managed by Terraform'.
++  A textual description field. Defaults to 'Managed by Pulumi'.
+ 
+ * `dnssec_config` -
+   (Optional)
+@@ -374,13 +368,13 @@ The following arguments are supported:
+   Structure is [documented below](#nested_peering_config).
+ 
+ * `reverse_lookup` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   Specifies if this is a managed reverse lookup zone. If true, Cloud DNS will resolve reverse
+   lookup queries using automatically configured records for VPC resources. This only applies
+   to networks listed under `private_visibility_config`.
+ 
+ * `service_directory_config` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The presence of this field indicates that this zone is backed by Service Directory. The value of this field contains information related to the namespace associated with the zone.
+   Structure is [documented below](#nested_service_directory_config).
+ 
+diff --git b/website/docs/r/dns_policy.html.markdown a/website/docs/r/dns_policy.html.markdown
+index 137f7a3a9..6f9b457a8 100644
+--- b/website/docs/r/dns_policy.html.markdown
++++ a/website/docs/r/dns_policy.html.markdown
+@@ -96,7 +96,7 @@ The following arguments are supported:
+ 
+ * `description` -
+   (Optional)
+-  A textual description field. Defaults to 'Managed by Terraform'.
++  A textual description field. Defaults to 'Managed by Pulumi'.
+ 
+ * `enable_inbound_forwarding` -
+   (Optional)
+diff --git b/website/docs/r/firebase_project.html.markdown a/website/docs/r/firebase_project.html.markdown
+index 744d462d0..0cbb1104c 100644
+--- b/website/docs/r/firebase_project.html.markdown
++++ a/website/docs/r/firebase_project.html.markdown
+@@ -24,9 +24,6 @@ Since a FirebaseProject is actually also a GCP Project, a FirebaseProject uses u
+ identifiers (most importantly, the projectId) as its own for easy interop with GCP APIs.
+ Once Firebase has been added to a Google Project it cannot be removed.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about Project, see:
+ 
+ * [API documentation](https://firebase.google.com/docs/reference/firebase-management/rest/v1beta1/projects)
+@@ -40,8 +37,8 @@ To get more information about Project, see:
+ resource "google_project" "default" {
+   provider = google-beta
+ 
+-  project_id = "tf-test%{random_suffix}"
+-  name       = "tf-test%{random_suffix}"
++  project_id = "tf-test"
++  name       = "tf-test"
+   org_id     = "123456789"
+ 
+   labels = {
+diff --git b/website/docs/r/firebase_project_location.html.markdown a/website/docs/r/firebase_project_location.html.markdown
+index 818c02fca..01a10d34c 100644
+--- b/website/docs/r/firebase_project_location.html.markdown
++++ a/website/docs/r/firebase_project_location.html.markdown
+@@ -28,9 +28,6 @@ GCP Project already has an App Engine application or defaultLocation.finalize wa
+ specified locationId. Any new calls to defaultLocation.finalize with a different specified locationId will
+ return a 409 error.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about ProjectLocation, see:
+ 
+ * [API documentation](https://firebase.google.com/docs/reference/firebase-management/rest/v1beta1/projects.defaultLocation/finalize)
+@@ -44,8 +41,8 @@ To get more information about ProjectLocation, see:
+ resource "google_project" "default" {
+   provider = google-beta
+ 
+-  project_id = "tf-test%{random_suffix}"
+-  name       = "tf-test%{random_suffix}"
++  project_id = "tf-test"
++  name       = "tf-test"
+   org_id     = "123456789"
+ 
+   labels = {
+diff --git b/website/docs/r/firebase_web_app.html.markdown a/website/docs/r/firebase_web_app.html.markdown
+index 1aefa5a59..d6d7d1563 100644
+--- b/website/docs/r/firebase_web_app.html.markdown
++++ a/website/docs/r/firebase_web_app.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ A Google Cloud Firebase web application instance
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about WebApp, see:
+ 
+ * [API documentation](https://firebase.google.com/docs/reference/firebase-management/rest/v1beta1/projects.webApps)
+@@ -37,8 +34,8 @@ To get more information about WebApp, see:
+ resource "google_project" "default" {
+ 	provider = google-beta
+ 
+-	project_id = "tf-test%{random_suffix}"
+-	name       = "tf-test%{random_suffix}"
++	project_id = "tf-test"
++	name       = "tf-test"
+ 	org_id     = "123456789"
+ 
+ 	labels = {
+diff --git b/website/docs/r/gke_hub_membership.html.markdown a/website/docs/r/gke_hub_membership.html.markdown
+index 08fccbc5f..c2602add9 100644
+--- b/website/docs/r/gke_hub_membership.html.markdown
++++ a/website/docs/r/gke_hub_membership.html.markdown
+@@ -92,7 +92,7 @@ The following arguments are supported:
+ 
+ 
+ * `description` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   The name of this entity type to be displayed on the console. This field is unavailable in v1 of the API.
+ 
+ * `labels` -
+diff --git b/website/docs/r/google_billing_subaccount.html.markdown a/website/docs/r/google_billing_subaccount.html.markdown
+index c28d3d3ed..91c8f661f 100644
+--- b/website/docs/r/google_billing_subaccount.html.markdown
++++ a/website/docs/r/google_billing_subaccount.html.markdown
+@@ -8,7 +8,7 @@ description: |-
+ 
+ Allows creation and management of a Google Cloud Billing Subaccount.
+ 
+-!> **WARNING:** Deleting this Terraform resource will not delete or close the billing subaccount.
++!> **WARNING:** Deleting this resource will not delete or close the billing subaccount.
+ 
+ ```hcl
+ resource "google_billing_subaccount" "subaccount" {
+@@ -25,7 +25,7 @@ resource "google_billing_subaccount" "subaccount" {
+   will be created under in the form `{billing_account_id}` or `billingAccounts/{billing_account_id}`.
+ 
+ * `deletion_policy` (Optional) - If set to "RENAME_ON_DESTROY" the billing account display_name
+-  will be changed to "Terraform Destroyed" along with a timestamp.  If set to "" this will not occur.
++  will be changed to "Destroyed" along with a timestamp.  If set to "" this will not occur.
+   Default is "".
+ 
+ ## Attributes Reference
+diff --git b/website/docs/r/google_folder.html.markdown a/website/docs/r/google_folder.html.markdown
+index 7d3b5c9b8..cc3653b03 100644
+--- b/website/docs/r/google_folder.html.markdown
++++ a/website/docs/r/google_folder.html.markdown
+@@ -15,7 +15,7 @@ A folder can contain projects, other folders, or a combination of both. You can
+ 
+ Folders created live inside an Organization. See the [Organization documentation](https://cloud.google.com/resource-manager/docs/quickstarts) for more details.
+ 
+-The service account used to run Terraform when creating a `google_folder`
++The service account used to run the provider when creating a `google_folder`
+ resource must have `roles/resourcemanager.folderCreator`. See the
+ [Access Control for Folders Using IAM](https://cloud.google.com/resource-manager/docs/access-control-folders)
+ doc for more information.
+diff --git b/website/docs/r/google_folder_iam.html.markdown a/website/docs/r/google_folder_iam.html.markdown
+index 1c4b861ee..be01f90cf 100644
+--- b/website/docs/r/google_folder_iam.html.markdown
++++ a/website/docs/r/google_folder_iam.html.markdown
+@@ -28,7 +28,7 @@ Four different resources help you manage your IAM policy for a folder. Each of t
+    from anyone without permissions on its parent folder/organization. Proceed with caution.
+    It's not recommended to use `google_folder_iam_policy` with your provider folder
+    to avoid locking yourself out, and it should generally only be used with folders
+-   fully managed by Terraform. If you do use this resource, it is recommended to **import** the policy before
++   fully managed by this provider. If you do use this resource, it is recommended to **import** the policy before
+    applying the change.
+ 
+ ```hcl
+@@ -198,8 +198,8 @@ The following arguments are supported:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ 
+ ## Attributes Reference
+diff --git b/website/docs/r/google_folder_iam_binding.html.markdown a/website/docs/r/google_folder_iam_binding.html.markdown
+new file mode 100644
+index 000000000..0be906773
+--- /dev/null
++++ a/website/docs/r/google_folder_iam_binding.html.markdown
+@@ -0,0 +1,75 @@
++---
++subcategory: "Cloud Platform"
++layout: "google"
++page_title: "Google: google_folder_iam_binding"
++sidebar_current: "docs-google-folder-iam-binding"
++description: |-
++ Allows management of a single binding with an IAM policy for a Google Cloud Platform folder.
++---
++
++# google\_folder\_iam\_binding
++
++Allows creation and management of a single binding within IAM policy for
++an existing Google Cloud Platform folder.
++
++~> **Note:** This resource _must not_ be used in conjunction with
++   `google_folder_iam_policy` or they will fight over what your policy
++   should be.
++
++~> **Note:** On create, this resource will overwrite members of any existing roles.
++    Use `pulumi import` and inspect the output to ensure
++    your existing members are preserved.
++
++## Example Usage
++
++```hcl
++resource "google_folder" "department1" {
++  display_name = "Department 1"
++  parent       = "organizations/1234567"
++}
++
++resource "google_folder_iam_binding" "admin" {
++  folder = google_folder.department1.name
++  role   = "roles/editor"
++
++  members = [
++    "user:alice@gmail.com",
++  ]
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `folder` - (Required) The resource name of the folder the policy is attached to. Its format is folders/{folder_id}.
++
++* `members` (Required) - An array of identities that will be granted the privilege in the `role`.
++  Each entry can have one of the following values:
++  * **user:{emailid}**: An email address that is associated with a specific Google account. For example, alice@gmail.com.
++  * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
++  * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
++  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
++  * For more details on format and restrictions see https://cloud.google.com/billing/reference/rest/v1/Policy#Binding
++
++* `role` - (Required) The role that should be applied. Only one
++    `google_folder_iam_binding` can be used per role. Note that custom roles must be of the format
++    `[projects|organizations]/{parent-name}/roles/{role-name}`.
++
++## Attributes Reference
++
++In addition to the arguments listed above, the following computed attributes are
++exported:
++
++* `etag` - (Computed) The etag of the folder's IAM policy.
++
++## Import
++
++IAM binding imports use space-delimited identifiers; first the resource in question and then the role.  These bindings can be imported using the `folder` and role, e.g.
++
++```
++$ terraform import google_folder_iam_binding.viewer "folder-name roles/viewer"
++```
++
++-> **Custom Roles**: If you're importing a IAM binding with a custom role, make sure to use the
++ full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
+diff --git b/website/docs/r/google_kms_crypto_key_iam.html.markdown a/website/docs/r/google_kms_crypto_key_iam.html.markdown
+index 1567f3ff1..7b7a19673 100644
+--- b/website/docs/r/google_kms_crypto_key_iam.html.markdown
++++ a/website/docs/r/google_kms_crypto_key_iam.html.markdown
+@@ -48,7 +48,7 @@ resource "google_kms_crypto_key_iam_policy" "crypto_key" {
+ }
+ ```
+ 
+-With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
++With IAM Conditions:
+ 
+ ```hcl
+ data "google_iam_policy" "admin" {
+@@ -81,7 +81,7 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+ }
+ ```
+ 
+-With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
++With IAM Conditions:
+ 
+ ```hcl
+ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+@@ -110,7 +110,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
+ }
+ ```
+ 
+-With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
++With IAM Conditions:
+ 
+ ```hcl
+ resource "google_kms_crypto_key_iam_member" "crypto_key" {
+@@ -163,8 +163,8 @@ The following arguments are supported:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** The provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ 
+ ## Attributes Reference
+diff --git b/website/docs/r/google_kms_key_ring_iam.html.markdown a/website/docs/r/google_kms_key_ring_iam.html.markdown
+index 5a5d38d18..d4de234a8 100644
+--- b/website/docs/r/google_kms_key_ring_iam.html.markdown
++++ a/website/docs/r/google_kms_key_ring_iam.html.markdown
+@@ -40,7 +40,7 @@ resource "google_kms_key_ring_iam_policy" "key_ring" {
+ }
+ ```
+ 
+-With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
++With IAM Conditions:
+ 
+ ```hcl
+ resource "google_kms_key_ring" "keyring" {
+@@ -83,7 +83,7 @@ resource "google_kms_key_ring_iam_binding" "key_ring" {
+ }
+ ```
+ 
+-With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
++With IAM Conditions:
+ 
+ ```hcl
+ resource "google_kms_key_ring_iam_binding" "key_ring" {
+@@ -112,7 +112,7 @@ resource "google_kms_key_ring_iam_member" "key_ring" {
+ }
+ ```
+ 
+-With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
++With IAM Conditions:
+ 
+ ```hcl
+ resource "google_kms_key_ring_iam_member" "key_ring" {
+@@ -166,8 +166,8 @@ The following arguments are supported:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** The provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ 
+ ## Attributes Reference
+diff --git b/website/docs/r/google_organization_iam.html.markdown a/website/docs/r/google_organization_iam.html.markdown
+index 95c9802fe..3c5c00eda 100644
+--- b/website/docs/r/google_organization_iam.html.markdown
++++ a/website/docs/r/google_organization_iam.html.markdown
+@@ -26,9 +26,10 @@ Four different resources help you manage your IAM policy for a organization. Eac
+    resources. This resource makes it easy to remove your own access to
+    an organization, which will require a call to Google Support to have
+    fixed, and can take multiple days to resolve.
+-   <br /><br />
++
++
+    In general, this resource should only be used with organizations
+-   fully managed by Terraform.If you do use this resource,
++   fully managed by this provider.I f you do use this resource,
+    the best way to be sure that you are not making dangerous changes is to start
+    by **importing** your existing policy, and examining the diff very closely.
+ 
+@@ -201,8 +202,8 @@ The following arguments are supported:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ 
+ ## Attributes Reference
+diff --git b/website/docs/r/google_organization_iam_audit_config.html.markdown a/website/docs/r/google_organization_iam_audit_config.html.markdown
+new file mode 100644
+index 000000000..cd72afdc6
+--- /dev/null
++++ a/website/docs/r/google_organization_iam_audit_config.html.markdown
+@@ -0,0 +1,57 @@
++---
++subcategory: "Cloud Platform"
++layout: "google"
++page_title: "Google: google_organization_iam_audit_config"
++sidebar_current: "docs-google-organization-iam-audit-config"
++description: |-
++ Allows management of audit logging config for a given service for a Google Cloud Platform Organization.
++---
++
++# google\_organization\_iam\_audit\_config
++
++Allows management of audit logging config for a given service for a Google Cloud Platform Organization.
++
++## Example Usage
++
++```hcl
++resource "google_organization_iam_audit_config" "config" {
++  org_id = "your-organization-id"
++  service = "allServices"
++  audit_log_config {
++    log_type = "DATA_READ"
++    exempted_members = [
++      "user:joebloggs@hashicorp.com",
++    ]
++  }
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `org_id` - (Required) The numeric ID of the organization in which you want to manage the audit logging config.
++
++* `service` - (Required) Service which will be enabled for audit logging.  The special value `allServices` covers all services.  Note that if there are google\_organization\_iam\_audit\_config resources covering both `allServices` and a specific service then the union of the two AuditConfigs is used for that service: the `log_types` specified in each `audit_log_config` are enabled, and the `exempted_members` in each `audit_log_config` are exempted.
++
++* `audit_log_config` - (Required) The configuration for logging of each type of permission.  This can be specified multiple times.  Structure is documented below.
++
++---
++
++The `audit_log_config` block supports:
++
++* `log_type` - (Required) Permission type for which logging is to be configured.  Must be one of `DATA_READ`, `DATA_WRITE`, or `ADMIN_READ`.
++
++* `exempted_members` - (Optional) Identities that do not cause logging for this type of permission.
++  Each entry can have one of the following values:
++  * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
++  * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
++  * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
++  * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
++
++## Import
++IAM audit config imports use the identifier of the resource in question and the service, e.g.
++
++```
++terraform import google_organization_iam_audit_config.config "your-organization-id foo.googleapis.com"
++```
+diff --git b/website/docs/r/google_organization_iam_binding.html.markdown a/website/docs/r/google_organization_iam_binding.html.markdown
+new file mode 100644
+index 000000000..aaf5bebf9
+--- /dev/null
++++ a/website/docs/r/google_organization_iam_binding.html.markdown
+@@ -0,0 +1,64 @@
++---
++subcategory: "Cloud Platform"
++layout: "google"
++page_title: "Google: google_organization_iam_binding"
++sidebar_current: "docs-google-organization-iam-binding"
++description: |-
++ Allows management of a single binding with an IAM policy for a Google Cloud Platform Organization.
++---
++
++# google\_organization\_iam\_binding
++
++Allows creation and management of a single binding within IAM policy for
++an existing Google Cloud Platform Organization.
++
++~> **Note:** This resource __must not__ be used in conjunction with
++   `google_organization_iam_member` for the __same role__ or they will fight over
++   what your policy should be.
++
++~> **Note:** On create, this resource will overwrite members of any existing roles.
++    Use `pulumi import` and inspect the `output to ensure
++    your existing members are preserved.
++
++## Example Usage
++
++```hcl
++resource "google_organization_iam_binding" "binding" {
++  org_id = "123456789"
++  role    = "roles/browser"
++
++  members = [
++    "user:alice@gmail.com",
++  ]
++}
++```
++
++## Argument Reference
++
++The following arguments are supported:
++
++* `org_id` - (Required) The numeric ID of the organization in which you want to create a custom role.
++
++* `role` - (Required) The role that should be applied. Only one
++    `google_organization_iam_binding` can be used per role. Note that custom roles must be of the format
++    `[projects|organizations]/{parent-name}/roles/{role-name}`.
++
++* `members` - (Required) A list of users that the role should apply to. For more details on format and restrictions see https://cloud.google.com/billing/reference/rest/v1/Policy#Binding
++
++## Attributes Reference
++
++In addition to the arguments listed above, the following computed attributes are
++exported:
++
++* `etag` - (Computed) The etag of the organization's IAM policy.
++
++## Import
++
++IAM binding imports use space-delimited identifiers; first the resource in question and then the role.  These bindings can be imported using the `org_id` and role, e.g.
++
++```
++$ terraform import google_organization_iam_binding.my_org "your-org-id roles/viewer"
++```
++
++-> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
++ full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
+diff --git b/website/docs/r/google_organization_iam_custom_role.html.markdown a/website/docs/r/google_organization_iam_custom_role.html.markdown
+index fdfc0c8c9..a53dbf11a 100644
+--- b/website/docs/r/google_organization_iam_custom_role.html.markdown
++++ a/website/docs/r/google_organization_iam_custom_role.html.markdown
+@@ -16,7 +16,7 @@ and
+  same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
+  after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is
+  made available again. This means a deleted role that has been deleted for more than 7 days cannot be changed at all
+- by Terraform, and new roles cannot share that name.
++ by the provider, and new roles cannot share that name.
+  
+ ## Example Usage
+ 
+diff --git b/website/docs/r/google_project.html.markdown a/website/docs/r/google_project.html.markdown
+index 36f5eb069..6a0ae5b90 100644
+--- b/website/docs/r/google_project.html.markdown
++++ a/website/docs/r/google_project.html.markdown
+@@ -11,15 +11,13 @@ Allows creation and management of a Google Cloud Platform project.
+ Projects created with this resource must be associated with an Organization.
+ See the [Organization documentation](https://cloud.google.com/resource-manager/docs/quickstarts) for more details.
+ 
+-The user or service account that is running Terraform when creating a `google_project`
++The user or service account that is running this provider when creating a `google_project`
+ resource must have `roles/resourcemanager.projectCreator` on the specified organization. See the
+ [Access Control for Organizations Using IAM](https://cloud.google.com/resource-manager/docs/access-control-org)
+ doc for more information.
+ 
+ ~> This resource reads the specified billing account on every terraform apply and plan operation so you must have permissions on the specified billing account.
+ 
+-~> It is recommended to use the `constraints/compute.skipDefaultNetworkCreation` [constraint](/docs/providers/google/r/google_organization_policy.html) to remove the default network instead of setting `auto_create_network` to false, when possible.
+-
+ To get more information about projects, see:
+ 
+ * [API documentation](https://cloud.google.com/resource-manager/reference/rest/v1/projects)
+@@ -73,12 +71,12 @@ The following arguments are supported:
+    project to be migrated to the newly specified folder.
+ 
+ * `billing_account` - (Optional) The alphanumeric ID of the billing account this project
+-    belongs to. The user or service account performing this operation with Terraform
+-    must have at minimum Billing Account User privileges (`roles/billing.user`) on the billing account.
++    belongs to. The user or service account performing this operation with the provider
++    must have at mininum Billing Account User privileges (`roles/billing.user`) on the billing account.
+     See [Google Cloud Billing API Access Control](https://cloud.google.com/billing/docs/how-to/billing-access)
+     for more details.
+ 
+-* `skip_delete` - (Optional) If true, the Terraform resource can be deleted
++* `skip_delete` - (Optional) If true, the resource can be deleted
+     without deleting the Project via the Google API.
+ 
+ * `labels` - (Optional) A set of key/value label pairs to assign to the project.
+diff --git b/website/docs/r/google_project_iam.html.markdown a/website/docs/r/google_project_iam.html.markdown
+index f226bfeb5..241a3c83f 100644
+--- b/website/docs/r/google_project_iam.html.markdown
++++ a/website/docs/r/google_project_iam.html.markdown
+@@ -27,7 +27,7 @@ Four different resources help you manage your IAM policy for a project. Each of
+    from anyone without organization-level access to the project. Proceed with caution.
+    It's not recommended to use `google_project_iam_policy` with your provider project
+    to avoid locking yourself out, and it should generally only be used with projects
+-   fully managed by Terraform. If you do use this resource, it is recommended to **import** the policy before
++   fully managed by this provider. If you do use this resource, it is recommended to **import** the policy before
+    applying the change.
+ 
+ ```hcl
+@@ -198,8 +198,8 @@ inferred from the provider.
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ 
+ ## Attributes Reference
+diff --git b/website/docs/r/google_project_iam_custom_role.html.markdown a/website/docs/r/google_project_iam_custom_role.html.markdown
+index 33af6c36e..fc9bd337d 100644
+--- b/website/docs/r/google_project_iam_custom_role.html.markdown
++++ a/website/docs/r/google_project_iam_custom_role.html.markdown
+@@ -16,7 +16,7 @@ and
+  same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted
+  after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is
+  made available again. This means a deleted role that has been deleted for more than 7 days cannot be changed at all
+- by Terraform, and new roles cannot share that name.
++ by the provider, and new roles cannot share that name.
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/google_project_service.html.markdown a/website/docs/r/google_project_service.html.markdown
+index 2099eb4e0..4f32e9ef1 100644
+--- b/website/docs/r/google_project_service.html.markdown
++++ a/website/docs/r/google_project_service.html.markdown
+@@ -50,10 +50,7 @@ and which depend on this service should also be disabled when this service is
+ destroyed. If `false` or unset, an error will be generated if any enabled
+ services depend on this service when destroying it.
+ 
+-* `disable_on_destroy` - (Optional) If true, disable the service when the
+-Terraform resource is destroyed. Defaults to true. May be useful in the event
+-that a project is long-lived but the infrastructure running in that project
+-changes frequently.
++* `disable_on_destroy` - (Optional) If true, disable the service when the resource is destroyed. Defaults to true. May be useful in the event that a project is long-lived but the infrastructure running in that project changes frequently.
+ 
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/google_service_account.html.markdown a/website/docs/r/google_service_account.html.markdown
+index d39b86fc4..a345f324c 100644
+--- b/website/docs/r/google_service_account.html.markdown
++++ a/website/docs/r/google_service_account.html.markdown
+@@ -16,8 +16,7 @@ Allows management of a Google Cloud service account.
+ 
+ -> Creation of service accounts is eventually consistent, and that can lead to
+ errors when you try to apply ACLs to service accounts immediately after
+-creation. If using these resources in the same config, you can add a
+-[`sleep` using `local-exec`](https://github.com/hashicorp/terraform/issues/17726#issuecomment-377357866).
++creation.
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/google_service_account_iam.html.markdown a/website/docs/r/google_service_account_iam.html.markdown
+index 669d2b99a..f92865dc7 100644
+--- b/website/docs/r/google_service_account_iam.html.markdown
++++ a/website/docs/r/google_service_account_iam.html.markdown
+@@ -18,7 +18,9 @@ Three different resources help you manage your IAM policy for a service account.
+ 
+ ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
+ 
+-## google\_service\_account\_iam\_policy
++## Example Usage
++
++### Service Account IAM Policy
+ 
+ ```hcl
+ data "google_iam_policy" "admin" {
+@@ -42,7 +44,7 @@ resource "google_service_account_iam_policy" "admin-account-iam" {
+ }
+ ```
+ 
+-## google\_service\_account\_iam\_binding
++### Service Account IAM Binding
+ 
+ ```hcl
+ resource "google_service_account" "sa" {
+@@ -60,7 +62,7 @@ resource "google_service_account_iam_binding" "admin-account-iam" {
+ }
+ ```
+ 
+-With IAM Conditions:
++### Service Account IAM Binding With IAM Conditions:
+ 
+ ```hcl
+ resource "google_service_account" "sa" {
+@@ -84,7 +86,7 @@ resource "google_service_account_iam_binding" "admin-account-iam" {
+ }
+ ```
+ 
+-## google\_service\_account\_iam\_member
++### Service Account IAM Member
+ 
+ ```hcl
+ data "google_compute_default_service_account" "default" {
+@@ -109,7 +111,7 @@ resource "google_service_account_iam_member" "gce-default-account-iam" {
+ }
+ ```
+ 
+-With IAM Conditions:
++### Service Account IAM Member With IAM Conditions:
+ 
+ ```hcl
+ resource "google_service_account" "sa" {
+@@ -163,8 +165,8 @@ The following arguments are supported:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ 
+ ## Attributes Reference
+diff --git b/website/docs/r/healthcare_dataset_iam.html.markdown a/website/docs/r/healthcare_dataset_iam.html.markdown
+index 75eb160a2..8983593b6 100644
+--- b/website/docs/r/healthcare_dataset_iam.html.markdown
++++ a/website/docs/r/healthcare_dataset_iam.html.markdown
+@@ -6,9 +6,6 @@ description: |-
+ 
+ # IAM policy for Google Cloud Healthcare dataset
+ 
+-~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ Three different resources help you manage your IAM policy for Healthcare dataset. Each of these resources serves a different use case:
+ 
+ * `google_healthcare_dataset_iam_policy`: Authoritative. Sets the IAM policy for the dataset and replaces any existing policy already attached.
+diff --git b/website/docs/r/healthcare_dicom_store.html.markdown a/website/docs/r/healthcare_dicom_store.html.markdown
+index 628852e2e..698737439 100644
+--- b/website/docs/r/healthcare_dicom_store.html.markdown
++++ a/website/docs/r/healthcare_dicom_store.html.markdown
+@@ -159,7 +159,7 @@ The following arguments are supported:
+   Structure is [documented below](#nested_notification_config).
+ 
+ * `stream_configs` -
+-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
++  (Optional)
+   To enable streaming to BigQuery, configure the streamConfigs object in your DICOM store.
+   streamConfigs is an array, so you can specify multiple BigQuery destinations. You can stream metadata from a single DICOM store to up to five BigQuery tables in a BigQuery dataset.
+   Structure is [documented below](#nested_stream_configs).
+diff --git b/website/docs/r/healthcare_dicom_store_iam.html.markdown a/website/docs/r/healthcare_dicom_store_iam.html.markdown
+index 3bf31ce4e..1fb8128c5 100644
+--- b/website/docs/r/healthcare_dicom_store_iam.html.markdown
++++ a/website/docs/r/healthcare_dicom_store_iam.html.markdown
+@@ -6,9 +6,6 @@ description: |-
+ 
+ # IAM policy for Google Cloud Healthcare DICOM store
+ 
+-~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ Three different resources help you manage your IAM policy for Healthcare DICOM store. Each of these resources serves a different use case:
+ 
+ * `google_healthcare_dicom_store_iam_policy`: Authoritative. Sets the IAM policy for the DICOM store and replaces any existing policy already attached.
+diff --git b/website/docs/r/healthcare_fhir_store_iam.html.markdown a/website/docs/r/healthcare_fhir_store_iam.html.markdown
+index caa7c32db..aad701367 100644
+--- b/website/docs/r/healthcare_fhir_store_iam.html.markdown
++++ a/website/docs/r/healthcare_fhir_store_iam.html.markdown
+@@ -6,9 +6,6 @@ description: |-
+ 
+ # IAM policy for Google Cloud Healthcare FHIR store
+ 
+-~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ Three different resources help you manage your IAM policy for Healthcare FHIR store. Each of these resources serves a different use case:
+ 
+ * `google_healthcare_fhir_store_iam_policy`: Authoritative. Sets the IAM policy for the FHIR store and replaces any existing policy already attached.
+diff --git b/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown a/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
+index 76960623b..3c6e819dc 100644
+--- b/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
++++ a/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
+@@ -6,9 +6,6 @@ description: |-
+ 
+ # IAM policy for Google Cloud Healthcare HL7v2 store
+ 
+-~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ Three different resources help you manage your IAM policy for Healthcare HL7v2 store. Each of these resources serves a different use case:
+ 
+ * `google_healthcare_hl7_v2_store_iam_policy`: Authoritative. Sets the IAM policy for the HL7v2 store and replaces any existing policy already attached.
+diff --git b/website/docs/r/iam_deny_policy.html.markdown a/website/docs/r/iam_deny_policy.html.markdown
+index b58a1a464..c1ad343ba 100644
+--- b/website/docs/r/iam_deny_policy.html.markdown
++++ a/website/docs/r/iam_deny_policy.html.markdown
+@@ -36,8 +36,8 @@ To get more information about DenyPolicy, see:
+ ```hcl
+ resource "google_project" "project" {
+   provider        = google-beta
+-  project_id      = "tf-test%{random_suffix}"
+-  name            = "tf-test%{random_suffix}"
++  project_id      = "tf-test"
++  name            = "tf-test"
+   org_id          = "123456789"
+   billing_account = "000000-0000000-0000000-000000"
+ }
+diff --git b/website/docs/r/iap_app_engine_service_iam.html.markdown a/website/docs/r/iap_app_engine_service_iam.html.markdown
+index e4ffe94b1..cc310f90d 100644
+--- b/website/docs/r/iap_app_engine_service_iam.html.markdown
++++ a/website/docs/r/iap_app_engine_service_iam.html.markdown
+@@ -186,8 +186,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** The provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/iap_app_engine_version_iam.html.markdown a/website/docs/r/iap_app_engine_version_iam.html.markdown
+index 951599e38..1f2455ede 100644
+--- b/website/docs/r/iap_app_engine_version_iam.html.markdown
++++ a/website/docs/r/iap_app_engine_version_iam.html.markdown
+@@ -193,8 +193,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** The provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/iap_brand.html.markdown a/website/docs/r/iap_brand.html.markdown
+index 5e92f10fc..e6e8b66c8 100644
+--- b/website/docs/r/iap_brand.html.markdown
++++ a/website/docs/r/iap_brand.html.markdown
+@@ -29,7 +29,6 @@ project and the underlying Google API doesn't not support DELETE or PATCH method
+ Destroying a Terraform-managed Brand will remove it from state
+ but *will not delete it from Google Cloud.*
+ 
+-
+ To get more information about Brand, see:
+ 
+ * [API documentation](https://cloud.google.com/iap/docs/reference/rest/v1/projects.brands)
+diff --git b/website/docs/r/iap_client.html.markdown a/website/docs/r/iap_client.html.markdown
+index 5b89f4d07..ecb2d179e 100644
+--- b/website/docs/r/iap_client.html.markdown
++++ a/website/docs/r/iap_client.html.markdown
+@@ -32,9 +32,8 @@ To get more information about Client, see:
+ * How-to Guides
+     * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `secret`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `secret` will be stored in the raw
++state as plain-text.
+ 
+ ## Example Usage - Iap Client
+ 
+diff --git b/website/docs/r/iap_tunnel_iam.html.markdown a/website/docs/r/iap_tunnel_iam.html.markdown
+index b7356d67f..b6d4abe21 100644
+--- b/website/docs/r/iap_tunnel_iam.html.markdown
++++ a/website/docs/r/iap_tunnel_iam.html.markdown
+@@ -173,9 +173,6 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
+-  consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+ In addition to the arguments listed above, the following computed attributes are
+diff --git b/website/docs/r/iap_tunnel_instance_iam.html.markdown a/website/docs/r/iap_tunnel_instance_iam.html.markdown
+index 5fecbd66b..a485c12c6 100644
+--- b/website/docs/r/iap_tunnel_instance_iam.html.markdown
++++ a/website/docs/r/iap_tunnel_instance_iam.html.markdown
+@@ -185,8 +185,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/iap_web_backend_service_iam.html.markdown a/website/docs/r/iap_web_backend_service_iam.html.markdown
+index 2813fe266..e9ef81f71 100644
+--- b/website/docs/r/iap_web_backend_service_iam.html.markdown
++++ a/website/docs/r/iap_web_backend_service_iam.html.markdown
+@@ -179,8 +179,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/iap_web_iam.html.markdown a/website/docs/r/iap_web_iam.html.markdown
+index bd6d0be56..401af7f7d 100644
+--- b/website/docs/r/iap_web_iam.html.markdown
++++ a/website/docs/r/iap_web_iam.html.markdown
+@@ -172,8 +172,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/iap_web_type_app_engine_iam.html.markdown a/website/docs/r/iap_web_type_app_engine_iam.html.markdown
+index 14f08406c..21f568e33 100644
+--- b/website/docs/r/iap_web_type_app_engine_iam.html.markdown
++++ a/website/docs/r/iap_web_type_app_engine_iam.html.markdown
+@@ -179,8 +179,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/iap_web_type_compute_iam.html.markdown a/website/docs/r/iap_web_type_compute_iam.html.markdown
+index d29264f82..aa3a631ce 100644
+--- b/website/docs/r/iap_web_type_compute_iam.html.markdown
++++ a/website/docs/r/iap_web_type_compute_iam.html.markdown
+@@ -172,8 +172,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/kms_crypto_key.html.markdown a/website/docs/r/kms_crypto_key.html.markdown
+index 45d6e8cd2..d83f75590 100644
+--- b/website/docs/r/kms_crypto_key.html.markdown
++++ a/website/docs/r/kms_crypto_key.html.markdown
+@@ -23,9 +23,9 @@ A `CryptoKey` represents a logical key that can be used for cryptographic operat
+ 
+ 
+ ~> **Note:** CryptoKeys cannot be deleted from Google Cloud Platform.
+-Destroying a Terraform-managed CryptoKey will remove it from state
++Destroying a provider-managed CryptoKey will remove it from state
+ and delete all CryptoKeyVersions, rendering the key unusable, but *will
+-not delete the resource from the project.* When Terraform destroys these keys,
++not delete the resource from the project.* When the provider destroys these keys,
+ any data previously encrypted with these keys will be irrecoverable.
+ For this reason, it is strongly recommended that you add lifecycle hooks
+ to the resource to prevent accidental destruction.
+diff --git b/website/docs/r/kms_key_ring.html.markdown a/website/docs/r/kms_key_ring.html.markdown
+index b7df45912..5736ec146 100644
+--- b/website/docs/r/kms_key_ring.html.markdown
++++ a/website/docs/r/kms_key_ring.html.markdown
+@@ -23,7 +23,7 @@ A `KeyRing` is a toplevel logical grouping of `CryptoKeys`.
+ 
+ 
+ ~> **Note:** KeyRings cannot be deleted from Google Cloud Platform.
+-Destroying a Terraform-managed KeyRing will remove it from state but
++Destroying a provider-managed KeyRing will remove it from state but
+ *will not delete the resource from the project.*
+ 
+ 
+diff --git b/website/docs/r/kms_key_ring_import_job.html.markdown a/website/docs/r/kms_key_ring_import_job.html.markdown
+index c0fa1e7bb..0e3845916 100644
+--- b/website/docs/r/kms_key_ring_import_job.html.markdown
++++ a/website/docs/r/kms_key_ring_import_job.html.markdown
+@@ -27,7 +27,7 @@ was wrapped with the `KeyRingImportJob`'s public key.
+ 
+ 
+ ~> **Note:** KeyRingImportJobs cannot be deleted from Google Cloud Platform.
+-Destroying a Terraform-managed KeyRingImportJob will remove it from state but
++Destroying a provider-managed KeyRingImportJob will remove it from state but
+ *will not delete the resource from the project.*
+ 
+ 
+diff --git b/website/docs/r/kms_secret_ciphertext.html.markdown a/website/docs/r/kms_secret_ciphertext.html.markdown
+index cf5898150..1cdc9297a 100644
+--- b/website/docs/r/kms_secret_ciphertext.html.markdown
++++ a/website/docs/r/kms_secret_ciphertext.html.markdown
+@@ -34,9 +34,7 @@ To get more information about SecretCiphertext, see:
+ * How-to Guides
+     * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `plaintext`, `additional_authenticated_data`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
+ 
+ ## Example Usage - Kms Secret Ciphertext Basic
+ 
+diff --git b/website/docs/r/logging_billing_account_bucket_config.html.markdown a/website/docs/r/logging_billing_account_bucket_config.html.markdown
+index 90c5ac128..e82386375 100644
+--- b/website/docs/r/logging_billing_account_bucket_config.html.markdown
++++ a/website/docs/r/logging_billing_account_bucket_config.html.markdown
+@@ -10,7 +10,7 @@ Manages a billing account level logging bucket config. For more information see
+ [the official logging documentation](https://cloud.google.com/logging/docs/) and
+ [Storing Logs](https://cloud.google.com/logging/docs/storage).
+ 
+-~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your terraform state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
++~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/logging_billing_account_sink.html.markdown a/website/docs/r/logging_billing_account_sink.html.markdown
+index a2a78c2a0..992badf29 100644
+--- b/website/docs/r/logging_billing_account_sink.html.markdown
++++ a/website/docs/r/logging_billing_account_sink.html.markdown
+@@ -12,7 +12,7 @@ description: |-
+ 
+ ~> **Note** You must have the "Logs Configuration Writer" IAM role (`roles/logging.configWriter`)
+ [granted on the billing account](https://cloud.google.com/billing/reference/rest/v1/billingAccounts/getIamPolicy) to
+-the credentials used with Terraform. [IAM roles granted on a billing account](https://cloud.google.com/billing/docs/how-to/billing-access) are separate from the
++the credentials used with this provider. [IAM roles granted on a billing account](https://cloud.google.com/billing/docs/how-to/billing-access) are separate from the
+ typical IAM roles granted on a project.
+ 
+ ## Example Usage
+diff --git b/website/docs/r/logging_folder_bucket_config.html.markdown a/website/docs/r/logging_folder_bucket_config.html.markdown
+index 7fa39b27e..04fbff488 100644
+--- b/website/docs/r/logging_folder_bucket_config.html.markdown
++++ a/website/docs/r/logging_folder_bucket_config.html.markdown
+@@ -10,7 +10,7 @@ Manages a folder-level logging bucket config. For more information see
+ [the official logging documentation](https://cloud.google.com/logging/docs/) and
+ [Storing Logs](https://cloud.google.com/logging/docs/storage).
+ 
+-~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your terraform state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
++~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/logging_folder_exclusion.html.markdown a/website/docs/r/logging_folder_exclusion.html.markdown
+index f3cd9d481..812a373d4 100644
+--- b/website/docs/r/logging_folder_exclusion.html.markdown
++++ a/website/docs/r/logging_folder_exclusion.html.markdown
+@@ -12,7 +12,7 @@ Manages a folder-level logging exclusion. For more information see:
+ * How-to Guides
+     * [Excluding Logs](https://cloud.google.com/logging/docs/exclusions)
+ 
+-~> You can specify exclusions for log sinks created by terraform by using the exclusions field of `google_logging_folder_sink`
++~> You can specify exclusions for log sinks created by the provider by using the exclusions field of `google_logging_folder_sink`
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/logging_organization_bucket_config.html.markdown a/website/docs/r/logging_organization_bucket_config.html.markdown
+index b8f7b760e..e336636ce 100644
+--- b/website/docs/r/logging_organization_bucket_config.html.markdown
++++ a/website/docs/r/logging_organization_bucket_config.html.markdown
+@@ -10,7 +10,7 @@ Manages a organization-level logging bucket config. For more information see
+ [the official logging documentation](https://cloud.google.com/logging/docs/) and
+ [Storing Logs](https://cloud.google.com/logging/docs/storage).
+ 
+-~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your terraform state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
++~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/logging_organization_exclusion.html.markdown a/website/docs/r/logging_organization_exclusion.html.markdown
+index 072cbd643..822488887 100644
+--- b/website/docs/r/logging_organization_exclusion.html.markdown
++++ a/website/docs/r/logging_organization_exclusion.html.markdown
+@@ -12,7 +12,7 @@ Manages an organization-level logging exclusion. For more information see:
+ * How-to Guides
+     * [Excluding Logs](https://cloud.google.com/logging/docs/exclusions)
+ 
+-~> You can specify exclusions for log sinks created by terraform by using the exclusions field of `google_logging_organization_sink`
++~> You can specify exclusions for log sinks created by the provider by using the exclusions field of `google_logging_organization_sink`
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/logging_project_bucket_config.html.markdown a/website/docs/r/logging_project_bucket_config.html.markdown
+index b57afd87d..3d9f1336a 100644
+--- b/website/docs/r/logging_project_bucket_config.html.markdown
++++ a/website/docs/r/logging_project_bucket_config.html.markdown
+@@ -10,7 +10,7 @@ Manages a project-level logging bucket config. For more information see
+ [the official logging documentation](https://cloud.google.com/logging/docs/) and
+ [Storing Logs](https://cloud.google.com/logging/docs/storage).
+ 
+-~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your terraform state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
++~> **Note:** Logging buckets are automatically created for a given folder, project, organization, billingAccount and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your state but will leave the logging bucket unchanged. The buckets that are currently automatically created are "_Default" and "_Required".
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/logging_project_exclusion.html.markdown a/website/docs/r/logging_project_exclusion.html.markdown
+index ebd08f34b..dec7aba3e 100644
+--- b/website/docs/r/logging_project_exclusion.html.markdown
++++ a/website/docs/r/logging_project_exclusion.html.markdown
+@@ -12,7 +12,7 @@ Manages a project-level logging exclusion. For more information see:
+ * How-to Guides
+     * [Excluding Logs](https://cloud.google.com/logging/docs/exclusions)
+ 
+-~> You can specify exclusions for log sinks created by terraform by using the exclusions field of `google_logging_project_sink`
++~> You can specify exclusions for log sinks created by the provider by using the exclusions field of `google_logging_project_sink`
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/logging_project_sink.html.markdown a/website/docs/r/logging_project_sink.html.markdown
+index bf178133c..7029dd75f 100644
+--- b/website/docs/r/logging_project_sink.html.markdown
++++ a/website/docs/r/logging_project_sink.html.markdown
+@@ -14,7 +14,7 @@ Manages a project-level logging sink. For more information see:
+ 
+ ~> You can specify exclusions for log sinks created by terraform by using the exclusions field of `google_logging_folder_sink`
+ 
+-~> **Note:** You must have [granted the "Logs Configuration Writer"](https://cloud.google.com/logging/docs/access-control) IAM role (`roles/logging.configWriter`) to the credentials used with terraform.
++~> **Note:** You must have [granted the "Logs Configuration Writer"](https://cloud.google.com/logging/docs/access-control) IAM role (`roles/logging.configWriter`) to the credentials used with this provider.
+ 
+ ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
+ 
+diff --git b/website/docs/r/monitoring_notification_channel.html.markdown a/website/docs/r/monitoring_notification_channel.html.markdown
+index d9363faf6..9b9eb8e7e 100644
+--- b/website/docs/r/monitoring_notification_channel.html.markdown
++++ a/website/docs/r/monitoring_notification_channel.html.markdown
+@@ -30,7 +30,7 @@ and labels to configure that channel. Each `type` has specific labels that need
+ present for that channel to be correctly configured. The labels that are required to be
+ present for one channel `type` are often different than those required for another.
+ Due to these loose constraints it's often best to set up a channel through the UI
+-and import to Terraform when setting up a brand new channel type to determine which
++and import it to the provider when setting up a brand new channel type to determine which
+ labels are required.
+ 
+ A list of supported channels per project the `list` endpoint can be
+@@ -45,9 +45,8 @@ To get more information about NotificationChannel, see:
+     * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
+     * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `sensitive_labels.auth_token`, `sensitive_labels.password`, `sensitive_labels.service_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=notification_channel_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -101,7 +100,7 @@ The following arguments are supported:
+   Configuration fields that define the channel and its behavior. The
+   permissible and required labels are specified in the
+   NotificationChannelDescriptor corresponding to the type field.
+-  Labels with sensitive data are obfuscated by the API and therefore Terraform cannot
++  Labels with sensitive data are obfuscated by the API and therefore the provider cannot
+   determine if there are upstream changes to these fields. They can also be configured via
+   the sensitive_labels block, but cannot be configured in both places.
+ 
+diff --git b/website/docs/r/monitoring_slo.html.markdown a/website/docs/r/monitoring_slo.html.markdown
+index 3d4a3b169..e05f38822 100644
+--- b/website/docs/r/monitoring_slo.html.markdown
++++ a/website/docs/r/monitoring_slo.html.markdown
+@@ -53,7 +53,7 @@ resource "google_monitoring_slo" "appeng_slo" {
+   service = data.google_monitoring_app_engine_service.default.service_id
+ 
+   slo_id = "ae-slo"
+-  display_name = "Terraform Test SLO for App Engine"
++  display_name = "Test SLO for App Engine"
+ 
+   goal = 0.9
+   calendar_period = "DAY"
+@@ -82,7 +82,7 @@ resource "google_monitoring_custom_service" "customsrv" {
+ resource "google_monitoring_slo" "request_based_slo" {
+   service = google_monitoring_custom_service.customsrv.service_id
+   slo_id = "consumed-api-slo"
+-  display_name = "Terraform Test SLO with request based SLI (good total ratio)"
++  display_name = "Test SLO with request based SLI (good total ratio)"
+ 
+   goal = 0.9
+   rolling_period_days = 30
+@@ -113,7 +113,7 @@ resource "google_monitoring_custom_service" "customsrv" {
+ 
+ resource "google_monitoring_slo" "windows_based" {
+   service = google_monitoring_custom_service.customsrv.service_id
+-  display_name = "Terraform Test SLO with window based SLI"
++  display_name = "Test SLO with window based SLI"
+ 
+   goal = 0.95
+   calendar_period = "FORTNIGHT"
+@@ -143,7 +143,7 @@ resource "google_monitoring_custom_service" "customsrv" {
+ 
+ resource "google_monitoring_slo" "windows_based" {
+   service = google_monitoring_custom_service.customsrv.service_id
+-  display_name = "Terraform Test SLO with window based SLI"
++  display_name = "Test SLO with window based SLI"
+ 
+   goal = 0.9
+   rolling_period_days = 20
+@@ -179,7 +179,7 @@ resource "google_monitoring_custom_service" "customsrv" {
+ 
+ resource "google_monitoring_slo" "windows_based" {
+   service = google_monitoring_custom_service.customsrv.service_id
+-  display_name = "Terraform Test SLO with window based SLI"
++  display_name = "Test SLO with window based SLI"
+ 
+   goal = 0.9
+   rolling_period_days = 20
+@@ -215,7 +215,7 @@ resource "google_monitoring_custom_service" "customsrv" {
+ 
+ resource "google_monitoring_slo" "windows_based" {
+   service = google_monitoring_custom_service.customsrv.service_id
+-  display_name = "Terraform Test SLO with window based SLI"
++  display_name = "Test SLO with window based SLI"
+ 
+   goal = 0.9
+   rolling_period_days = 20
+diff --git b/website/docs/r/monitoring_uptime_check_config.html.markdown a/website/docs/r/monitoring_uptime_check_config.html.markdown
+index 7fc0e9905..fd76ececa 100644
+--- b/website/docs/r/monitoring_uptime_check_config.html.markdown
++++ a/website/docs/r/monitoring_uptime_check_config.html.markdown
+@@ -28,9 +28,8 @@ To get more information about UptimeCheckConfig, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `http_check.auth_info.password`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
++state as plain-text.
+ 
+ ## Example Usage - Uptime Check Config Http
+ 
+diff --git b/website/docs/r/notebooks_instance.html.markdown a/website/docs/r/notebooks_instance.html.markdown
+index ea0296d91..891f32386 100644
+--- b/website/docs/r/notebooks_instance.html.markdown
++++ a/website/docs/r/notebooks_instance.html.markdown
+@@ -67,7 +67,6 @@ resource "google_notebooks_instance" "instance" {
+   machine_type = "e2-medium"
+   metadata = {
+     proxy-mode = "service_account"
+-    terraform  = "true"
+   }
+   container_image {
+     repository = "gcr.io/deeplearning-platform-release/base-cpu"
+@@ -130,10 +129,6 @@ resource "google_notebooks_instance" "instance" {
+   labels = {
+     k = "val"
+   }
+-
+-  metadata = {
+-    terraform = "true"
+-  }
+ }
+ 
+ data "google_compute_network" "my_network" {
+diff --git b/website/docs/r/os_config_guest_policies.html.markdown a/website/docs/r/os_config_guest_policies.html.markdown
+index 4a700a868..185157382 100644
+--- b/website/docs/r/os_config_guest_policies.html.markdown
++++ a/website/docs/r/os_config_guest_policies.html.markdown
+@@ -23,9 +23,6 @@ An OS Config resource representing a guest configuration policy. These policies
+ the desired state for VM instance guest environments including packages to install or remove,
+ package repository configurations, and software to install.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about GuestPolicies, see:
+ 
+ * [API documentation](https://cloud.google.com/compute/docs/osconfig/rest)
+diff --git b/website/docs/r/project_service_identity.html.markdown a/website/docs/r/project_service_identity.html.markdown
+index 9b4367a4d..4d951db93 100644
+--- b/website/docs/r/project_service_identity.html.markdown
++++ a/website/docs/r/project_service_identity.html.markdown
+@@ -6,9 +6,6 @@ description: |-
+ 
+ # google\_project\_service\_identity
+ 
+-~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ Generate service identity for a service.
+ 
+ ~> **Note:** Once created, this resource cannot be updated or destroyed. These
+diff --git b/website/docs/r/redis_instance.html.markdown a/website/docs/r/redis_instance.html.markdown
+index 0823cbc78..382daae11 100644
+--- b/website/docs/r/redis_instance.html.markdown
++++ a/website/docs/r/redis_instance.html.markdown
+@@ -62,7 +62,7 @@ resource "google_redis_instance" "cache" {
+   authorized_network = data.google_compute_network.redis-network.id
+ 
+   redis_version     = "REDIS_4_0"
+-  display_name      = "Terraform Test Instance"
++  display_name      = "Test Instance"
+   reserved_ip_range = "192.168.0.0/29"
+ 
+   labels = {
+@@ -164,7 +164,7 @@ resource "google_redis_instance" "cache" {
+   connect_mode       = "PRIVATE_SERVICE_ACCESS"
+ 
+   redis_version     = "REDIS_4_0"
+-  display_name      = "Terraform Test Instance"
++  display_name      = "Test Instance"
+ 
+   depends_on = [google_service_networking_connection.private_service_connection]
+ 
+diff --git b/website/docs/r/secret_manager_secret_version.html.markdown a/website/docs/r/secret_manager_secret_version.html.markdown
+index 51dffe705..1a7bad0a9 100644
+--- b/website/docs/r/secret_manager_secret_version.html.markdown
++++ a/website/docs/r/secret_manager_secret_version.html.markdown
+@@ -23,9 +23,8 @@ A secret version resource.
+ 
+ 
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `payload.secret_data`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `payload.secret_data` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=secret_version_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+diff --git b/website/docs/r/security_scanner_scan_config.html.markdown a/website/docs/r/security_scanner_scan_config.html.markdown
+index 88a98dc84..ae65134fc 100644
+--- b/website/docs/r/security_scanner_scan_config.html.markdown
++++ a/website/docs/r/security_scanner_scan_config.html.markdown
+@@ -21,18 +21,13 @@ description: |-
+ 
+ A ScanConfig resource contains the configurations to launch a scan.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about ScanConfig, see:
+ 
+ * [API documentation](https://cloud.google.com/security-scanner/docs/reference/rest/v1beta/projects.scanConfigs)
+ * How-to Guides
+     * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `authentication.google_account.password`, `authentication.custom_account.password`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=scan_config_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -50,7 +45,7 @@ resource "google_compute_address" "scanner_static_ip" {
+ 
+ resource "google_security_scanner_scan_config" "scan-config" {
+   provider         = google-beta
+-  display_name     = "terraform-scan-config"
++  display_name     = "scan-config"
+   starting_urls    = ["http://${google_compute_address.scanner_static_ip.address}"]
+   target_platforms = ["COMPUTE"]
+ }
+diff --git b/website/docs/r/service_directory_endpoint.html.markdown a/website/docs/r/service_directory_endpoint.html.markdown
+index dee78de55..5b3a039f3 100644
+--- b/website/docs/r/service_directory_endpoint.html.markdown
++++ a/website/docs/r/service_directory_endpoint.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ An individual endpoint that provides a service.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about Endpoint, see:
+ 
+ * [API documentation](https://cloud.google.com/service-directory/docs/reference/rest/v1beta1/projects.locations.namespaces.services.endpoints)
+diff --git b/website/docs/r/service_directory_namespace.html.markdown a/website/docs/r/service_directory_namespace.html.markdown
+index 184b0a243..3537c59ed 100644
+--- b/website/docs/r/service_directory_namespace.html.markdown
++++ a/website/docs/r/service_directory_namespace.html.markdown
+@@ -22,9 +22,6 @@ description: |-
+ A container for `services`. Namespaces allow administrators to group services
+ together and define permissions for a collection of services.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about Namespace, see:
+ 
+ * [API documentation](https://cloud.google.com/service-directory/docs/reference/rest/v1beta1/projects.locations.namespaces)
+diff --git b/website/docs/r/service_directory_namespace_iam.html.markdown a/website/docs/r/service_directory_namespace_iam.html.markdown
+index 9b743863f..3a7d86ffe 100644
+--- b/website/docs/r/service_directory_namespace_iam.html.markdown
++++ a/website/docs/r/service_directory_namespace_iam.html.markdown
+@@ -32,11 +32,6 @@ A data source can be used to retrieve policy data in advent you do not need crea
+ 
+ ~> **Note:** `google_service_directory_namespace_iam_binding` resources **can be** used in conjunction with `google_service_directory_namespace_iam_member` resources **only if** they do not grant privilege to the same role.
+ 
+-
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+-
+ ## google\_service\_directory\_namespace\_iam\_policy
+ 
+ ```hcl
+diff --git b/website/docs/r/service_directory_service.html.markdown a/website/docs/r/service_directory_service.html.markdown
+index 0309256c0..8d6f4e1d6 100644
+--- b/website/docs/r/service_directory_service.html.markdown
++++ a/website/docs/r/service_directory_service.html.markdown
+@@ -21,9 +21,6 @@ description: |-
+ 
+ An individual service. A service contains a name and optional metadata.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about Service, see:
+ 
+ * [API documentation](https://cloud.google.com/service-directory/docs/reference/rest/v1beta1/projects.locations.namespaces.services)
+diff --git b/website/docs/r/service_directory_service_iam.html.markdown a/website/docs/r/service_directory_service_iam.html.markdown
+index 0281581a4..3edd2135b 100644
+--- b/website/docs/r/service_directory_service_iam.html.markdown
++++ a/website/docs/r/service_directory_service_iam.html.markdown
+@@ -32,11 +32,6 @@ A data source can be used to retrieve policy data in advent you do not need crea
+ 
+ ~> **Note:** `google_service_directory_service_iam_binding` resources **can be** used in conjunction with `google_service_directory_service_iam_member` resources **only if** they do not grant privilege to the same role.
+ 
+-
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+-
+ ## google\_service\_directory\_service\_iam\_policy
+ 
+ ```hcl
+diff --git b/website/docs/r/service_usage_consumer_quota_override.html.markdown a/website/docs/r/service_usage_consumer_quota_override.html.markdown
+index 24cd73e17..2838bb48e 100644
+--- b/website/docs/r/service_usage_consumer_quota_override.html.markdown
++++ a/website/docs/r/service_usage_consumer_quota_override.html.markdown
+@@ -23,9 +23,6 @@ A consumer override is applied to the consumer on its own authority to limit its
+ Consumer overrides cannot be used to grant more quota than would be allowed by admin overrides,
+ producer overrides, or the default limit of the service.
+ 
+-~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+-
+ To get more information about ConsumerQuotaOverride, see:
+ 
+ * How-to Guides
+diff --git b/website/docs/r/spanner_database.html.markdown a/website/docs/r/spanner_database.html.markdown
+index 1bffab723..1266bdbe8 100644
+--- b/website/docs/r/spanner_database.html.markdown
++++ a/website/docs/r/spanner_database.html.markdown
+@@ -28,12 +28,7 @@ To get more information about Database, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/spanner/)
+ 
+-~> **Warning:** On newer versions of the provider, you must explicitly set `deletion_protection=false`
+-(and run `terraform apply` to write the field to state) in order to destroy an instance.
+-It is recommended to not set this field (or set it to true) until you're ready to destroy.
+-On older versions, it is strongly recommended to set `lifecycle { prevent_destroy = true }`
+-on databases in order to prevent accidental data loss. See [Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
+-for more information on lifecycle parameters.
++~> **Warning:** It is strongly recommended to set `lifecycle { prevent_destroy = true }` on databases in order to prevent accidental data loss.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=spanner_database_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -109,8 +104,8 @@ The following arguments are supported:
+ * `project` - (Optional) The ID of the project in which the resource belongs.
+     If it is not provided, the provider project is used.
+ 
+-* `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
+-in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
++* `deletion_protection` - (Optional) Whether or not to allow the provider to destroy the instance. Unless this field is set to false
++in state, a `destroy` or `update` that would delete the instance will fail.
+ 
+ 
+ <a name="nested_encryption_config"></a>The `encryption_config` block supports:
+diff --git b/website/docs/r/sql_database_instance.html.markdown a/website/docs/r/sql_database_instance.html.markdown
+index 0fd644091..ced263f64 100644
+--- b/website/docs/r/sql_database_instance.html.markdown
++++ a/website/docs/r/sql_database_instance.html.markdown
+@@ -10,12 +10,12 @@ Creates a new Google SQL Database Instance. For more information, see the [offic
+ or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/instances).
+ 
+ ~> **NOTE on `google_sql_database_instance`:** - Second-generation instances include a
+-default 'root'@'%' user with no password. This user will be deleted by Terraform on
++default 'root'@'%' user with no password. This user will be deleted by the provider on
+ instance creation. You should use `google_sql_user` to define a custom user with
+ a restricted host and strong password.
+ 
+ -> **Note**: On newer versions of the provider, you must explicitly set `deletion_protection=false`
+-(and run `terraform apply` to write the field to state) in order to destroy an instance.
++(and run `pulumi update` to write the field to state) in order to destroy an instance.
+ It is recommended to not set this field (or set it to true) until you're ready to destroy the instance and its databases.
+ 
+ ## Example Usage
+@@ -180,7 +180,7 @@ SQL Server version to use. Supported values include `MYSQL_5_6`,
+ includes an up-to-date reference of supported versions.
+ 
+ * `name` - (Optional, Computed) The name of the instance. If the name is left
+-    blank, Terraform will randomly generate one when the instance is first
++    blank, the provider will randomly generate one when the instance is first
+     created. This is done because after a name is used, it cannot be reused for
+     up to [one week](https://cloud.google.com/sql/docs/delete-instance).
+ 
+@@ -200,7 +200,7 @@ includes an up-to-date reference of supported versions.
+ 
+ * `encryption_key_name` - (Optional)
+     The full path to the encryption key used for the CMEK disk encryption.  Setting
+-    up disk encryption currently requires manual steps outside of Terraform.
++    up disk encryption currently requires manual steps outside of this provider.
+     The provided key must be in the same region as the SQL instance.  In order
+     to use this feature, a special kind of service account must be created and
+     granted permission on this key.  This step can currently only be done
+@@ -208,18 +208,16 @@ includes an up-to-date reference of supported versions.
+     That service account needs the `Cloud KMS > Cloud KMS CryptoKey Encrypter/Decrypter` role on your
+     key - please see [this step](https://cloud.google.com/sql/docs/mysql/configure-cmek#grantkey).
+ 
+-* `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
+-in Terraform state, a `terraform destroy` or `terraform apply` command that deletes the instance will fail. Defaults to `true`.
+-
+-  ~> **NOTE:** This flag only protects instances from deletion within Terraform. To protect your instances from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform), use the API flag `settings.deletion_protection_enabled`.
++* `deletion_protection` - (Optional) Whether or not to allow the provider to destroy the instance. Unless this field is set to false
++in state, a `destroy` or `update` command that deletes the instance will fail. Defaults to `true`.
+ 
+ * `restore_backup_context` - (optional) The context needed to restore the database to a backup run. This field will
+-    cause Terraform to trigger the database to restore from the backup run indicated. The configuration is detailed below.
+-    **NOTE:** Restoring from a backup is an imperative action and not recommended via Terraform. Adding or modifying this
++    cause the provider to trigger the database to restore from the backup run indicated. The configuration is detailed below.
++    **NOTE:** Restoring from a backup is an imperative action and not recommended via this provider. Adding or modifying this
+     block during resource creation/update will trigger the restore action after the resource is created/updated.
+ 
+ * `clone` - (Optional) The context needed to create this instance as a clone of another instance. When this field is set during
+-    resource creation, Terraform will attempt to clone another instance as indicated in the context. The
++    resource creation, this provider will attempt to clone another instance as indicated in the context. The
+     configuration is detailed below.
+ 
+ The `settings` block supports:
+@@ -437,7 +435,7 @@ The optional `clone` block supports:
+ * `allocated_ip_range` -  (Optional) The name of the allocated ip range for the private ip CloudSQL instance. For example: "google-managed-services-default". If set, the cloned instance ip will be created in the allocated range. The range name must comply with [RFC 1035](https://tools.ietf.org/html/rfc1035). Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?.
+ 
+ The optional `restore_backup_context` block supports:
+-**NOTE:** Restoring from a backup is an imperative action and not recommended via Terraform. Adding or modifying this
++**NOTE:** Restoring from a backup is an imperative action and not recommended via this provider. Adding or modifying this
+ block during resource creation/update will trigger the restore action after the resource is created/updated.
+ 
+ * `backup_run_id` - (Required) The ID of the backup run to restore from.
+@@ -473,21 +471,13 @@ instance.
+ 
+   * A `PRIVATE` address is an address for an instance which has been configured to use private networking see: [Private IP](https://cloud.google.com/sql/docs/mysql/private-ip).
+ 
+-* `first_ip_address` - The first IPv4 address of any type assigned. This is to
+-support accessing the [first address in the list in a terraform output](https://github.com/hashicorp/terraform-provider-google/issues/912)
+-when the resource is configured with a `count`.
++* `first_ip_address` - The first IPv4 address of any type assigned.
+ 
+ * `available_maintenance_versions`  - The list of all maintenance versions applicable on the instance.
+ 
+-* `public_ip_address` - The first public (`PRIMARY`) IPv4 address assigned. This is
+-a workaround for an [issue fixed in Terraform 0.12](https://github.com/hashicorp/terraform/issues/17048)
+-but also provides a convenient way to access an IP of a specific type without
+-performing filtering in a Terraform config.
++* `public_ip_address` - The first public (`PRIMARY`) IPv4 address assigned.
+ 
+-* `private_ip_address` - The first private (`PRIVATE`) IPv4 address assigned. This is
+-a workaround for an [issue fixed in Terraform 0.12](https://github.com/hashicorp/terraform/issues/17048)
+-but also provides a convenient way to access an IP of a specific type without
+-performing filtering in a Terraform config.
++* `private_ip_address` - The first private (`PRIVATE`) IPv4 address assigned.
+ 
+ * `instance_type` - The type of the instance. The supported values are `SQL_INSTANCE_TYPE_UNSPECIFIED`, `CLOUD_SQL_INSTANCE`, `ON_PREMISES_INSTANCE` and `READ_REPLICA_INSTANCE`.
+ 
+diff --git b/website/docs/r/sql_ssl_cert.html.markdown a/website/docs/r/sql_ssl_cert.html.markdown
+index baff78aae..fa73d8f49 100644
+--- b/website/docs/r/sql_ssl_cert.html.markdown
++++ a/website/docs/r/sql_ssl_cert.html.markdown
+@@ -8,8 +8,7 @@ description: |-
+ 
+ Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
+ 
+-~> **Note:** All arguments including the private key will be stored in the raw state as plain-text.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Note:** All arguments including the private key will be stored in the raw state as plain-text
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/sql_user.html.markdown a/website/docs/r/sql_user.html.markdown
+index 9f5f93b1f..03af29f90 100644
+--- b/website/docs/r/sql_user.html.markdown
++++ a/website/docs/r/sql_user.html.markdown
+@@ -9,8 +9,6 @@ description: |-
+ Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
+ 
+ ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data). Passwords will not be retrieved when running
+-"terraform import".
+ 
+ ## Example Usage
+ 
+diff --git b/website/docs/r/storage_bucket.html.markdown a/website/docs/r/storage_bucket.html.markdown
+index 32275ea33..37e0dd646 100644
+--- b/website/docs/r/storage_bucket.html.markdown
++++ a/website/docs/r/storage_bucket.html.markdown
+@@ -93,7 +93,7 @@ The following arguments are supported:
+ 
+ * `force_destroy` - (Optional, Default: false) When deleting a bucket, this
+     boolean option will delete all contained objects. If you try to delete a
+-    bucket that contains objects, Terraform will fail that run.
++    bucket that contains objects, the provider will fail that run.
+ 
+ * `project` - (Optional) The ID of the project in which the resource belongs. If it
+     is not provided, the provider project is used.
+@@ -216,9 +216,9 @@ The following arguments are supported:
+   until a relevant action has occurred which triggers its creation.
+   You should use the [`google_storage_project_service_account`](/docs/providers/google/d/storage_project_service_account.html) data source to obtain the email
+   address for the service account when configuring IAM policy on the Cloud KMS key.
+-  This data source calls an API which creates the account if required, ensuring your Terraform applies cleanly and repeatedly irrespective of the
++  This data source calls an API which creates the account if required, ensuring your provider applies cleanly and repeatedly irrespective of the
+   state of the project.
+-  You should take care for race conditions when the same Terraform manages IAM policy on the Cloud KMS crypto key. See the data source page for more details.
++  You should take care for race conditions when the same provider manages IAM policy on the Cloud KMS crypto key. See the data source page for more details.
+ 
+ <a name="nested_custom_placement_config"></a>The `custom_placement_config` block supports:
+ 
+diff --git b/website/docs/r/storage_bucket_access_control.html.markdown a/website/docs/r/storage_bucket_access_control.html.markdown
+index c7d6eaa45..7d1986a72 100644
+--- b/website/docs/r/storage_bucket_access_control.html.markdown
++++ a/website/docs/r/storage_bucket_access_control.html.markdown
+@@ -21,8 +21,7 @@ description: |-
+ # google\_storage\_bucket\_access\_control
+ 
+ Bucket ACLs can be managed authoritatively using the
+-[`storage_bucket_acl`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_acl)
+-resource. Do not use these two resources in conjunction to manage the same bucket.
++`storage_bucket_acl` resource. Do not use these two resources in conjunction to manage the same bucket.
+ 
+ The BucketAccessControls resource manages the Access Control List
+ (ACLs) for a single entity/role pairing on a bucket. ACLs let you specify who
+diff --git b/website/docs/r/storage_bucket_acl.html.markdown a/website/docs/r/storage_bucket_acl.html.markdown
+index 8b5b59ff1..5805f6eb3 100644
+--- b/website/docs/r/storage_bucket_acl.html.markdown
++++ a/website/docs/r/storage_bucket_acl.html.markdown
+@@ -11,7 +11,7 @@ Authoritatively manages a bucket's ACLs in Google cloud storage service (GCS). F
+ and
+ [API](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls).
+ 
+-Bucket ACLs can be managed non authoritatively using the [`storage_bucket_access_control`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_access_control) resource. Do not use these two resources in conjunction to manage the same bucket.
++Bucket ACLs can be managed non authoritatively using the `storage_bucket_access_control` resource. Do not use these two resources in conjunction to manage the same bucket.
+ 
+ Permissions can be granted either by ACLs or Cloud IAM policies. In general, permissions granted by Cloud IAM policies do not appear in ACLs, and permissions granted by ACLs do not appear in Cloud IAM policies. The only exception is for ACLs applied directly on a bucket and certain bucket-level Cloud IAM policies, as described in [Cloud IAM relation to ACLs](https://cloud.google.com/storage/docs/access-control/iam#acls).
+ 
+diff --git b/website/docs/r/storage_bucket_iam.html.markdown a/website/docs/r/storage_bucket_iam.html.markdown
+index 93419817b..d7ed3e14b 100644
+--- b/website/docs/r/storage_bucket_iam.html.markdown
++++ a/website/docs/r/storage_bucket_iam.html.markdown
+@@ -170,8 +170,8 @@ The `condition` block supports:
+ 
+ * `description` - (Optional) An optional description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
+ 
+-~> **Warning:** Terraform considers the `role` and condition contents (`title`+`description`+`expression`) as the
+-  identifier for the binding. This means that if any part of the condition is changed out-of-band, Terraform will
++~> **Warning:** This provider considers the `role` and condition contents (`title`+`description`+`expression`) as the
++  identifier for the binding. This means that if any part of the condition is changed out-of-band, the provider will
+   consider it to be an entirely different resource and will treat it as such.
+ ## Attributes Reference
+ 
+diff --git b/website/docs/r/storage_bucket_object.html.markdown a/website/docs/r/storage_bucket_object.html.markdown
+index 57995a5d9..08b71c256 100644
+--- b/website/docs/r/storage_bucket_object.html.markdown
++++ a/website/docs/r/storage_bucket_object.html.markdown
+@@ -48,7 +48,7 @@ The following arguments are supported:
+ 
+ One of the following is required:
+ 
+-* `content` - (Optional, Sensitive) Data as `string` to be uploaded. Must be defined if `source` is not. **Note**: The `content` field is marked as sensitive. To view the raw contents of the object, please define an [output](/docs/configuration/outputs.html).
++* `content` - (Optional, Sensitive) Data as `string` to be uploaded. Must be defined if `source` is not. **Note**: The `content` field is marked as sensitive.
+ 
+ * `source` - (Optional) A path to the data you want to upload. Must be defined
+     if `content` is not.
+diff --git b/website/docs/r/storage_hmac_key.html.markdown a/website/docs/r/storage_hmac_key.html.markdown
+index 34bcf854c..29c1d208b 100644
+--- b/website/docs/r/storage_hmac_key.html.markdown
++++ a/website/docs/r/storage_hmac_key.html.markdown
+@@ -31,12 +31,10 @@ To get more information about HmacKey, see:
+     * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
+ 
+ ~> **Warning:** All arguments including the `secret` value will be stored in the raw
+-state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-On import, the `secret` value will not be retrieved.
++state as plain-text. On import, the `secret` value will not be retrieved.
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `secret`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
++~> **Warning:** All arguments including `secret` will be stored in the raw
++state as plain-text.
+ 
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_hmac_key&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+@@ -52,7 +50,7 @@ resource "google_service_account" "service_account" {
+   account_id = "my-svc-acc"
+ }
+ 
+-#Create the HMAC key for the associated service account 
++#Create the HMAC key for the associated service account
+ resource "google_storage_hmac_key" "key" {
+   service_account_email = google_service_account.service_account.email
+ }
+diff --git b/website/docs/r/storage_object_acl.html.markdown a/website/docs/r/storage_object_acl.html.markdown
+index 5097a6bd5..c55429277 100644
+--- b/website/docs/r/storage_object_acl.html.markdown
++++ a/website/docs/r/storage_object_acl.html.markdown
+@@ -58,11 +58,6 @@ resource "google_storage_object_acl" "image-store-acl" {
+ * `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Object ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls) for more details.
+ Must be set if `predefined_acl` is not.
+ 
+--> The object's creator will always have `OWNER` permissions for their object, and any attempt to modify that permission would return an error. Instead, Terraform automatically
+-adds that role/entity pair to your `terraform plan` results when it is omitted in your config; `terraform plan` will show the correct final state at every point except for at
+-`Create` time, where the object role/entity pair is omitted if not explicitly set.
+-
+-
+ ## Attributes Reference
+ 
+ Only the arguments listed above are exposed as attributes.
+diff --git b/website/docs/r/tpu_node.html.markdown a/website/docs/r/tpu_node.html.markdown
+index f56436c17..0ffee5cc6 100644
+--- b/website/docs/r/tpu_node.html.markdown
++++ a/website/docs/r/tpu_node.html.markdown
+@@ -71,7 +71,7 @@ resource "google_tpu_node" "tpu" {
+ 
+   tensorflow_version = data.google_tpu_tensorflow_versions.available.versions[0]
+ 
+-  description = "Terraform Google Provider test TPU"
++  description = "Google Provider test TPU"
+   use_service_networking = true
+   network = google_service_networking_connection.private_service_connection.network
+ 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,7 +3,7 @@ module github.com/pulumi/pulumi-gcp/provider/v6
 go 1.19
 
 require (
-	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20210315160117-642085ce9b99
+	github.com/hashicorp/terraform-provider-google-beta v0.0.0
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.11.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.49.0
 	github.com/pulumi/pulumi/pkg/v3 v3.69.0
@@ -12,7 +12,7 @@ require (
 
 replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9
-	github.com/hashicorp/terraform-provider-google-beta => github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230605233926-969874ef7510
+	github.com/hashicorp/terraform-provider-google-beta => ../upstream
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1721,8 +1721,6 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9 h1:JMw+t5I+6E8Lna7JF+ghAoOLOl23UIbshJyRNP+K1HU=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220824175045-450992f2f5b9/go.mod h1:mYPs/uchNcBq7AclQv9QUtSf9iNcfp1Ag21jqTlDf2M=
-github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230605233926-969874ef7510 h1:zFxXoBM/o/sqmJpdmUTcXUnMgVT3uV0sLyuIU2qKKjE=
-github.com/pulumi/terraform-provider-google-beta v1.20.1-0.20230605233926-969874ef7510/go.mod h1:QWdb0MSg9vlnhw7H/c+0X0ZnZAr/GM8HAANgF7rutV0=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -363,17 +363,18 @@ func Provider() tfbridge.ProviderInfo {
 		shimv2.NewProvider(google.Provider()),
 		google.New(version.Version)) // this probably should be TF version but it does not seem to matter
 	prov := tfbridge.ProviderInfo{
-		P:              p,
-		Name:           "google-beta",
-		ResourcePrefix: "google",
-		GitHubOrg:      "hashicorp",
-		Description:    "A Pulumi package for creating and managing Google Cloud Platform resources.",
-		Keywords:       []string{"pulumi", "gcp"},
-		License:        "Apache-2.0",
-		Homepage:       "https://pulumi.io",
-		Repository:     "https://github.com/pulumi/pulumi-gcp",
-		Version:        version.Version,
-		MetadataInfo:   tfbridge.NewProviderMetadata(metadata),
+		P:                p,
+		Name:             "google-beta",
+		ResourcePrefix:   "google",
+		GitHubOrg:        "hashicorp",
+		Description:      "A Pulumi package for creating and managing Google Cloud Platform resources.",
+		Keywords:         []string{"pulumi", "gcp"},
+		License:          "Apache-2.0",
+		Homepage:         "https://pulumi.io",
+		Repository:       "https://github.com/pulumi/pulumi-gcp",
+		Version:          version.Version,
+		MetadataInfo:     tfbridge.NewProviderMetadata(metadata),
+		UpstreamRepoPath: "./upstream",
 		Config: map[string]*tfbridge.SchemaInfo{
 			"project": {
 				Default: &tfbridge.DefaultInfo{


### PR DESCRIPTION
Fixes #1102 

Since team ecosystem now owns `pulumi-gcp`, migrating from maintaining a fork to using the submodule aligns this provider with the rest of ecosystem's providers, allowing us to utilize the `upgrade-provider` tool on it.