### PR TITLE
Remove goreleaser hooks

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -26,10 +26,6 @@ builds:
   - darwin
   - windows
   - linux
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gcp/provider/v6/pkg/version.Version={{.Tag}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,10 +26,6 @@ builds:
   - darwin
   - windows
   - linux
-  hooks:
-    post:
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
-    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-gcp/provider/v6/pkg/version.Version={{.Tag}}


### PR DESCRIPTION
This is to unblock GCP releasing (https://github.com/pulumi/pulumi-gcp/issues/1197). The changes were made to ci-mgmt already in https://github.com/pulumi/ci-mgmt/pull/572, but this PR is expedite this rollout.