### PR TITLE
Add project_name for goreleaser

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -441,7 +441,6 @@ on:
   push:
     branches:
     - master
-    - rquitales/fix-goreleaser
     paths-ignore:
     - "**.md"
     tags-ignore:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -441,6 +441,7 @@ on:
   push:
     branches:
     - master
+    - rquitales/fix-goreleaser
     paths-ignore:
     - "**.md"
     tags-ignore:

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -37,3 +37,4 @@ release:
   disable: true
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: pulumi-gcp

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,3 +46,4 @@ release:
   disable: false
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
+project_name: pulumi-gcp


### PR DESCRIPTION
When CI is upgraded to goreleaser v1.21, our publish steps fail as the `project_name` could not be formulated by GoReleaser. This PR explicitly sets the `project_name`.

Note, for faster feedback loop, this PR should be merged first and a follow-up PR in pu/ci-mgmt will be created.
I've also triggered the CI workflow for this commit to test that it works and it is passing: https://github.com/pulumi/pulumi-gcp/actions/runs/6313530404/job/17142821989

Fixes: #1217 