### PR TITLE
Refine auto-naming for a few HTTP-based resources

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -1,0 +1,25 @@
+// Copyright 2016-2023, Pulumi Corporation.  All rights reserved.
+//go:build go || all
+// +build go all
+
+package examples
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpHealthCheck(t *testing.T) {
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join(getCwd(t), "http-health-check"),
+	})
+}

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -5,20 +5,13 @@
 package examples
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHttpHealthCheck(t *testing.T) {
-	cwd, err := os.Getwd()
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: filepath.Join(getCwd(t), "http-health-check"),
 	})

--- a/examples/http-health-check/Pulumi.yaml
+++ b/examples/http-health-check/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: test-http-autonaming
+runtime:
+  name: yaml
+resources:
+  testedResource:
+    type: gcp:compute:HttpHealthCheck
+    properties:
+      checkIntervalSec: 1
+      requestPath: /health_check
+      timeoutSec: 1

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -311,9 +311,9 @@ func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []st
 	return ""
 }
 
-// httpAutoName provides a schema info with autonaming set to lowercase names for resources that don't support capital casing in names.
+// lowercaseAutoName provides a schema info with autonaming set to lowercase names for resources that don't support capital casing in names.
 // This seems to be the case for many resources where a name ends up being in HTTP URLs.
-func httpAutoName() *tfbridge.SchemaInfo {
+func lowercaseAutoName() *tfbridge.SchemaInfo {
 	return tfbridge.AutoNameWithCustomOptions("name", tfbridge.AutoNameOptions{
 		Separator: "-",
 		Maxlen:    63,
@@ -1088,7 +1088,7 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "compute_backend_service.html.markdown",
 				},
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"name": httpAutoName(),
+					"name": lowercaseAutoName(),
 				},
 			},
 			"google_compute_backend_service_signed_url_key": {
@@ -1113,13 +1113,13 @@ func Provider() tfbridge.ProviderInfo {
 			"google_compute_http_health_check": {
 				Tok: gcpResource(gcpCompute, "HttpHealthCheck"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"name": httpAutoName(),
+					"name": lowercaseAutoName(),
 				},
 			},
 			"google_compute_https_health_check": {
 				Tok: gcpResource(gcpCompute, "HttpsHealthCheck"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"name": httpAutoName(),
+					"name": lowercaseAutoName(),
 				},
 			},
 			"google_compute_image":                       {Tok: gcpResource(gcpCompute, "Image")},
@@ -1181,12 +1181,17 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "compute_network_endpoint_group.html.markdown",
 				},
 			},
-			"google_compute_network_firewall_policy":                    {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicy")},
-			"google_compute_network_firewall_policy_association":        {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicyAssociation")},
-			"google_compute_network_firewall_policy_rule":               {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicyRule")},
-			"google_compute_network_peering":                            {Tok: gcpResource(gcpCompute, "NetworkPeering")},
-			"google_compute_network_peering_routes_config":              {Tok: gcpResource(gcpCompute, "NetworkPeeringRoutesConfig")},
-			"google_compute_network":                                    {Tok: gcpResource(gcpCompute, "Network")},
+			"google_compute_network_firewall_policy":             {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicy")},
+			"google_compute_network_firewall_policy_association": {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicyAssociation")},
+			"google_compute_network_firewall_policy_rule":        {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicyRule")},
+			"google_compute_network_peering":                     {Tok: gcpResource(gcpCompute, "NetworkPeering")},
+			"google_compute_network_peering_routes_config":       {Tok: gcpResource(gcpCompute, "NetworkPeeringRoutesConfig")},
+			"google_compute_network": {
+				Tok: gcpResource(gcpCompute, "Network"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": lowercaseAutoName(),
+				},
+			},
 			"google_compute_project_default_network_tier":               {Tok: gcpResource(gcpCompute, "ProjectDefaultNetworkTier")},
 			"google_compute_project_metadata":                           {Tok: gcpResource(gcpCompute, "ProjectMetadata")},
 			"google_compute_project_metadata_item":                      {Tok: gcpResource(gcpCompute, "ProjectMetadataItem")},
@@ -1261,13 +1266,13 @@ func Provider() tfbridge.ProviderInfo {
 			"google_compute_target_http_proxy": {
 				Tok: gcpResource(gcpCompute, "TargetHttpProxy"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"name": httpAutoName(),
+					"name": lowercaseAutoName(),
 				},
 			},
 			"google_compute_target_https_proxy": {
 				Tok: gcpResource(gcpCompute, "TargetHttpsProxy"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"name": httpAutoName(),
+					"name": lowercaseAutoName(),
 				},
 			},
 			"google_compute_target_instance":   {Tok: gcpResource(gcpCompute, "TargetInstance")},
@@ -1278,7 +1283,7 @@ func Provider() tfbridge.ProviderInfo {
 			"google_compute_url_map": {
 				Tok: gcpResource(gcpCompute, "URLMap"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"name": httpAutoName(),
+					"name": lowercaseAutoName(),
 				},
 			},
 			"google_compute_vpn_gateway":         {Tok: gcpResource(gcpCompute, "VPNGateway")},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -311,7 +311,7 @@ func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []st
 	return ""
 }
 
-// httpAutoName provides a schema info with automating set to lowercase names for resources that don't support capital casing in names.
+// httpAutoName provides a schema info with autonaming set to lowercase names for resources that don't support capital casing in names.
 // This seems to be the case for many resources where a name ends up being in HTTP URLs.
 func httpAutoName() *tfbridge.SchemaInfo {
 	return tfbridge.AutoNameWithCustomOptions("name", tfbridge.AutoNameOptions{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -311,6 +311,19 @@ func stringValue(vars resource.PropertyMap, prop resource.PropertyKey, envs []st
 	return ""
 }
 
+// httpAutoName provides a schema info with automating set to lowercase names for resources that don't support capital casing in names.
+// This seems to be the case for many resources where a name ends up being in HTTP URLs.
+func httpAutoName() *tfbridge.SchemaInfo {
+	return tfbridge.AutoNameWithCustomOptions("name", tfbridge.AutoNameOptions{
+		Separator: "-",
+		Maxlen:    63,
+		Randlen:   7,
+		Transform: func(name string) string {
+			return strings.ToLower(name)
+		},
+	})
+}
+
 func preConfigureCallbackWithLogger(ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig) error {
 
 	project := stringValue(vars, "project", []string{
@@ -1074,6 +1087,9 @@ func Provider() tfbridge.ProviderInfo {
 				Docs: &tfbridge.DocInfo{
 					Source: "compute_backend_service.html.markdown",
 				},
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": httpAutoName(),
+				},
 			},
 			"google_compute_backend_service_signed_url_key": {
 				Tok: gcpResource(gcpCompute, "BackendServiceSignedUrlKey"),
@@ -1094,14 +1110,24 @@ func Provider() tfbridge.ProviderInfo {
 			"google_compute_global_network_endpoint_group": {Tok: gcpResource(gcpCompute, "GlobalNetworkEndpointGroup")},
 			"google_compute_ha_vpn_gateway":                {Tok: gcpResource(gcpCompute, "HaVpnGateway")},
 			"google_compute_health_check":                  {Tok: gcpResource(gcpCompute, "HealthCheck")},
-			"google_compute_http_health_check":             {Tok: gcpResource(gcpCompute, "HttpHealthCheck")},
-			"google_compute_https_health_check":            {Tok: gcpResource(gcpCompute, "HttpsHealthCheck")},
-			"google_compute_image":                         {Tok: gcpResource(gcpCompute, "Image")},
-			"google_compute_instance":                      {Tok: gcpResource(gcpCompute, "Instance")},
-			"google_compute_instance_from_template":        {Tok: gcpResource(gcpCompute, "InstanceFromTemplate")},
-			"google_compute_instance_group":                {Tok: gcpResource(gcpCompute, "InstanceGroup")},
-			"google_compute_instance_group_manager":        {Tok: gcpResource(gcpCompute, "InstanceGroupManager")},
-			"google_compute_instance_from_machine_image":   {Tok: gcpResource(gcpCompute, "InstanceFromMachineImage")},
+			"google_compute_http_health_check": {
+				Tok: gcpResource(gcpCompute, "HttpHealthCheck"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": httpAutoName(),
+				},
+			},
+			"google_compute_https_health_check": {
+				Tok: gcpResource(gcpCompute, "HttpsHealthCheck"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": httpAutoName(),
+				},
+			},
+			"google_compute_image":                       {Tok: gcpResource(gcpCompute, "Image")},
+			"google_compute_instance":                    {Tok: gcpResource(gcpCompute, "Instance")},
+			"google_compute_instance_from_template":      {Tok: gcpResource(gcpCompute, "InstanceFromTemplate")},
+			"google_compute_instance_group":              {Tok: gcpResource(gcpCompute, "InstanceGroup")},
+			"google_compute_instance_group_manager":      {Tok: gcpResource(gcpCompute, "InstanceGroupManager")},
+			"google_compute_instance_from_machine_image": {Tok: gcpResource(gcpCompute, "InstanceFromMachineImage")},
 			"google_compute_instance_iam_binding": {
 				Tok: gcpResource(gcpCompute, "InstanceIAMBinding"),
 				Docs: &tfbridge.DocInfo{
@@ -1232,14 +1258,29 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "compute_subnetwork_iam.html.markdown",
 				},
 			},
-			"google_compute_target_http_proxy":   {Tok: gcpResource(gcpCompute, "TargetHttpProxy")},
-			"google_compute_target_https_proxy":  {Tok: gcpResource(gcpCompute, "TargetHttpsProxy")},
-			"google_compute_target_instance":     {Tok: gcpResource(gcpCompute, "TargetInstance")},
-			"google_compute_target_ssl_proxy":    {Tok: gcpResource(gcpCompute, "TargetSSLProxy")},
-			"google_compute_target_tcp_proxy":    {Tok: gcpResource(gcpCompute, "TargetTCPProxy")},
-			"google_compute_target_pool":         {Tok: gcpResource(gcpCompute, "TargetPool")},
-			"google_compute_target_grpc_proxy":   {Tok: gcpResource(gcpCompute, "TargetGrpcProxy")},
-			"google_compute_url_map":             {Tok: gcpResource(gcpCompute, "URLMap")},
+			"google_compute_target_http_proxy": {
+				Tok: gcpResource(gcpCompute, "TargetHttpProxy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": httpAutoName(),
+				},
+			},
+			"google_compute_target_https_proxy": {
+				Tok: gcpResource(gcpCompute, "TargetHttpsProxy"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": httpAutoName(),
+				},
+			},
+			"google_compute_target_instance":   {Tok: gcpResource(gcpCompute, "TargetInstance")},
+			"google_compute_target_ssl_proxy":  {Tok: gcpResource(gcpCompute, "TargetSSLProxy")},
+			"google_compute_target_tcp_proxy":  {Tok: gcpResource(gcpCompute, "TargetTCPProxy")},
+			"google_compute_target_pool":       {Tok: gcpResource(gcpCompute, "TargetPool")},
+			"google_compute_target_grpc_proxy": {Tok: gcpResource(gcpCompute, "TargetGrpcProxy")},
+			"google_compute_url_map": {
+				Tok: gcpResource(gcpCompute, "URLMap"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": httpAutoName(),
+				},
+			},
 			"google_compute_vpn_gateway":         {Tok: gcpResource(gcpCompute, "VPNGateway")},
 			"google_compute_vpn_tunnel":          {Tok: gcpResource(gcpCompute, "VPNTunnel")},
 			"google_compute_reservation":         {Tok: gcpResource(gcpCompute, "Reservation")},


### PR DESCRIPTION
We have a few reports about auto-naming failing when a given resource type does not allow capital letters in it. The motivation seems to be that those names are used as parts of URLs.

The PR overrides auto naming to use lowercase letters for a set of reported resources.

I added a test for one of the resources - the test fails without the fix and passes with the fix.

Fix https://github.com/pulumi/pulumi-gcp/issues/1148
Fix https://github.com/pulumi/pulumi-gcp/issues/813
Fix https://github.com/pulumi/pulumi-gcp/issues/1254