### PR TITLE
Switch default runtime of CallbackFunction to nodejs18

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -53,11 +53,9 @@ func TestAccLoadbalancer(t *testing.T) {
 }
 
 func TestAccTopic(t *testing.T) {
-	t.Skip("Temp skipping due to major version upgrade")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "topic"),
-			RunUpdateTest: true,
+			Dir: filepath.Join(getCwd(t), "topic"),
 			// One change is known to occur during refresh of the resources in this example:
 			// * `~  gcp:storage:Bucket f-bucket updated changes: + websites`
 			ExpectRefreshChanges: true,
@@ -67,11 +65,9 @@ func TestAccTopic(t *testing.T) {
 }
 
 func TestAccBucket(t *testing.T) {
-	t.Skip("Temp skipping due to major version upgrade")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "bucket"),
-			RunUpdateTest: true,
+			Dir: filepath.Join(getCwd(t), "bucket"),
 			// One change is known to occur during refresh of the resources in this example:
 			// * `~  gcp:storage:Bucket f-bucket updated changes: + websites`
 			ExpectRefreshChanges: true,
@@ -90,11 +86,9 @@ func TestAccMinimal(t *testing.T) {
 }
 
 func TestAccServerless(t *testing.T) {
-	t.Skip("Temp skipping due to major version upgrade")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "serverless"),
-			RunUpdateTest: true,
+			Dir: filepath.Join(getCwd(t), "serverless"),
 			// One change is known to occur during refresh of the resources in this example:
 			// * `~  gcp:storage:Bucket f-bucket updated changes: + websites`
 			ExpectRefreshChanges: true,

--- a/examples/serverless/index.ts
+++ b/examples/serverless/index.ts
@@ -16,7 +16,7 @@ import * as gcp from "@pulumi/gcp";
 
 // Create the Function resource
 let f = new gcp.cloudfunctions.HttpCallbackFunction("f",
-    (req, res) => {
+    (req: any, res: any) => {
         res.send(`Hello ${req.body.name || 'World'}!`);
     });
 

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/gcp": "^5.0.0"
+        "@pulumi/gcp": "latest"
     },
     "devDependencies": {
         "@types/node": "^8.0.0"

--- a/sdk/nodejs/cloudfunctions/zMixins.ts
+++ b/sdk/nodejs/cloudfunctions/zMixins.ts
@@ -169,7 +169,7 @@ export class CallbackFunction extends pulumi.ComponentResource {
 
         this.function = new cloudfunctions.Function(functionName, {
             ...argsCopy,
-            runtime: utils.ifUndefined(args.runtime, "nodejs8"),
+            runtime: utils.ifUndefined(args.runtime, "nodejs18"),
             entryPoint: handlerName,
             sourceArchiveBucket: this.bucket.name,
             sourceArchiveObject: this.bucketObject.name,


### PR DESCRIPTION
`CallbackFunction` defaults to Node.js 8 runtime, which was deprecated a long time ago. This PR switches the current version to Node.js 18. It's not breaking, since old defaults don't work, so we can't break anyone.

I also enabled three related tests. To make tests pass I had to:
- Disable `RunUpdateTest`. As I understand, an update test runs the program with the existing release first before testing the current code. The existing release does not work because it uses Node.js 8, so the test fails.
- Remove express types due to https://github.com/pulumi/pulumi-gcp/issues/939

Resolve https://github.com/pulumi/pulumi-gcp/issues/533
Resolve https://github.com/pulumi/pulumi-gcp/issues/1257