### PR TITLE
Re-enable TestAccBucket

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -65,13 +65,15 @@ func TestAccTopic(t *testing.T) {
 }
 
 func TestAccBucket(t *testing.T) {
-	t.Skip("Skipping due to high failure rates. See pulumi/pulumi-gcp#1267")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "bucket"),
 			// One change is known to occur during refresh of the resources in this example:
 			// * `~  gcp:storage:Bucket f-bucket updated changes: + websites`
 			ExpectRefreshChanges: true,
+			// GCP buckets seem to be eventually consistent, so we need to retry on failure when deploying a cloud function
+			// that uses the bucket as a trigger.
+			RetryFailedSteps: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -65,6 +65,7 @@ func TestAccTopic(t *testing.T) {
 }
 
 func TestAccBucket(t *testing.T) {
+	t.Skip("Skipping due to high failure rates. See pulumi/pulumi-gcp#1267")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "bucket"),


### PR DESCRIPTION
Fixes: #1267

Note: This re-enables the test with retry on failure. It would be ideal if we could handle retry on the provider/resource level instead so that users do not need to re-run `pulumi up` to fix this.