### PR TITLE
Try using a bigger host for the prereq build on nightly to see if it resolves the OOM like build failure

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -33,4 +33,5 @@ skipGoReleaserHooks: true
 javaGenVersion: v0.9.7
 runner:
   publish: pulumi-ubuntu-8core
+  prerequisites: pulumi-ubuntu-8core
   buildSdk: pulumi-ubuntu-8core

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -185,7 +185,7 @@ jobs:
         aws s3 cp "${{ env.COVERAGE_OUTPUT_DIR }}/summary.json" "${s3FullURI}" --acl bucket-owner-full-control
   prerequisites:
     name: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -133,7 +133,7 @@ jobs:
 
   prerequisites:
     name: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -132,7 +132,7 @@ jobs:
         - java
   prerequisites:
     name: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
         "${GITHUB_REF#refs/tags/}"
   prerequisites:
     name: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -154,7 +154,7 @@ jobs:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3


### PR DESCRIPTION
Should resolve [Workflow failure: cron· pulumi-gcp/1301](https://github.com/pulumi/pulumi-gcp/issues/1301) Eventually, we need to restructure builds to make them more manageable. 