### PR TITLE
Fix test cleanup for TestRegression794

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -78,7 +78,10 @@ func TestRegression794(t *testing.T) {
 
 	t.Cleanup(func() {
 		// Select an empty program to delete the stack.
-		s, err := auto.UpsertStackInlineSource(ctx, stackName, originProject, nil)
+		s, err := auto.UpsertStackInlineSource(ctx, stackName, originProject, nil, auto.WorkDir(workdir), auto.EnvVars(map[string]string{
+			workspace.PulumiBackendURLEnvVar: backendUrl,
+			"PULUMI_CONFIG_PASSPHRASE":       configPassphrase,
+		}))
 		if err != nil {
 			t.Fatalf("failed to select workspace to delete: %v", err)
 		}
@@ -94,6 +97,9 @@ func TestRegression794(t *testing.T) {
 			instance, err := sql.NewDatabaseInstance(ctx, "test", &sql.DatabaseInstanceArgs{
 				Name:            pulumi.String(databaseName),
 				DatabaseVersion: pulumi.String("POSTGRES_15"),
+				// We need to explicitly disable deletion protection, otherwise the database will not be deleted
+				// when the stack is destroyed.
+				DeletionProtection: pulumi.BoolPtr(false),
 				Settings: sql.DatabaseInstanceSettingsArgs{
 					// In testing, we saw these times for running tests over at least two trials on each:
 					//


### PR DESCRIPTION
This PR fixes the clean up steps for `TestRegression794` to prevent leaking an expensive Cloud SQL DB instance. The 2 changes required are:

1. `DeletionProtection` needs to explicitly be set to `false`
2. The stack backend used for deletion by default attempts to use Pulumi Cloud. This causes an empty stack to be used for running `pulumi destroy`, which will not destroy the DB instance. We need to also specify the `PULUMI_BACKEND_URL` to point to the local backend we've been using in prior steps

Fixes: #1311