### PR TITLE
Cleanup version prefix

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -14,7 +14,6 @@ env:
   GOOGLE_REGION: "us-central1"
   GOOGLE_ZONE: "us-central1-a"
   PULUMI_MISSING_DOCS_ERROR: true
-  VERSION_PREFIX: 7.0.0
 upstream-provider-repo: terraform-provider-google-beta
 makeTemplate: bridged
 plugins:

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -35,7 +35,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   command-dispatch-for-testing:
     name: command-dispatch-for-testing

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -41,7 +41,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 
 jobs:
   license_check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 
 jobs:
   lint:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,7 +35,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -35,7 +35,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -36,7 +36,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   build_sdk:
     name: build_sdk

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -37,7 +37,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   resync_build:
     name: resync-build

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -36,7 +36,6 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   TF_APPEND_USER_AGENT: pulumi
   TRAVIS_OS_NAME: linux
-  VERSION_PREFIX: 7.0.0
 jobs:
   build_sdk:
     if: github.event_name == 'repository_dispatch' ||


### PR DESCRIPTION
We set VERSION_PREFIX temporarily during the v7 release to make sure pulumictl versions code as 7.x.x; it is no longer necessary now that pulumictl will be finding a 7.x. tag in Git history.