### PR TITLE
Plugin versions must be set via ci config

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -18,11 +18,11 @@ upstream-provider-repo: terraform-provider-google-beta
 makeTemplate: bridged
 plugins:
   - name: random
-    version: "4.8.2"
+    version: "4.14.0"
   - name: kubernetes
-    version: "3.20.0"
+    version: "4.5.4"
   - name: tls
-    version: "4.6.0"
+    version: "4.11.1"
   - name: http
     version: "0.0.1"
   - name: time


### PR DESCRIPTION
This PR realigns the plugin versions set in #1341 via the ci config file.

Resolves build failure in https://github.com/pulumi/pulumi-gcp/pull/1354.
