### PR TITLE
Patch documentation for Compute Forwarding Rule and Compute Global Forwarding Rule

### DIFF
--- a/patches/0001-Allow-disabling-the-partner-name.patch
+++ b/patches/0001-Allow-disabling-the-partner-name.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 7 Mar 2023 11:09:59 +0000
-Subject: [PATCH 1/9] Allow disabling the partner name
+Subject: [PATCH 01/10] Allow disabling the partner name
 
 Add options to set or disable partner name.
 

--- a/patches/0002-Add-nil-checks-for-sql-database-instance-flattening.patch
+++ b/patches/0002-Add-nil-checks-for-sql-database-instance-flattening.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 7 Mar 2023 11:50:33 +0000
-Subject: [PATCH 2/9] Add nil checks for sql database instance flattening
+Subject: [PATCH 02/10] Add nil checks for sql database instance flattening
 
 
 diff --git a/google-beta/services/sql/resource_sql_database_instance.go b/google-beta/services/sql/resource_sql_database_instance.go

--- a/patches/0003-rebase-bigquery_dataset.patch
+++ b/patches/0003-rebase-bigquery_dataset.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guinevere Saenger <guinevere@pulumi.com>
 Date: Wed, 4 Oct 2023 12:49:17 -0700
-Subject: [PATCH 3/9] rebase bigquery_dataset
+Subject: [PATCH 03/10] rebase bigquery_dataset
 
 
 diff --git a/google-beta/services/bigquery/resource_bigquery_dataset.go b/google-beta/services/bigquery/resource_bigquery_dataset.go

--- a/patches/0004-Add-flattening-of-self-managed-certificates.patch
+++ b/patches/0004-Add-flattening-of-self-managed-certificates.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 7 Mar 2023 11:57:44 +0000
-Subject: [PATCH 4/9] Add flattening of self managed certificates
+Subject: [PATCH 04/10] Add flattening of self managed certificates
 
 
 diff --git a/google-beta/services/certificatemanager/resource_certificate_manager_certificate.go b/google-beta/services/certificatemanager/resource_certificate_manager_certificate.go

--- a/patches/0005-website-docs-d-tweaks.patch
+++ b/patches/0005-website-docs-d-tweaks.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Daniel Bradley <daniel@pulumi.com>
 Date: Tue, 7 Mar 2023 11:16:06 +0000
-Subject: [PATCH 5/9] website/docs/d tweaks
+Subject: [PATCH 05/10] website/docs/d tweaks
 
 
 diff --git a/website/docs/d/cloud_run_service.html.markdown b/website/docs/d/cloud_run_service.html.markdown

--- a/patches/0006-docs-patching.patch
+++ b/patches/0006-docs-patching.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Guinevere Saenger <guinevere@pulumi.com>
 Date: Wed, 4 Oct 2023 12:52:40 -0700
-Subject: [PATCH 6/9] docs patching
+Subject: [PATCH 06/10] docs patching
 
 
 diff --git a/website/docs/r/api_gateway_api.html.markdown b/website/docs/r/api_gateway_api.html.markdown

--- a/patches/0007-Exclude-scripts-dir-from-provider-go-module.patch
+++ b/patches/0007-Exclude-scripts-dir-from-provider-go-module.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aaron Friel <mayreply@aaronfriel.com>
 Date: Thu, 22 Jun 2023 09:45:36 -0700
-Subject: [PATCH 7/9] Exclude scripts dir from provider go module
+Subject: [PATCH 07/10] Exclude scripts dir from provider go module
 
 This directory references a private Go module, which we cannot "go vet" or check.
 

--- a/patches/0008-Remove-duplicative-resource-token.patch
+++ b/patches/0008-Remove-duplicative-resource-token.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aaron Friel <mayreply@aaronfriel.com>
 Date: Thu, 22 Jun 2023 16:38:12 -0700
-Subject: [PATCH 8/9] Remove duplicative resource token
+Subject: [PATCH 08/10] Remove duplicative resource token
 
 
 diff --git a/google-beta/provider/provider.go b/google-beta/provider/provider.go

--- a/patches/0009-Fix-794-with-an-unconditional-read.patch
+++ b/patches/0009-Fix-794-with-an-unconditional-read.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aaron Friel <mayreply@aaronfriel.com>
 Date: Thu, 7 Sep 2023 16:28:00 -0700
-Subject: [PATCH 9/9] Fix #794 with an unconditional read.
+Subject: [PATCH 09/10] Fix #794 with an unconditional read.
 
 
 diff --git a/google-beta/services/sql/resource_sql_database_instance.go b/google-beta/services/sql/resource_sql_database_instance.go

--- a/patches/0010-Remove-pattern-string-from-compute-forwarding-rules.patch
+++ b/patches/0010-Remove-pattern-string-from-compute-forwarding-rules.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Guinevere Saenger <guinevere@pulumi.com>
+Date: Thu, 16 Nov 2023 13:58:59 -0800
+Subject: [PATCH 10/10] Remove pattern string from compute forwarding rules
+
+
+diff --git a/website/docs/r/compute_forwarding_rule.html.markdown b/website/docs/r/compute_forwarding_rule.html.markdown
+index 4c6774f39..b31c6012d 100644
+--- a/website/docs/r/compute_forwarding_rule.html.markdown
++++ b/website/docs/r/compute_forwarding_rule.html.markdown
+@@ -1437,7 +1437,7 @@ The following arguments are supported:
+   For internal forwarding rules within the same VPC network, two or more
+   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
+   cannot have overlapping `portRange`s.
+-  @pattern: \d+(?:-\d+)?
++  
+ 
+ * `ports` -
+   (Optional)
+@@ -1458,7 +1458,7 @@ The following arguments are supported:
+   For internal forwarding rules within the same VPC network, two or more
+   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
+   they share at least one port number.
+-  @pattern: \d+(?:-\d+)?
++  
+ 
+ * `subnetwork` -
+   (Optional)
+diff --git a/website/docs/r/compute_global_forwarding_rule.html.markdown b/website/docs/r/compute_global_forwarding_rule.html.markdown
+index 88f3f0c94..99614ee2b 100644
+--- a/website/docs/r/compute_global_forwarding_rule.html.markdown
++++ b/website/docs/r/compute_global_forwarding_rule.html.markdown
+@@ -1337,7 +1337,7 @@ The following arguments are supported:
+   For internal forwarding rules within the same VPC network, two or more
+   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
+   cannot have overlapping `portRange`s.
+-  @pattern: \d+(?:-\d+)?
++  
+ 
+ * `subnetwork` -
+   (Optional)

--- a/sdk/dotnet/Compute/ForwardingRule.cs
+++ b/sdk/dotnet/Compute/ForwardingRule.cs
@@ -367,7 +367,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         /// cannot have overlapping `portRange`s.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         [Output("portRange")]
         public Output<string> PortRange { get; private set; } = null!;
@@ -390,7 +389,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
         /// they share at least one port number.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         [Output("ports")]
         public Output<ImmutableArray<string>> Ports { get; private set; } = null!;
@@ -779,7 +777,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         /// cannot have overlapping `portRange`s.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         [Input("portRange")]
         public Input<string>? PortRange { get; set; }
@@ -805,7 +802,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
         /// they share at least one port number.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         public InputList<string> Ports
         {
@@ -1163,7 +1159,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         /// cannot have overlapping `portRange`s.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         [Input("portRange")]
         public Input<string>? PortRange { get; set; }
@@ -1189,7 +1184,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
         /// they share at least one port number.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         public InputList<string> Ports
         {

--- a/sdk/dotnet/Compute/GlobalForwardingRule.cs
+++ b/sdk/dotnet/Compute/GlobalForwardingRule.cs
@@ -413,7 +413,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         /// cannot have overlapping `portRange`s.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         [Output("portRange")]
         public Output<string?> PortRange { get; private set; } = null!;
@@ -712,7 +711,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         /// cannot have overlapping `portRange`s.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         [Input("portRange")]
         public Input<string>? PortRange { get; set; }
@@ -978,7 +976,6 @@ namespace Pulumi.Gcp.Compute
         /// For internal forwarding rules within the same VPC network, two or more
         /// forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         /// cannot have overlapping `portRange`s.
-        /// @pattern: \d+(?:-\d+)?
         /// </summary>
         [Input("portRange")]
         public Input<string>? PortRange { get; set; }

--- a/sdk/go/gcp/compute/forwardingRule.go
+++ b/sdk/go/gcp/compute/forwardingRule.go
@@ -315,7 +315,6 @@ type ForwardingRule struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange pulumi.StringOutput `pulumi:"portRange"`
 	// The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
 	// Only packets addressed to ports in the specified range will be forwarded
@@ -334,7 +333,6 @@ type ForwardingRule struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
 	//   they share at least one port number.
-	//   @pattern: \d+(?:-\d+)?
 	Ports pulumi.StringArrayOutput `pulumi:"ports"`
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -595,7 +593,6 @@ type forwardingRuleState struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange *string `pulumi:"portRange"`
 	// The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
 	// Only packets addressed to ports in the specified range will be forwarded
@@ -614,7 +611,6 @@ type forwardingRuleState struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
 	//   they share at least one port number.
-	//   @pattern: \d+(?:-\d+)?
 	Ports []string `pulumi:"ports"`
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -841,7 +837,6 @@ type ForwardingRuleState struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange pulumi.StringPtrInput
 	// The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
 	// Only packets addressed to ports in the specified range will be forwarded
@@ -860,7 +855,6 @@ type ForwardingRuleState struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
 	//   they share at least one port number.
-	//   @pattern: \d+(?:-\d+)?
 	Ports pulumi.StringArrayInput
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -1082,7 +1076,6 @@ type forwardingRuleArgs struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange *string `pulumi:"portRange"`
 	// The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
 	// Only packets addressed to ports in the specified range will be forwarded
@@ -1101,7 +1094,6 @@ type forwardingRuleArgs struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
 	//   they share at least one port number.
-	//   @pattern: \d+(?:-\d+)?
 	Ports []string `pulumi:"ports"`
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -1308,7 +1300,6 @@ type ForwardingRuleArgs struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange pulumi.StringPtrInput
 	// The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
 	// Only packets addressed to ports in the specified range will be forwarded
@@ -1327,7 +1318,6 @@ type ForwardingRuleArgs struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
 	//   they share at least one port number.
-	//   @pattern: \d+(?:-\d+)?
 	Ports pulumi.StringArrayInput
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -1685,7 +1675,6 @@ func (o ForwardingRuleOutput) NoAutomateDnsZone() pulumi.BoolPtrOutput {
 //     For internal forwarding rules within the same VPC network, two or more
 //     forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 //     cannot have overlapping `portRange`s.
-//     @pattern: \d+(?:-\d+)?
 func (o ForwardingRuleOutput) PortRange() pulumi.StringOutput {
 	return o.ApplyT(func(v *ForwardingRule) pulumi.StringOutput { return v.PortRange }).(pulumi.StringOutput)
 }
@@ -1707,7 +1696,6 @@ func (o ForwardingRuleOutput) PortRange() pulumi.StringOutput {
 //     For internal forwarding rules within the same VPC network, two or more
 //     forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
 //     they share at least one port number.
-//     @pattern: \d+(?:-\d+)?
 func (o ForwardingRuleOutput) Ports() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *ForwardingRule) pulumi.StringArrayOutput { return v.Ports }).(pulumi.StringArrayOutput)
 }

--- a/sdk/go/gcp/compute/globalForwardingRule.go
+++ b/sdk/go/gcp/compute/globalForwardingRule.go
@@ -366,7 +366,6 @@ type GlobalForwardingRule struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange pulumi.StringPtrOutput `pulumi:"portRange"`
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -568,7 +567,6 @@ type globalForwardingRuleState struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange *string `pulumi:"portRange"`
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -733,7 +731,6 @@ type GlobalForwardingRuleState struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange pulumi.StringPtrInput
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -895,7 +892,6 @@ type globalForwardingRuleArgs struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange *string `pulumi:"portRange"`
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -1045,7 +1041,6 @@ type GlobalForwardingRuleArgs struct {
 	//   For internal forwarding rules within the same VPC network, two or more
 	//   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 	//   cannot have overlapping `portRange`s.
-	//   @pattern: \d+(?:-\d+)?
 	PortRange pulumi.StringPtrInput
 	// The ID of the project in which the resource belongs.
 	// If it is not provided, the provider project is used.
@@ -1329,7 +1324,6 @@ func (o GlobalForwardingRuleOutput) NoAutomateDnsZone() pulumi.BoolPtrOutput {
 //     For internal forwarding rules within the same VPC network, two or more
 //     forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
 //     cannot have overlapping `portRange`s.
-//     @pattern: \d+(?:-\d+)?
 func (o GlobalForwardingRuleOutput) PortRange() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *GlobalForwardingRule) pulumi.StringPtrOutput { return v.PortRange }).(pulumi.StringPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/ForwardingRule.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/ForwardingRule.java
@@ -2128,7 +2128,6 @@ public class ForwardingRule extends com.pulumi.resources.CustomResource {
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Export(name="portRange", refs={String.class}, tree="[0]")
@@ -2154,7 +2153,6 @@ public class ForwardingRule extends com.pulumi.resources.CustomResource {
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Output<String> portRange() {
@@ -2178,7 +2176,6 @@ public class ForwardingRule extends com.pulumi.resources.CustomResource {
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      *   they share at least one port number.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Export(name="ports", refs={List.class,String.class}, tree="[0,1]")
@@ -2202,7 +2199,6 @@ public class ForwardingRule extends com.pulumi.resources.CustomResource {
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      *   they share at least one port number.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Output<Optional<List<String>>> ports() {

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/ForwardingRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/ForwardingRuleArgs.java
@@ -480,7 +480,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Import(name="portRange")
@@ -506,7 +505,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Optional<Output<String>> portRange() {
@@ -531,7 +529,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      *   they share at least one port number.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Import(name="ports")
@@ -555,7 +552,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      *   they share at least one port number.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Optional<Output<List<String>>> ports() {
@@ -1337,7 +1333,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1367,7 +1362,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1394,7 +1388,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
          *   they share at least one port number.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1422,7 +1415,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
          *   they share at least one port number.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1449,7 +1441,6 @@ public final class ForwardingRuleArgs extends com.pulumi.resources.ResourceArgs 
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
          *   they share at least one port number.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/GlobalForwardingRule.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/GlobalForwardingRule.java
@@ -1803,7 +1803,6 @@ public class GlobalForwardingRule extends com.pulumi.resources.CustomResource {
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Export(name="portRange", refs={String.class}, tree="[0]")
@@ -1826,7 +1825,6 @@ public class GlobalForwardingRule extends com.pulumi.resources.CustomResource {
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Output<Optional<String>> portRange() {

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/GlobalForwardingRuleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/GlobalForwardingRuleArgs.java
@@ -361,7 +361,6 @@ public final class GlobalForwardingRuleArgs extends com.pulumi.resources.Resourc
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Import(name="portRange")
@@ -384,7 +383,6 @@ public final class GlobalForwardingRuleArgs extends com.pulumi.resources.Resourc
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Optional<Output<String>> portRange() {
@@ -958,7 +956,6 @@ public final class GlobalForwardingRuleArgs extends com.pulumi.resources.Resourc
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -985,7 +982,6 @@ public final class GlobalForwardingRuleArgs extends com.pulumi.resources.Resourc
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/inputs/ForwardingRuleState.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/inputs/ForwardingRuleState.java
@@ -542,7 +542,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Import(name="portRange")
@@ -568,7 +567,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Optional<Output<String>> portRange() {
@@ -593,7 +591,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      *   they share at least one port number.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Import(name="ports")
@@ -617,7 +614,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      *   they share at least one port number.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Optional<Output<List<String>>> ports() {
@@ -1573,7 +1569,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1603,7 +1598,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1630,7 +1624,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
          *   they share at least one port number.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1658,7 +1651,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
          *   they share at least one port number.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1685,7 +1677,6 @@ public final class ForwardingRuleState extends com.pulumi.resources.ResourceArgs
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
          *   they share at least one port number.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/inputs/GlobalForwardingRuleState.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/inputs/GlobalForwardingRuleState.java
@@ -408,7 +408,6 @@ public final class GlobalForwardingRuleState extends com.pulumi.resources.Resour
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     @Import(name="portRange")
@@ -431,7 +430,6 @@ public final class GlobalForwardingRuleState extends com.pulumi.resources.Resour
      *   For internal forwarding rules within the same VPC network, two or more
      *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      *   cannot have overlapping `portRange`s.
-     *   @pattern: \d+(?:-\d+)?
      * 
      */
     public Optional<Output<String>> portRange() {
@@ -1139,7 +1137,6 @@ public final class GlobalForwardingRuleState extends com.pulumi.resources.Resour
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 
@@ -1166,7 +1163,6 @@ public final class GlobalForwardingRuleState extends com.pulumi.resources.Resour
          *   For internal forwarding rules within the same VPC network, two or more
          *   forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
          *   cannot have overlapping `portRange`s.
-         *   @pattern: \d+(?:-\d+)?
          * 
          * @return builder
          * 

--- a/sdk/nodejs/compute/forwardingRule.ts
+++ b/sdk/nodejs/compute/forwardingRule.ts
@@ -323,7 +323,6 @@ export class ForwardingRule extends pulumi.CustomResource {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      * cannot have overlapping `portRange`s.
-     * @pattern: \d+(?:-\d+)?
      */
     public readonly portRange!: pulumi.Output<string>;
     /**
@@ -344,7 +343,6 @@ export class ForwardingRule extends pulumi.CustomResource {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      * they share at least one port number.
-     * @pattern: \d+(?:-\d+)?
      */
     public readonly ports!: pulumi.Output<string[] | undefined>;
     /**
@@ -731,7 +729,6 @@ export interface ForwardingRuleState {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      * cannot have overlapping `portRange`s.
-     * @pattern: \d+(?:-\d+)?
      */
     portRange?: pulumi.Input<string>;
     /**
@@ -752,7 +749,6 @@ export interface ForwardingRuleState {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      * they share at least one port number.
-     * @pattern: \d+(?:-\d+)?
      */
     ports?: pulumi.Input<pulumi.Input<string>[]>;
     /**
@@ -1032,7 +1028,6 @@ export interface ForwardingRuleArgs {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      * cannot have overlapping `portRange`s.
-     * @pattern: \d+(?:-\d+)?
      */
     portRange?: pulumi.Input<string>;
     /**
@@ -1053,7 +1048,6 @@ export interface ForwardingRuleArgs {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
      * they share at least one port number.
-     * @pattern: \d+(?:-\d+)?
      */
     ports?: pulumi.Input<pulumi.Input<string>[]>;
     /**

--- a/sdk/nodejs/compute/globalForwardingRule.ts
+++ b/sdk/nodejs/compute/globalForwardingRule.ts
@@ -342,7 +342,6 @@ export class GlobalForwardingRule extends pulumi.CustomResource {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      * cannot have overlapping `portRange`s.
-     * @pattern: \d+(?:-\d+)?
      */
     public readonly portRange!: pulumi.Output<string | undefined>;
     /**
@@ -628,7 +627,6 @@ export interface GlobalForwardingRuleState {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      * cannot have overlapping `portRange`s.
-     * @pattern: \d+(?:-\d+)?
      */
     portRange?: pulumi.Input<string>;
     /**
@@ -830,7 +828,6 @@ export interface GlobalForwardingRuleArgs {
      * For internal forwarding rules within the same VPC network, two or more
      * forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
      * cannot have overlapping `portRange`s.
-     * @pattern: \d+(?:-\d+)?
      */
     portRange?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_gcp/compute/forwarding_rule.py
+++ b/sdk/python/pulumi_gcp/compute/forwarding_rule.py
@@ -186,7 +186,6 @@ class ForwardingRuleArgs:
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[Sequence[pulumi.Input[str]]] ports: The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
                Only packets addressed to ports in the specified range will be forwarded
                to the backends configured with this forwarding rule.
@@ -204,7 +203,6 @@ class ForwardingRuleArgs:
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
                they share at least one port number.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[bool] recreate_closed_psc: This is used in PSC consumer ForwardingRule to make terraform recreate the ForwardingRule when the status is closed
@@ -605,7 +603,6 @@ class ForwardingRuleArgs:
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         cannot have overlapping `portRange`s.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "port_range")
 
@@ -634,7 +631,6 @@ class ForwardingRuleArgs:
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
         they share at least one port number.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "ports")
 
@@ -954,7 +950,6 @@ class _ForwardingRuleState:
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[Sequence[pulumi.Input[str]]] ports: The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
                Only packets addressed to ports in the specified range will be forwarded
                to the backends configured with this forwarding rule.
@@ -972,7 +967,6 @@ class _ForwardingRuleState:
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
                they share at least one port number.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[str] psc_connection_id: The PSC connection id of the PSC Forwarding Rule.
@@ -1447,7 +1441,6 @@ class _ForwardingRuleState:
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         cannot have overlapping `portRange`s.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "port_range")
 
@@ -1476,7 +1469,6 @@ class _ForwardingRuleState:
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
         they share at least one port number.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "ports")
 
@@ -1925,7 +1917,6 @@ class ForwardingRule(pulumi.CustomResource):
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[Sequence[pulumi.Input[str]]] ports: The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
                Only packets addressed to ports in the specified range will be forwarded
                to the backends configured with this forwarding rule.
@@ -1943,7 +1934,6 @@ class ForwardingRule(pulumi.CustomResource):
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
                they share at least one port number.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[bool] recreate_closed_psc: This is used in PSC consumer ForwardingRule to make terraform recreate the ForwardingRule when the status is closed
@@ -2349,7 +2339,6 @@ class ForwardingRule(pulumi.CustomResource):
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[Sequence[pulumi.Input[str]]] ports: The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
                Only packets addressed to ports in the specified range will be forwarded
                to the backends configured with this forwarding rule.
@@ -2367,7 +2356,6 @@ class ForwardingRule(pulumi.CustomResource):
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
                they share at least one port number.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[str] psc_connection_id: The PSC connection id of the PSC Forwarding Rule.
@@ -2737,7 +2725,6 @@ class ForwardingRule(pulumi.CustomResource):
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         cannot have overlapping `portRange`s.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "port_range")
 
@@ -2762,7 +2749,6 @@ class ForwardingRule(pulumi.CustomResource):
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
         they share at least one port number.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "ports")
 

--- a/sdk/python/pulumi_gcp/compute/global_forwarding_rule.py
+++ b/sdk/python/pulumi_gcp/compute/global_forwarding_rule.py
@@ -155,7 +155,6 @@ class GlobalForwardingRuleArgs:
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] source_ip_ranges: If not empty, this Forwarding Rule will only forward the traffic when the source IP address matches one of the IP addresses or CIDR ranges set here. Note that a Forwarding Rule can only have up to 64 source IP ranges, and this field can only be used with a regional Forwarding Rule whose scheme is EXTERNAL. Each sourceIpRange entry should be either an IP address (for example, 1.2.3.4) or a CIDR range (for example, 1.2.3.0/24).
@@ -455,7 +454,6 @@ class GlobalForwardingRuleArgs:
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         cannot have overlapping `portRange`s.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "port_range")
 
@@ -645,7 +643,6 @@ class _GlobalForwardingRuleState:
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[str] psc_connection_id: The PSC connection id of the PSC Forwarding Rule.
@@ -991,7 +988,6 @@ class _GlobalForwardingRuleState:
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         cannot have overlapping `portRange`s.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "port_range")
 
@@ -1381,7 +1377,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] source_ip_ranges: If not empty, this Forwarding Rule will only forward the traffic when the source IP address matches one of the IP addresses or CIDR ranges set here. Note that a Forwarding Rule can only have up to 64 source IP ranges, and this field can only be used with a regional Forwarding Rule whose scheme is EXTERNAL. Each sourceIpRange entry should be either an IP address (for example, 1.2.3.4) or a CIDR range (for example, 1.2.3.0/24).
@@ -1764,7 +1759,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
                For internal forwarding rules within the same VPC network, two or more
                forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
                cannot have overlapping `portRange`s.
-               @pattern: \\d+(?:-\\d+)?
         :param pulumi.Input[str] project: The ID of the project in which the resource belongs.
                If it is not provided, the provider project is used.
         :param pulumi.Input[str] psc_connection_id: The PSC connection id of the PSC Forwarding Rule.
@@ -2036,7 +2030,6 @@ class GlobalForwardingRule(pulumi.CustomResource):
         For internal forwarding rules within the same VPC network, two or more
         forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
         cannot have overlapping `portRange`s.
-        @pattern: \\d+(?:-\\d+)?
         """
         return pulumi.get(self, "port_range")
 


### PR DESCRIPTION
Upstream introduced what looks to be a spurious string `@pattern: \d+(?:-\d+)?` to the description for ComputeForwardingRule and ComputeGlobalForwardingRule. We need to patch this because Javadoc interprets this string as a Javadoc tag, but such a tag does not exist. This resulted in a [failure to publish the Java SDK](https://github.com/pulumi/pulumi-gcp/actions/runs/6881931301/job/18728079843) on GCP v7.1.0. 

Note that this patch _only_ addresses the documentation files. It seems likely that the upstream markdown is generated from the schema description, but as we on our end directly read from the markdown for the docs, this presents the minimum necessary change.

After this is merged, we can cut a patch version, which should result in successful publication of the Java SDK as version 7.1.1.

Follow-up issue here: https://github.com/pulumi/pulumi-java/issues/1271

Fixes https://github.com/pulumi/pulumi-gcp/issues/1353

- Add patch to remove a docstring that Java docstring does not recognize
- make schema and sdks
