### PR TITLE
Extended documentation for engineSplitTraffic

### DIFF
--- a/sdk/nodejs/appengine/engineSplitTraffic.ts
+++ b/sdk/nodejs/appengine/engineSplitTraffic.ts
@@ -12,6 +12,7 @@ import * as utilities from "../utilities";
  * To get more information about ServiceSplitTraffic, see:
  *
  * * [API documentation](https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services)
+ * * [API documentation for migrateTraffic](https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services/patch#query-parameters)
  *
  * ## Example Usage
  * ### App Engine Service Split Traffic


### PR DESCRIPTION
I believe the docs for `migrateTraffic` are not easily accessible. I had to look into Terraform provider code to understand that `patch` is being used. The docs should be more explainable now.