### PR TITLE
Remove notes from upstream docs about storing secrets in plain text

### DIFF
--- a/patches/0006-docs-patching.patch
+++ b/patches/0006-docs-patching.patch
@@ -4,6 +4,36 @@ Date: Wed, 4 Oct 2023 12:52:40 -0700
 Subject: [PATCH 06/10] docs patching
 
 
+diff --git a/website/docs/r/active_directory_domain_trust.html.markdown b/website/docs/r/active_directory_domain_trust.html.markdown
+index 61b68184d..f675d5a44 100644
+--- a/website/docs/r/active_directory_domain_trust.html.markdown
++++ b/website/docs/r/active_directory_domain_trust.html.markdown
+@@ -28,10 +28,6 @@ To get more information about DomainTrust, see:
+ * How-to Guides
+     * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `trust_handshake_secret`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ ## Example Usage - Active Directory Domain Trust Basic
+ 
+ 
+diff --git a/website/docs/r/alloydb_cluster.html.markdown b/website/docs/r/alloydb_cluster.html.markdown
+index dc94aff9a..43ef334a8 100644
+--- a/website/docs/r/alloydb_cluster.html.markdown
++++ b/website/docs/r/alloydb_cluster.html.markdown
+@@ -28,10 +28,6 @@ To get more information about Cluster, see:
+ * How-to Guides
+     * [AlloyDB](https://cloud.google.com/alloydb/docs/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `initial_user.password`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=alloydb_cluster_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/api_gateway_api.html.markdown b/website/docs/r/api_gateway_api.html.markdown
 index 74d746e00..7ef1814e2 100644
 --- a/website/docs/r/api_gateway_api.html.markdown
@@ -125,22 +155,25 @@ index 34c818adb..ffbefe6d7 100644
    authorized_network                   = google_compute_network.apigee_network.id
    runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
 diff --git a/website/docs/r/app_engine_application.html.markdown b/website/docs/r/app_engine_application.html.markdown
-index de386e9ff..0029e996e 100644
+index de386e9ff..47ae8ee32 100644
 --- a/website/docs/r/app_engine_application.html.markdown
 +++ b/website/docs/r/app_engine_application.html.markdown
-@@ -9,9 +9,9 @@ description: |-
+@@ -9,12 +9,9 @@ description: |-
  Allows creation and management of an App Engine application.
  
  ~> App Engine applications cannot be deleted once they're created; you have to delete the
 -   entire project to delete the application. Terraform will report the application has been
 -   successfully deleted; this is a limitation of Terraform, and will go away in the future.
 -   Terraform is not able to delete App Engine applications.
+-
+-~> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
+-state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
 +   entire project to delete the application. This provider will report the application has been
 +   successfully deleted; this is a limitation of the provider, and will go away in the future.
 +   This provider is not able to delete App Engine applications.
  
- ~> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
- state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+ ## Example Usage
+ 
 diff --git a/website/docs/r/app_engine_flexible_app_version.html.markdown b/website/docs/r/app_engine_flexible_app_version.html.markdown
 index 5a62364bc..cbebdfdce 100644
 --- a/website/docs/r/app_engine_flexible_app_version.html.markdown
@@ -154,6 +187,36 @@ index 5a62364bc..cbebdfdce 100644
  
  * `default_expiration` -
    (Optional)
+diff --git a/website/docs/r/bigquery_connection.html.markdown b/website/docs/r/bigquery_connection.html.markdown
+index 3c854945d..72e83d412 100644
+--- a/website/docs/r/bigquery_connection.html.markdown
++++ b/website/docs/r/bigquery_connection.html.markdown
+@@ -28,10 +28,6 @@ To get more information about Connection, see:
+ * How-to Guides
+     * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=bigquery_connection_cloud_resource&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+diff --git a/website/docs/r/bigquery_data_transfer_config.html.markdown b/website/docs/r/bigquery_data_transfer_config.html.markdown
+index 42b20a460..35fdb3a2e 100644
+--- a/website/docs/r/bigquery_data_transfer_config.html.markdown
++++ b/website/docs/r/bigquery_data_transfer_config.html.markdown
+@@ -29,10 +29,6 @@ To get more information about Config, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ ## Example Usage - Bigquerydatatransfer Config Scheduled Query
+ 
+ 
 diff --git a/website/docs/r/bigquery_job.html.markdown b/website/docs/r/bigquery_job.html.markdown
 index ad9bde671..3e338c6c3 100644
 --- a/website/docs/r/bigquery_job.html.markdown
@@ -336,10 +399,21 @@ index 160329c40..f77bc8434 100644
  ## Attributes Reference
  
 diff --git a/website/docs/r/certificate_manager_certificate.html.markdown b/website/docs/r/certificate_manager_certificate.html.markdown
-index 06207e136..a80a0894f 100644
+index 06207e136..a30b6001e 100644
 --- a/website/docs/r/certificate_manager_certificate.html.markdown
 +++ b/website/docs/r/certificate_manager_certificate.html.markdown
-@@ -156,19 +156,38 @@ resource "google_privateca_certificate_authority" "ca_authority" {
+@@ -23,10 +23,6 @@ Certificate represents a HTTP-reachable backend for a Certificate.
+ 
+ 
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=certificate_manager_google_managed_certificate_dns&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -156,19 +152,38 @@ resource "google_privateca_certificate_authority" "ca_authority" {
      <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
    </a>
  </div>
@@ -383,7 +457,7 @@ index 06207e136..a80a0894f 100644
  ```
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=certificate_manager_self_managed_certificate_regional&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -389,6 +408,7 @@ The following arguments are supported:
+@@ -389,6 +404,7 @@ The following arguments are supported:
    (Optional)
    The certificate chain in PEM-encoded form.
    Leaf certificate comes first, followed by intermediate ones if any.
@@ -391,6 +465,21 @@ index 06207e136..a80a0894f 100644
  
  * `pem_private_key` -
    (Optional)
+diff --git a/website/docs/r/certificate_manager_trust_config.html.markdown b/website/docs/r/certificate_manager_trust_config.html.markdown
+index 60d676219..4fc33a3f8 100644
+--- a/website/docs/r/certificate_manager_trust_config.html.markdown
++++ b/website/docs/r/certificate_manager_trust_config.html.markdown
+@@ -28,10 +28,6 @@ To get more information about TrustConfig, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=certificate_manager_trust_config&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/cloud_identity_group_membership.html.markdown b/website/docs/r/cloud_identity_group_membership.html.markdown
 index 0bb3ff0d0..90a347de5 100644
 --- a/website/docs/r/cloud_identity_group_membership.html.markdown
@@ -664,38 +753,36 @@ index a2f6f69ba..2f7bc1ff3 100644
    a Stackdriver Monitoring TimeSeries.list API call.
    This filter is used to select a specific TimeSeries for
 diff --git a/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown b/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
-index 9bce1ba3a..f937568e0 100644
+index 9bce1ba3a..6bac2b55a 100644
 --- a/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
 +++ b/website/docs/r/compute_backend_bucket_signed_url_key.html.markdown
-@@ -28,9 +28,8 @@ To get more information about BackendBucketSignedUrlKey, see:
+@@ -28,10 +28,6 @@ To get more information about BackendBucketSignedUrlKey, see:
  * How-to Guides
      * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `key_value`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `key_value` will be stored in the raw
-+state as plain-text.
- 
+-
  ## Example Usage - Backend Bucket Signed Url Key
  
+ 
 diff --git a/website/docs/r/compute_backend_service.html.markdown b/website/docs/r/compute_backend_service.html.markdown
-index 07e776730..025685511 100644
+index 07e776730..3a6c88b9c 100644
 --- a/website/docs/r/compute_backend_service.html.markdown
 +++ b/website/docs/r/compute_backend_service.html.markdown
-@@ -34,9 +34,8 @@ To get more information about BackendService, see:
+@@ -34,10 +34,6 @@ To get more information about BackendService, see:
  * How-to Guides
      * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=backend_service_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -657,7 +656,7 @@ The following arguments are supported:
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -657,7 +653,7 @@ The following arguments are supported:
  <a name="nested_circuit_breakers"></a>The `circuit_breakers` block supports:
  
  * `connect_timeout` -
@@ -705,20 +792,19 @@ index 07e776730..025685511 100644
    Structure is [documented below](#nested_connect_timeout).
  
 diff --git a/website/docs/r/compute_backend_service_signed_url_key.html.markdown b/website/docs/r/compute_backend_service_signed_url_key.html.markdown
-index af6522a4f..a1fef9b4e 100644
+index af6522a4f..989c698bf 100644
 --- a/website/docs/r/compute_backend_service_signed_url_key.html.markdown
 +++ b/website/docs/r/compute_backend_service_signed_url_key.html.markdown
-@@ -28,9 +28,8 @@ To get more information about BackendServiceSignedUrlKey, see:
+@@ -28,10 +28,6 @@ To get more information about BackendServiceSignedUrlKey, see:
  * How-to Guides
      * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `key_value`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `key_value` will be stored in the raw
-+state as plain-text.
- 
+-
  ## Example Usage - Backend Service Signed Url Key
+ 
  
 diff --git a/website/docs/r/compute_disk.html.markdown b/website/docs/r/compute_disk.html.markdown
 index b261d1c3d..03b634c05 100644
@@ -1298,10 +1384,21 @@ index 43cdf51e0..1dadabfc0 100644
    a Stackdriver Monitoring TimeSeries.list API call.
    This filter is used to select a specific TimeSeries for
 diff --git a/website/docs/r/compute_region_backend_service.html.markdown b/website/docs/r/compute_region_backend_service.html.markdown
-index 6dc240fc0..e70e1ac37 100644
+index 6dc240fc0..51b5ae17f 100644
 --- a/website/docs/r/compute_region_backend_service.html.markdown
 +++ b/website/docs/r/compute_region_backend_service.html.markdown
-@@ -524,7 +524,7 @@ The following arguments are supported:
+@@ -30,10 +30,6 @@ To get more information about RegionBackendService, see:
+ * How-to Guides
+     * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_backend_service_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -524,7 +520,7 @@ The following arguments are supported:
    Possible values are: `NONE`, `CLIENT_IP`, `CLIENT_IP_PORT_PROTO`, `CLIENT_IP_PROTO`, `GENERATED_COOKIE`, `HEADER_FIELD`, `HTTP_COOKIE`, `CLIENT_IP_NO_DESTINATION`.
  
  * `connection_tracking_policy` -
@@ -1310,7 +1407,7 @@ index 6dc240fc0..e70e1ac37 100644
    Connection Tracking configuration for this BackendService.
    This is available only for Layer 4 Internal Load Balancing and
    Network Load Balancing.
-@@ -673,7 +673,7 @@ The following arguments are supported:
+@@ -673,7 +669,7 @@ The following arguments are supported:
  <a name="nested_circuit_breakers"></a>The `circuit_breakers` block supports:
  
  * `connect_timeout` -
@@ -1319,7 +1416,7 @@ index 6dc240fc0..e70e1ac37 100644
    The timeout for new network connections to hosts.
    Structure is [documented below](#nested_connect_timeout).
  
-@@ -874,7 +874,7 @@ The following arguments are supported:
+@@ -874,7 +870,7 @@ The following arguments are supported:
    can be specified as values, and you cannot specify a status code more than once.
  
  * `ttl` -
@@ -1329,22 +1426,21 @@ index 6dc240fc0..e70e1ac37 100644
    (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
  
 diff --git a/website/docs/r/compute_region_disk.html.markdown b/website/docs/r/compute_region_disk.html.markdown
-index f9c8d1281..98aced933 100644
+index f9c8d1281..0763e621b 100644
 --- a/website/docs/r/compute_region_disk.html.markdown
 +++ b/website/docs/r/compute_region_disk.html.markdown
-@@ -43,9 +43,8 @@ To get more information about RegionDisk, see:
+@@ -43,10 +43,6 @@ To get more information about RegionDisk, see:
  * How-to Guides
      * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `disk_encryption_key.raw_key`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_disk_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -203,7 +202,7 @@ The following arguments are supported:
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -203,7 +199,7 @@ The following arguments are supported:
    create the disk. Provide this when creating the disk.
  
  * `interface` -
@@ -1353,7 +1449,7 @@ index f9c8d1281..98aced933 100644
    Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI.
  
    ~> **Warning:** `interface` is deprecated and will be removed in a future major release. This field is no longer used and can be safely removed from your configurations; disk interfaces are automatically determined on attachment.
-@@ -310,7 +309,7 @@ The following arguments are supported:
+@@ -310,7 +306,7 @@ The following arguments are supported:
    RFC 4648 base64 to either encrypt or decrypt this resource.
  
  * `kms_key_name` -
@@ -1430,22 +1526,21 @@ index 2d1697d9f..cf5976e3a 100644
  
    version {
 diff --git a/website/docs/r/compute_region_ssl_certificate.html.markdown b/website/docs/r/compute_region_ssl_certificate.html.markdown
-index 3239fd5ef..0b3edf669 100644
+index 3239fd5ef..db0101235 100644
 --- a/website/docs/r/compute_region_ssl_certificate.html.markdown
 +++ b/website/docs/r/compute_region_ssl_certificate.html.markdown
-@@ -30,9 +30,8 @@ To get more information about RegionSslCertificate, see:
+@@ -30,10 +30,6 @@ To get more information about RegionSslCertificate, see:
  * How-to Guides
      * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `certificate`, `private_key`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_ssl_certificate_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -102,7 +101,7 @@ resource "random_id" "certificate" {
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -102,7 +98,7 @@ resource "random_id" "certificate" {
  // Using with Region Target HTTPS Proxies
  //
  // SSL certificates cannot be updated after creation. In order to apply
@@ -1456,10 +1551,10 @@ index 3239fd5ef..0b3edf669 100644
  // recommended to specify create_before_destroy in a lifecycle block.
 diff --git a/website/docs/r/compute_region_ssl_certificate.html.markdown.porig b/website/docs/r/compute_region_ssl_certificate.html.markdown.porig
 new file mode 100644
-index 000000000..62d6db522
+index 000000000..153b337c3
 --- /dev/null
 +++ b/website/docs/r/compute_region_ssl_certificate.html.markdown.porig
-@@ -0,0 +1,259 @@
+@@ -0,0 +1,255 @@
 +---
 +# ----------------------------------------------------------------------------
 +#
@@ -1491,10 +1586,6 @@ index 000000000..62d6db522
 +* [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionSslCertificates)
 +* How-to Guides
 +    * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
-+
-+~> **Warning:** All arguments including the following potentially sensitive
-+values will be stored in the raw state as plain text: `certificate`, `private_key`.
-+[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
 +
 +<div class = "oics-button" style="float: right; margin: 0 0 -15px">
 +  <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=region_ssl_certificate_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
@@ -1733,38 +1824,36 @@ index 98af03c92..cc5a976a6 100644
  ## Example Usage
  
 diff --git a/website/docs/r/compute_snapshot.html.markdown b/website/docs/r/compute_snapshot.html.markdown
-index c426334cf..038079530 100644
+index c426334cf..93f00bb0f 100644
 --- a/website/docs/r/compute_snapshot.html.markdown
 +++ b/website/docs/r/compute_snapshot.html.markdown
-@@ -39,9 +39,8 @@ To get more information about Snapshot, see:
+@@ -39,10 +39,6 @@ To get more information about Snapshot, see:
  * How-to Guides
      * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `snapshot_encryption_key.raw_key`, `source_disk_encryption_key.raw_key`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=snapshot_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/compute_ssl_certificate.html.markdown b/website/docs/r/compute_ssl_certificate.html.markdown
-index a6e3ee9f2..2424c509f 100644
+index a6e3ee9f2..464a74483 100644
 --- a/website/docs/r/compute_ssl_certificate.html.markdown
 +++ b/website/docs/r/compute_ssl_certificate.html.markdown
-@@ -30,9 +30,8 @@ To get more information about SslCertificate, see:
+@@ -30,10 +30,6 @@ To get more information about SslCertificate, see:
  * How-to Guides
      * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `certificate`, `private_key`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=ssl_certificate_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -99,12 +98,8 @@ resource "random_id" "certificate" {
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -99,12 +95,8 @@ resource "random_id" "certificate" {
  // Using with Target HTTPS Proxies
  //
  // SSL certificates cannot be updated after creation. In order to apply
@@ -1837,21 +1926,20 @@ index d282b9178..376d46e33 100644
  
  * `project` - (Optional) The ID of the project in which the resource belongs. If it
 diff --git a/website/docs/r/compute_vpn_tunnel.html.markdown b/website/docs/r/compute_vpn_tunnel.html.markdown
-index 9db13a01f..145a05e51 100644
+index 9db13a01f..36f02c802 100644
 --- a/website/docs/r/compute_vpn_tunnel.html.markdown
 +++ b/website/docs/r/compute_vpn_tunnel.html.markdown
-@@ -29,9 +29,8 @@ To get more information about VpnTunnel, see:
+@@ -29,10 +29,6 @@ To get more information about VpnTunnel, see:
      * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
      * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `shared_secret`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `shared_secret` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=vpn_tunnel_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/container_cluster.html.markdown b/website/docs/r/container_cluster.html.markdown
 index 7ec0fb4e1..5e119dd02 100644
 --- a/website/docs/r/container_cluster.html.markdown
@@ -2171,6 +2259,36 @@ index d8db626fc..5613e008c 100644
  }
  ```
  
+diff --git a/website/docs/r/data_loss_prevention_deidentify_template.html.markdown b/website/docs/r/data_loss_prevention_deidentify_template.html.markdown
+index e0b881d0f..0ee152e54 100644
+--- a/website/docs/r/data_loss_prevention_deidentify_template.html.markdown
++++ b/website/docs/r/data_loss_prevention_deidentify_template.html.markdown
+@@ -28,10 +28,6 @@ To get more information about DeidentifyTemplate, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ ## Example Usage - Dlp Deidentify Template Basic
+ 
+ 
+diff --git a/website/docs/r/database_migration_service_connection_profile.html.markdown b/website/docs/r/database_migration_service_connection_profile.html.markdown
+index 3d1ba3911..395e94bb1 100644
+--- a/website/docs/r/database_migration_service_connection_profile.html.markdown
++++ b/website/docs/r/database_migration_service_connection_profile.html.markdown
+@@ -28,10 +28,6 @@ To get more information about ConnectionProfile, see:
+ * How-to Guides
+     * [Database Migration](https://cloud.google.com/database-migration/docs/)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=database_migration_service_connection_profile_cloudsql&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/dataflow_flex_template_job.html.markdown b/website/docs/r/dataflow_flex_template_job.html.markdown
 index d592b3fdb..429c7fd7d 100644
 --- a/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -2357,6 +2475,21 @@ index d3dbe728e..7b25f85c3 100644
  
  ## Attributes Reference
  
+diff --git a/website/docs/r/datastream_connection_profile.html.markdown b/website/docs/r/datastream_connection_profile.html.markdown
+index 4403af5cd..9b5a8fc2d 100644
+--- a/website/docs/r/datastream_connection_profile.html.markdown
++++ b/website/docs/r/datastream_connection_profile.html.markdown
+@@ -28,10 +28,6 @@ To get more information about ConnectionProfile, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=datastream_connection_profile_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/deployment_manager_deployment.html.markdown b/website/docs/r/deployment_manager_deployment.html.markdown
 index b6cb3d92f..47d37812e 100644
 --- a/website/docs/r/deployment_manager_deployment.html.markdown
@@ -2403,6 +2536,21 @@ index 7b53d1baf..9dcaf6e43 100644
  
  * `project` - (Optional) The ID of the project in which the resource belongs.
      If it is not provided, the provider project is used.
+diff --git a/website/docs/r/dialogflow_cx_agent.html.markdown b/website/docs/r/dialogflow_cx_agent.html.markdown
+index 3585b68e9..2f4a69eca 100644
+--- a/website/docs/r/dialogflow_cx_agent.html.markdown
++++ b/website/docs/r/dialogflow_cx_agent.html.markdown
+@@ -28,10 +28,6 @@ To get more information about Agent, see:
+ * How-to Guides
+     * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=dialogflowcx_agent_full&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/dns_managed_zone.html.markdown b/website/docs/r/dns_managed_zone.html.markdown
 index 6ed95ccb9..7161ac335 100644
 --- a/website/docs/r/dns_managed_zone.html.markdown
@@ -2479,6 +2627,21 @@ index 832826a46..81ea3d619 100644
  
  * `enable_inbound_forwarding` -
    (Optional)
+diff --git a/website/docs/r/edgecontainer_cluster.html.markdown b/website/docs/r/edgecontainer_cluster.html.markdown
+index 67791741c..a7b90b934 100644
+--- a/website/docs/r/edgecontainer_cluster.html.markdown
++++ b/website/docs/r/edgecontainer_cluster.html.markdown
+@@ -28,10 +28,6 @@ To get more information about Cluster, see:
+ * How-to Guides
+     * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `cluster_ca_certificate`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=edgecontainer_cluster&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/firebase_project.html.markdown b/website/docs/r/firebase_project.html.markdown
 index 83652f8c9..ca2e05ae2 100644
 --- a/website/docs/r/firebase_project.html.markdown
@@ -3271,6 +3434,21 @@ index 2eab2d0ad..071608f1e 100644
  Three different resources help you manage your IAM policy for Healthcare HL7v2 store. Each of these resources serves a different use case:
  
  * `google_healthcare_hl7_v2_store_iam_policy`: Authoritative. Sets the IAM policy for the HL7v2 store and replaces any existing policy already attached.
+diff --git a/website/docs/r/iam_workforce_pool_provider.html.markdown b/website/docs/r/iam_workforce_pool_provider.html.markdown
+index 6230e21c0..a2399ec6c 100644
+--- a/website/docs/r/iam_workforce_pool_provider.html.markdown
++++ b/website/docs/r/iam_workforce_pool_provider.html.markdown
+@@ -31,10 +31,6 @@ To get more information about WorkforcePoolProvider, see:
+ ~> **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
+ billing/quota project. The account team notifies you when the project is granted access.
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ ## Example Usage - Iam Workforce Pool Provider Saml Basic
+ 
+ 
 diff --git a/website/docs/r/iap_app_engine_service_iam.html.markdown b/website/docs/r/iap_app_engine_service_iam.html.markdown
 index e4ffe94b1..cc310f90d 100644
 --- a/website/docs/r/iap_app_engine_service_iam.html.markdown
@@ -3314,20 +3492,19 @@ index 8970309da..7235d0daa 100644
  
  * [API documentation](https://cloud.google.com/iap/docs/reference/rest/v1/projects.brands)
 diff --git a/website/docs/r/iap_client.html.markdown b/website/docs/r/iap_client.html.markdown
-index d31b87051..7df80eaff 100644
+index d31b87051..ad88d825f 100644
 --- a/website/docs/r/iap_client.html.markdown
 +++ b/website/docs/r/iap_client.html.markdown
-@@ -32,9 +32,8 @@ To get more information about Client, see:
+@@ -32,10 +32,6 @@ To get more information about Client, see:
  * How-to Guides
      * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `secret`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `secret` will be stored in the raw
-+state as plain-text.
- 
+-
  ## Example Usage - Iap Client
+ 
  
 diff --git a/website/docs/r/iap_tunnel_iam.html.markdown b/website/docs/r/iap_tunnel_iam.html.markdown
 index b7356d67f..b6d4abe21 100644
@@ -3461,19 +3638,19 @@ index 764dcf5f1..e369505cb 100644
  
  
 diff --git a/website/docs/r/kms_secret_ciphertext.html.markdown b/website/docs/r/kms_secret_ciphertext.html.markdown
-index cf5898150..1cdc9297a 100644
+index cf5898150..516058386 100644
 --- a/website/docs/r/kms_secret_ciphertext.html.markdown
 +++ b/website/docs/r/kms_secret_ciphertext.html.markdown
-@@ -34,9 +34,7 @@ To get more information about SecretCiphertext, see:
+@@ -34,10 +34,6 @@ To get more information about SecretCiphertext, see:
  * How-to Guides
      * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `plaintext`, `additional_authenticated_data`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
- 
+-
  ## Example Usage - Kms Secret Ciphertext Basic
+ 
  
 diff --git a/website/docs/r/logging_billing_account_bucket_config.html.markdown b/website/docs/r/logging_billing_account_bucket_config.html.markdown
 index d782ccd2f..5b6120a4f 100644
@@ -3593,7 +3770,7 @@ index 7aac31384..137e15cbf 100644
  ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
  
 diff --git a/website/docs/r/monitoring_notification_channel.html.markdown b/website/docs/r/monitoring_notification_channel.html.markdown
-index 46e003edf..b60f062a6 100644
+index 46e003edf..7943882be 100644
 --- a/website/docs/r/monitoring_notification_channel.html.markdown
 +++ b/website/docs/r/monitoring_notification_channel.html.markdown
 @@ -30,7 +30,7 @@ and labels to configure that channel. Each `type` has specific labels that need
@@ -3605,19 +3782,18 @@ index 46e003edf..b60f062a6 100644
  labels are required.
  
  A list of supported channels per project the `list` endpoint can be
-@@ -45,9 +45,8 @@ To get more information about NotificationChannel, see:
+@@ -45,10 +45,6 @@ To get more information about NotificationChannel, see:
      * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
      * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `sensitive_labels.auth_token`, `sensitive_labels.password`, `sensitive_labels.service_key`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=notification_channel_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -101,7 +100,7 @@ The following arguments are supported:
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -101,7 +97,7 @@ The following arguments are supported:
    Configuration fields that define the channel and its behavior. The
    permissible and required labels are specified in the
    NotificationChannelDescriptor corresponding to the type field.
@@ -3685,21 +3861,35 @@ index 8d04d36a1..7091f611e 100644
    goal = 0.9
    rolling_period_days = 20
 diff --git a/website/docs/r/monitoring_uptime_check_config.html.markdown b/website/docs/r/monitoring_uptime_check_config.html.markdown
-index eb593594c..929f171ae 100644
+index eb593594c..484968b56 100644
 --- a/website/docs/r/monitoring_uptime_check_config.html.markdown
 +++ b/website/docs/r/monitoring_uptime_check_config.html.markdown
-@@ -28,9 +28,8 @@ To get more information about UptimeCheckConfig, see:
+@@ -28,10 +28,6 @@ To get more information about UptimeCheckConfig, see:
  * How-to Guides
      * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `http_check.auth_info.password`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-+state as plain-text.
- 
+-
  ## Example Usage - Uptime Check Config Http
  
+ 
+diff --git a/website/docs/r/network_services_edge_cache_keyset.html.markdown b/website/docs/r/network_services_edge_cache_keyset.html.markdown
+index bea35a691..1ea40bc64 100644
+--- a/website/docs/r/network_services_edge_cache_keyset.html.markdown
++++ b/website/docs/r/network_services_edge_cache_keyset.html.markdown
+@@ -28,10 +28,6 @@ To get more information about EdgeCacheKeyset, see:
+ * How-to Guides
+     * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `public_key.public_key.value`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=network_services_edge_cache_keyset_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/notebooks_instance.html.markdown b/website/docs/r/notebooks_instance.html.markdown
 index 6e8bbeeb8..c141c2217 100644
 --- a/website/docs/r/notebooks_instance.html.markdown
@@ -3751,6 +3941,21 @@ index 9b4367a4d..4d951db93 100644
  Generate service identity for a service.
  
  ~> **Note:** Once created, this resource cannot be updated or destroyed. These
+diff --git a/website/docs/r/public_ca_external_account_key.html.markdown b/website/docs/r/public_ca_external_account_key.html.markdown
+index 243cb6b6f..0ec8b8af9 100644
+--- a/website/docs/r/public_ca_external_account_key.html.markdown
++++ b/website/docs/r/public_ca_external_account_key.html.markdown
+@@ -36,10 +36,6 @@ You must use an EAB secret within 7 days of obtaining it.
+ The EAB secret is invalidated if you don't use it within 7 days.
+ The ACME account registered by using an EAB secret has no expiration.
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ ## Example Usage - Public Ca External Account Key
+ 
+ 
 diff --git a/website/docs/r/redis_instance.html.markdown b/website/docs/r/redis_instance.html.markdown
 index 551c74a51..4dabffa49 100644
 --- a/website/docs/r/redis_instance.html.markdown
@@ -3774,26 +3979,25 @@ index 551c74a51..4dabffa49 100644
    depends_on = [google_service_networking_connection.private_service_connection]
  
 diff --git a/website/docs/r/secret_manager_secret_version.html.markdown b/website/docs/r/secret_manager_secret_version.html.markdown
-index 1d93f5a60..07933090d 100644
+index 1d93f5a60..c5dd6df36 100644
 --- a/website/docs/r/secret_manager_secret_version.html.markdown
 +++ b/website/docs/r/secret_manager_secret_version.html.markdown
-@@ -23,9 +23,8 @@ A secret version resource.
+@@ -23,10 +23,6 @@ A secret version resource.
  
  
  
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `payload.secret_data`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-+state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=secret_version_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/security_scanner_scan_config.html.markdown b/website/docs/r/security_scanner_scan_config.html.markdown
-index c55db73d9..3b2c926a7 100644
+index c55db73d9..d4223d930 100644
 --- a/website/docs/r/security_scanner_scan_config.html.markdown
 +++ b/website/docs/r/security_scanner_scan_config.html.markdown
-@@ -21,18 +21,13 @@ description: |-
+@@ -21,19 +21,12 @@ description: |-
  
  A ScanConfig resource contains the configurations to launch a scan.
  
@@ -3809,11 +4013,11 @@ index c55db73d9..3b2c926a7 100644
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `authentication.google_account.password`, `authentication.custom_account.password`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
- 
+-
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=scan_config_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -50,7 +45,7 @@ resource "google_compute_address" "scanner_static_ip" {
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
+@@ -50,7 +43,7 @@ resource "google_compute_address" "scanner_static_ip" {
  
  resource "google_security_scanner_scan_config" "scan-config" {
    provider         = google-beta
@@ -4035,33 +4239,50 @@ index 67b1c0a27..92c010d5c 100644
  
  * `instance_type` - The type of the instance. The supported values are `SQL_INSTANCE_TYPE_UNSPECIFIED`, `CLOUD_SQL_INSTANCE`, `ON_PREMISES_INSTANCE` and `READ_REPLICA_INSTANCE`.
  
+diff --git a/website/docs/r/sql_source_representation_instance.html.markdown b/website/docs/r/sql_source_representation_instance.html.markdown
+index 17c12edef..96185ca84 100644
+--- a/website/docs/r/sql_source_representation_instance.html.markdown
++++ b/website/docs/r/sql_source_representation_instance.html.markdown
+@@ -28,10 +28,6 @@ affect billing. You cannot update the source representation instance.
+ 
+ 
+ 
+-~> **Warning:** All arguments including the following potentially sensitive
+-values will be stored in the raw state as plain text: `on_premises_configuration.password`.
+-[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+-
+ <div class = "oics-button" style="float: right; margin: 0 0 -15px">
+   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=sql_source_representation_instance_basic&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
+     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
 diff --git a/website/docs/r/sql_ssl_cert.html.markdown b/website/docs/r/sql_ssl_cert.html.markdown
-index baff78aae..fa73d8f49 100644
+index baff78aae..07c373d0a 100644
 --- a/website/docs/r/sql_ssl_cert.html.markdown
 +++ b/website/docs/r/sql_ssl_cert.html.markdown
-@@ -8,8 +8,7 @@ description: |-
+@@ -8,9 +8,6 @@ description: |-
  
  Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
  
 -~> **Note:** All arguments including the private key will be stored in the raw state as plain-text.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Note:** All arguments including the private key will be stored in the raw state as plain-text
- 
+-
  ## Example Usage
  
+ Example creating a SQL Client Certificate.
 diff --git a/website/docs/r/sql_user.html.markdown b/website/docs/r/sql_user.html.markdown
-index 9b96d4463..6bc7816be 100644
+index 9b96d4463..3063ec2e6 100644
 --- a/website/docs/r/sql_user.html.markdown
 +++ b/website/docs/r/sql_user.html.markdown
-@@ -9,8 +9,6 @@ description: |-
+@@ -8,10 +8,6 @@ description: |-
+ 
  Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
  
- ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+-~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data). Passwords will not be retrieved when running
 -"terraform import".
- 
+-
  ## Example Usage
  
+ Example creating a SQL User.
 diff --git a/website/docs/r/storage_bucket.html.markdown b/website/docs/r/storage_bucket.html.markdown
 index 0c2123fa2..8471cb448 100644
 --- a/website/docs/r/storage_bucket.html.markdown
@@ -4143,26 +4364,25 @@ index 4832d1bdc..ec218c643 100644
  * `source` - (Optional) A path to the data you want to upload. Must be defined
      if `content` is not.
 diff --git a/website/docs/r/storage_hmac_key.html.markdown b/website/docs/r/storage_hmac_key.html.markdown
-index 835dd41da..3d3904207 100644
+index 835dd41da..6e6991a20 100644
 --- a/website/docs/r/storage_hmac_key.html.markdown
 +++ b/website/docs/r/storage_hmac_key.html.markdown
-@@ -31,12 +31,10 @@ To get more information about HmacKey, see:
+@@ -30,13 +30,7 @@ To get more information about HmacKey, see:
+ * How-to Guides
      * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
  
- ~> **Warning:** All arguments including the `secret` value will be stored in the raw
+-~> **Warning:** All arguments including the `secret` value will be stored in the raw
 -state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
 -On import, the `secret` value will not be retrieved.
-+state as plain-text. On import, the `secret` value will not be retrieved.
- 
+-
 -~> **Warning:** All arguments including the following potentially sensitive
 -values will be stored in the raw state as plain text: `secret`.
 -[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
-+~> **Warning:** All arguments including `secret` will be stored in the raw
-+state as plain-text.
++~> **Warning:** On import, the `secret` value will not be retrieved.
  
  <div class = "oics-button" style="float: right; margin: 0 0 -15px">
    <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=storage_hmac_key&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-@@ -52,7 +50,7 @@ resource "google_service_account" "service_account" {
+@@ -52,7 +46,7 @@ resource "google_service_account" "service_account" {
    account_id = "my-svc-acc"
  }
  

--- a/sdk/dotnet/ActiveDirectory/DomainTrust.cs
+++ b/sdk/dotnet/ActiveDirectory/DomainTrust.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.ActiveDirectory
     /// * How-to Guides
     ///     * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `trust_handshake_secret`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Active Directory Domain Trust Basic
     /// 

--- a/sdk/dotnet/Alloydb/Cluster.cs
+++ b/sdk/dotnet/Alloydb/Cluster.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.Alloydb
     /// * How-to Guides
     ///     * [AlloyDB](https://cloud.google.com/alloydb/docs/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `initial_user.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Alloydb Cluster Basic
     /// 

--- a/sdk/dotnet/AppEngine/Application.cs
+++ b/sdk/dotnet/AppEngine/Application.cs
@@ -17,9 +17,6 @@ namespace Pulumi.Gcp.AppEngine
     ///    successfully deleted; this is a limitation of the provider, and will go away in the future.
     ///    This provider is not able to delete App Engine applications.
     /// 
-    /// &gt; **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-    /// state as plain-text. Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// 
     /// ```csharp

--- a/sdk/dotnet/BigQuery/Connection.cs
+++ b/sdk/dotnet/BigQuery/Connection.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.BigQuery
     /// * How-to Guides
     ///     * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Bigquery Connection Cloud Resource
     /// 

--- a/sdk/dotnet/BigQuery/DataTransferConfig.cs
+++ b/sdk/dotnet/BigQuery/DataTransferConfig.cs
@@ -19,10 +19,6 @@ namespace Pulumi.Gcp.BigQuery
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Bigquerydatatransfer Config Scheduled Query
     /// 

--- a/sdk/dotnet/CertificateManager/Certificate.cs
+++ b/sdk/dotnet/CertificateManager/Certificate.cs
@@ -12,10 +12,6 @@ namespace Pulumi.Gcp.CertificateManager
     /// <summary>
     /// Certificate represents a HTTP-reachable backend for a Certificate.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Certificate Manager Google Managed Certificate Dns
     /// 

--- a/sdk/dotnet/CertificateManager/TrustConfig.cs
+++ b/sdk/dotnet/CertificateManager/TrustConfig.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.CertificateManager
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Certificate Manager Trust Config
     /// 

--- a/sdk/dotnet/Compute/BackendBucketSignedUrlKey.cs
+++ b/sdk/dotnet/Compute/BackendBucketSignedUrlKey.cs
@@ -18,9 +18,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
     /// 
-    /// &gt; **Warning:** All arguments including `key_value` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Backend Bucket Signed Url Key
     /// 

--- a/sdk/dotnet/Compute/BackendService.cs
+++ b/sdk/dotnet/Compute/BackendService.cs
@@ -23,9 +23,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
     /// 
-    /// &gt; **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Backend Service Cache Include Http Headers
     /// 

--- a/sdk/dotnet/Compute/BackendServiceSignedUrlKey.cs
+++ b/sdk/dotnet/Compute/BackendServiceSignedUrlKey.cs
@@ -18,9 +18,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
     /// 
-    /// &gt; **Warning:** All arguments including `key_value` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// 
     /// ## Import

--- a/sdk/dotnet/Compute/CaExternalAccountKey.cs
+++ b/sdk/dotnet/Compute/CaExternalAccountKey.cs
@@ -26,10 +26,6 @@ namespace Pulumi.Gcp.Compute
     /// The EAB secret is invalidated if you don't use it within 7 days.
     /// The ACME account registered by using an EAB secret has no expiration.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Public Ca External Account Key
     /// 

--- a/sdk/dotnet/Compute/RegionBackendService.cs
+++ b/sdk/dotnet/Compute/RegionBackendService.cs
@@ -19,10 +19,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// 
     /// ## Import

--- a/sdk/dotnet/Compute/RegionDisk.cs
+++ b/sdk/dotnet/Compute/RegionDisk.cs
@@ -32,9 +32,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
     /// 
-    /// &gt; **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Region Disk Basic
     /// 

--- a/sdk/dotnet/Compute/RegionSslCertificate.cs
+++ b/sdk/dotnet/Compute/RegionSslCertificate.cs
@@ -20,9 +20,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
     /// 
-    /// &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Region Ssl Certificate Basic
     /// 

--- a/sdk/dotnet/Compute/SSLCertificate.cs
+++ b/sdk/dotnet/Compute/SSLCertificate.cs
@@ -20,9 +20,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
     /// 
-    /// &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Ssl Certificate Basic
     /// 

--- a/sdk/dotnet/Compute/SecurityScanConfig.cs
+++ b/sdk/dotnet/Compute/SecurityScanConfig.cs
@@ -18,8 +18,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
     /// 
-    /// &gt; **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Scan Config Basic
     /// 

--- a/sdk/dotnet/Compute/Snapshot.cs
+++ b/sdk/dotnet/Compute/Snapshot.cs
@@ -29,9 +29,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
     /// 
-    /// &gt; **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Snapshot Basic
     /// 

--- a/sdk/dotnet/Compute/VPNTunnel.cs
+++ b/sdk/dotnet/Compute/VPNTunnel.cs
@@ -19,9 +19,6 @@ namespace Pulumi.Gcp.Compute
     ///     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
     ///     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
     /// 
-    /// &gt; **Warning:** All arguments including `shared_secret` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Vpn Tunnel Basic
     /// 

--- a/sdk/dotnet/DataLoss/PreventionDeidentifyTemplate.cs
+++ b/sdk/dotnet/DataLoss/PreventionDeidentifyTemplate.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.DataLoss
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Dlp Deidentify Template Image Transformations
     /// 

--- a/sdk/dotnet/DatabaseMigrationService/ConnectionProfile.cs
+++ b/sdk/dotnet/DatabaseMigrationService/ConnectionProfile.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.DatabaseMigrationService
     /// * How-to Guides
     ///     * [Database Migration](https://cloud.google.com/database-migration/docs/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Database Migration Service Connection Profile Cloudsql
     /// 

--- a/sdk/dotnet/Datastream/ConnectionProfile.cs
+++ b/sdk/dotnet/Datastream/ConnectionProfile.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.Datastream
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Datastream Connection Profile Basic
     /// 

--- a/sdk/dotnet/Diagflow/CxAgent.cs
+++ b/sdk/dotnet/Diagflow/CxAgent.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.Diagflow
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Dialogflowcx Agent Full
     /// 

--- a/sdk/dotnet/EdgeContainer/Cluster.cs
+++ b/sdk/dotnet/EdgeContainer/Cluster.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.EdgeContainer
     /// * How-to Guides
     ///     * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `cluster_ca_certificate`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Edgecontainer Cluster
     /// 

--- a/sdk/dotnet/Iam/WorkforcePoolProvider.cs
+++ b/sdk/dotnet/Iam/WorkforcePoolProvider.cs
@@ -21,10 +21,6 @@ namespace Pulumi.Gcp.Iam
     /// &gt; **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
     /// billing/quota project. The account team notifies you when the project is granted access.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Iam Workforce Pool Provider Saml Basic
     /// 

--- a/sdk/dotnet/Iap/Client.cs
+++ b/sdk/dotnet/Iap/Client.cs
@@ -22,9 +22,6 @@ namespace Pulumi.Gcp.Iap
     /// * How-to Guides
     ///     * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
     /// 
-    /// &gt; **Warning:** All arguments including `secret` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Iap Client
     /// 

--- a/sdk/dotnet/Kms/SecretCiphertext.cs
+++ b/sdk/dotnet/Kms/SecretCiphertext.cs
@@ -23,8 +23,6 @@ namespace Pulumi.Gcp.Kms
     /// * How-to Guides
     ///     * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
     /// 
-    /// &gt; **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Kms Secret Ciphertext Basic
     /// 

--- a/sdk/dotnet/Monitoring/NotificationChannel.cs
+++ b/sdk/dotnet/Monitoring/NotificationChannel.cs
@@ -34,9 +34,6 @@ namespace Pulumi.Gcp.Monitoring
     ///     * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
     ///     * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
     /// 
-    /// &gt; **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Notification Channel Basic
     /// 

--- a/sdk/dotnet/Monitoring/UptimeCheckConfig.cs
+++ b/sdk/dotnet/Monitoring/UptimeCheckConfig.cs
@@ -18,9 +18,6 @@ namespace Pulumi.Gcp.Monitoring
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
     /// 
-    /// &gt; **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Uptime Check Config Http
     /// 

--- a/sdk/dotnet/NetworkServices/EdgeCacheKeyset.cs
+++ b/sdk/dotnet/NetworkServices/EdgeCacheKeyset.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.NetworkServices
     /// * How-to Guides
     ///     * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `public_key.public_key.value`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Network Services Edge Cache Keyset Basic
     /// 

--- a/sdk/dotnet/SecretManager/SecretVersion.cs
+++ b/sdk/dotnet/SecretManager/SecretVersion.cs
@@ -12,9 +12,6 @@ namespace Pulumi.Gcp.SecretManager
     /// <summary>
     /// A secret version resource.
     /// 
-    /// &gt; **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Secret Version Basic
     /// 

--- a/sdk/dotnet/Sql/SourceRepresentationInstance.cs
+++ b/sdk/dotnet/Sql/SourceRepresentationInstance.cs
@@ -16,10 +16,6 @@ namespace Pulumi.Gcp.Sql
     /// contains no data, requires no configuration or maintenance, and does not
     /// affect billing. You cannot update the source representation instance.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Sql Source Representation Instance Basic
     /// 

--- a/sdk/dotnet/Sql/SslCert.cs
+++ b/sdk/dotnet/Sql/SslCert.cs
@@ -12,8 +12,6 @@ namespace Pulumi.Gcp.Sql
     /// <summary>
     /// Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
     /// 
-    /// &gt; **Note:** All arguments including the private key will be stored in the raw state as plain-text
-    /// 
     /// ## Example Usage
     /// 
     /// Example creating a SQL Client Certificate.

--- a/sdk/dotnet/Sql/User.cs
+++ b/sdk/dotnet/Sql/User.cs
@@ -12,8 +12,6 @@ namespace Pulumi.Gcp.Sql
     /// <summary>
     /// Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
     /// 
-    /// &gt; **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-    /// 
     /// ## Import
     /// 
     /// SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/dotnet/Storage/HmacKey.cs
+++ b/sdk/dotnet/Storage/HmacKey.cs
@@ -20,11 +20,7 @@ namespace Pulumi.Gcp.Storage
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
     /// 
-    /// &gt; **Warning:** All arguments including the `secret` value will be stored in the raw
-    /// state as plain-text. On import, the `secret` value will not be retrieved.
-    /// 
-    /// &gt; **Warning:** All arguments including `secret` will be stored in the raw
-    /// state as plain-text.
+    /// &gt; **Warning:** On import, the `secret` value will not be retrieved.
     /// 
     /// ## Example Usage
     /// ### Storage Hmac Key

--- a/sdk/go/gcp/activedirectory/domainTrust.go
+++ b/sdk/go/gcp/activedirectory/domainTrust.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `trustHandshakeSecret`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Active Directory Domain Trust Basic
 //

--- a/sdk/go/gcp/alloydb/cluster.go
+++ b/sdk/go/gcp/alloydb/cluster.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [AlloyDB](https://cloud.google.com/alloydb/docs/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `initial_user.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Alloydb Cluster Basic
 //

--- a/sdk/go/gcp/appengine/application.go
+++ b/sdk/go/gcp/appengine/application.go
@@ -20,9 +20,6 @@ import (
 //	successfully deleted; this is a limitation of the provider, and will go away in the future.
 //	This provider is not able to delete App Engine applications.
 //
-// > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-// state as plain-text. Read more about sensitive data in state.
-//
 // ## Example Usage
 //
 // ```go

--- a/sdk/go/gcp/bigquery/connection.go
+++ b/sdk/go/gcp/bigquery/connection.go
@@ -19,10 +19,6 @@ import (
 // * How-to Guides
 //   - [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Bigquery Connection Cloud Resource
 //

--- a/sdk/go/gcp/bigquery/dataTransferConfig.go
+++ b/sdk/go/gcp/bigquery/dataTransferConfig.go
@@ -21,10 +21,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Bigquerydatatransfer Config Scheduled Query
 //

--- a/sdk/go/gcp/certificatemanager/certificate.go
+++ b/sdk/go/gcp/certificatemanager/certificate.go
@@ -13,10 +13,6 @@ import (
 
 // Certificate represents a HTTP-reachable backend for a Certificate.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Certificate Manager Google Managed Certificate Dns
 //

--- a/sdk/go/gcp/certificatemanager/trustConfig.go
+++ b/sdk/go/gcp/certificatemanager/trustConfig.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/certificate-manager/docs)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Certificate Manager Trust Config
 //

--- a/sdk/go/gcp/compute/backendBucketSignedUrlKey.go
+++ b/sdk/go/gcp/compute/backendBucketSignedUrlKey.go
@@ -20,9 +20,6 @@ import (
 // * How-to Guides
 //   - [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 //
-// > **Warning:** All arguments including `keyValue` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Backend Bucket Signed Url Key
 //

--- a/sdk/go/gcp/compute/backendService.go
+++ b/sdk/go/gcp/compute/backendService.go
@@ -24,9 +24,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
 //
-// > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Backend Service Cache Include Http Headers
 //

--- a/sdk/go/gcp/compute/backendServiceSignedUrlKey.go
+++ b/sdk/go/gcp/compute/backendServiceSignedUrlKey.go
@@ -20,9 +20,6 @@ import (
 // * How-to Guides
 //   - [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 //
-// > **Warning:** All arguments including `keyValue` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 //
 // ## Import

--- a/sdk/go/gcp/compute/caExternalAccountKey.go
+++ b/sdk/go/gcp/compute/caExternalAccountKey.go
@@ -27,10 +27,6 @@ import (
 // The EAB secret is invalidated if you don't use it within 7 days.
 // The ACME account registered by using an EAB secret has no expiration.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `keyId`, `b64MacKey`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Public Ca External Account Key
 //

--- a/sdk/go/gcp/compute/regionBackendService.go
+++ b/sdk/go/gcp/compute/regionBackendService.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 //
 // ## Import

--- a/sdk/go/gcp/compute/regionDisk.go
+++ b/sdk/go/gcp/compute/regionDisk.go
@@ -34,9 +34,6 @@ import (
 // * How-to Guides
 //   - [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
 //
-// > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Region Disk Basic
 //

--- a/sdk/go/gcp/compute/regionSslCertificate.go
+++ b/sdk/go/gcp/compute/regionSslCertificate.go
@@ -22,9 +22,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 //
-// > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Region Ssl Certificate Basic
 //

--- a/sdk/go/gcp/compute/securityScanConfig.go
+++ b/sdk/go/gcp/compute/securityScanConfig.go
@@ -20,8 +20,6 @@ import (
 // * How-to Guides
 //   - [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
 //
-// > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
-//
 // ## Example Usage
 // ### Scan Config Basic
 //

--- a/sdk/go/gcp/compute/snapshot.go
+++ b/sdk/go/gcp/compute/snapshot.go
@@ -31,9 +31,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
 //
-// > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Snapshot Basic
 //

--- a/sdk/go/gcp/compute/sslcertificate.go
+++ b/sdk/go/gcp/compute/sslcertificate.go
@@ -22,9 +22,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 //
-// > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Ssl Certificate Basic
 //

--- a/sdk/go/gcp/compute/vpntunnel.go
+++ b/sdk/go/gcp/compute/vpntunnel.go
@@ -21,9 +21,6 @@ import (
 //   - [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
 //   - [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
 //
-// > **Warning:** All arguments including `sharedSecret` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Vpn Tunnel Basic
 //

--- a/sdk/go/gcp/databasemigrationservice/connectionProfile.go
+++ b/sdk/go/gcp/databasemigrationservice/connectionProfile.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Database Migration](https://cloud.google.com/database-migration/docs/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Database Migration Service Connection Profile Cloudsql
 //

--- a/sdk/go/gcp/dataloss/preventionDeidentifyTemplate.go
+++ b/sdk/go/gcp/dataloss/preventionDeidentifyTemplate.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Dlp Deidentify Template Image Transformations
 //

--- a/sdk/go/gcp/datastream/connectionProfile.go
+++ b/sdk/go/gcp/datastream/connectionProfile.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Datastream Connection Profile Basic
 //

--- a/sdk/go/gcp/diagflow/cxAgent.go
+++ b/sdk/go/gcp/diagflow/cxAgent.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Dialogflowcx Agent Full
 //

--- a/sdk/go/gcp/edgecontainer/cluster.go
+++ b/sdk/go/gcp/edgecontainer/cluster.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `clusterCaCertificate`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Edgecontainer Cluster
 //

--- a/sdk/go/gcp/iam/workforcePoolProvider.go
+++ b/sdk/go/gcp/iam/workforcePoolProvider.go
@@ -23,10 +23,6 @@ import (
 // > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
 // billing/quota project. The account team notifies you when the project is granted access.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Iam Workforce Pool Provider Saml Basic
 //

--- a/sdk/go/gcp/iap/client.go
+++ b/sdk/go/gcp/iap/client.go
@@ -24,9 +24,6 @@ import (
 // * How-to Guides
 //   - [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
 //
-// > **Warning:** All arguments including `secret` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Iap Client
 //

--- a/sdk/go/gcp/kms/secretCiphertext.go
+++ b/sdk/go/gcp/kms/secretCiphertext.go
@@ -25,8 +25,6 @@ import (
 // * How-to Guides
 //   - [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
 //
-// > **Warning:** All arguments including `plaintext` and `additionalAuthenticatedData` will be stored in the raw state as plain-text.
-//
 // ## Example Usage
 // ### Kms Secret Ciphertext Basic
 //

--- a/sdk/go/gcp/monitoring/notificationChannel.go
+++ b/sdk/go/gcp/monitoring/notificationChannel.go
@@ -36,9 +36,6 @@ import (
 //   - [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
 //   - [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
 //
-// > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Notification Channel Basic
 //

--- a/sdk/go/gcp/monitoring/uptimeCheckConfig.go
+++ b/sdk/go/gcp/monitoring/uptimeCheckConfig.go
@@ -20,9 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
 //
-// > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Uptime Check Config Http
 //

--- a/sdk/go/gcp/networkservices/edgeCacheKeyset.go
+++ b/sdk/go/gcp/networkservices/edgeCacheKeyset.go
@@ -19,10 +19,6 @@ import (
 // * How-to Guides
 //   - [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `public_key.public_key.value`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Network Services Edge Cache Keyset Basic
 //

--- a/sdk/go/gcp/secretmanager/secretVersion.go
+++ b/sdk/go/gcp/secretmanager/secretVersion.go
@@ -14,9 +14,6 @@ import (
 
 // A secret version resource.
 //
-// > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Secret Version Basic
 //

--- a/sdk/go/gcp/sql/sourceRepresentationInstance.go
+++ b/sdk/go/gcp/sql/sourceRepresentationInstance.go
@@ -18,10 +18,6 @@ import (
 // contains no data, requires no configuration or maintenance, and does not
 // affect billing. You cannot update the source representation instance.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Sql Source Representation Instance Basic
 //

--- a/sdk/go/gcp/sql/sslCert.go
+++ b/sdk/go/gcp/sql/sslCert.go
@@ -14,8 +14,6 @@ import (
 
 // Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
 //
-// > **Note:** All arguments including the private key will be stored in the raw state as plain-text
-//
 // ## Example Usage
 //
 // Example creating a SQL Client Certificate.

--- a/sdk/go/gcp/sql/user.go
+++ b/sdk/go/gcp/sql/user.go
@@ -14,8 +14,6 @@ import (
 
 // Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
 //
-// > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-//
 // ## Import
 //
 // SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/go/gcp/storage/hmacKey.go
+++ b/sdk/go/gcp/storage/hmacKey.go
@@ -22,11 +22,7 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
 //
-// > **Warning:** All arguments including the `secret` value will be stored in the raw
-// state as plain-text. On import, the `secret` value will not be retrieved.
-//
-// > **Warning:** All arguments including `secret` will be stored in the raw
-// state as plain-text.
+// > **Warning:** On import, the `secret` value will not be retrieved.
 //
 // ## Example Usage
 // ### Storage Hmac Key

--- a/sdk/java/src/main/java/com/pulumi/gcp/activedirectory/DomainTrust.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/activedirectory/DomainTrust.java
@@ -25,10 +25,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trust_handshake_secret`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Active Directory Domain Trust Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/alloydb/Cluster.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/alloydb/Cluster.java
@@ -38,10 +38,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [AlloyDB](https://cloud.google.com/alloydb/docs/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `initial_user.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Alloydb Cluster Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/appengine/Application.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/appengine/Application.java
@@ -25,9 +25,6 @@ import javax.annotation.Nullable;
  *    successfully deleted; this is a limitation of the provider, and will go away in the future.
  *    This provider is not able to delete App Engine applications.
  * 
- * &gt; **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
- * state as plain-text. Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ```java
  * package generated_program;

--- a/sdk/java/src/main/java/com/pulumi/gcp/bigquery/Connection.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/bigquery/Connection.java
@@ -29,10 +29,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Bigquery Connection Cloud Resource
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/bigquery/DataTransferConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/bigquery/DataTransferConfig.java
@@ -30,10 +30,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Bigquerydatatransfer Config Scheduled Query
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/Certificate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/Certificate.java
@@ -21,10 +21,6 @@ import javax.annotation.Nullable;
 /**
  * Certificate represents a HTTP-reachable backend for a Certificate.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Certificate Manager Google Managed Certificate Dns
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/TrustConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/TrustConfig.java
@@ -26,10 +26,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Certificate Manager Trust Config
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendBucketSignedUrlKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendBucketSignedUrlKey.java
@@ -23,9 +23,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  * 
- * &gt; **Warning:** All arguments including `key_value` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Backend Bucket Signed Url Key
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendService.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendService.java
@@ -40,9 +40,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
  * 
- * &gt; **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Backend Service Basic
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendServiceSignedUrlKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendServiceSignedUrlKey.java
@@ -23,9 +23,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  * 
- * &gt; **Warning:** All arguments including `key_value` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Backend Service Signed Url Key
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/CaExternalAccountKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/CaExternalAccountKey.java
@@ -32,10 +32,6 @@ import javax.annotation.Nullable;
  * The EAB secret is invalidated if you don&#39;t use it within 7 days.
  * The ACME account registered by using an EAB secret has no expiration.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Public Ca External Account Key
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionBackendService.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionBackendService.java
@@ -37,10 +37,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Region Backend Service Basic
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionDisk.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionDisk.java
@@ -44,9 +44,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
  * 
- * &gt; **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Region Disk Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionSslCertificate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionSslCertificate.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  * 
- * &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Region Ssl Certificate Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/SSLCertificate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/SSLCertificate.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  * 
- * &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Ssl Certificate Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/SecurityScanConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/SecurityScanConfig.java
@@ -27,8 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
  * 
- * &gt; **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
- * 
  * ## Example Usage
  * ### Scan Config Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/Snapshot.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/Snapshot.java
@@ -39,9 +39,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
  * 
- * &gt; **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Snapshot Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/VPNTunnel.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/VPNTunnel.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  *     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
  *     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
  * 
- * &gt; **Warning:** All arguments including `shared_secret` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Vpn Tunnel Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/databasemigrationservice/ConnectionProfile.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/databasemigrationservice/ConnectionProfile.java
@@ -31,10 +31,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Database Migration](https://cloud.google.com/database-migration/docs/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Database Migration Service Connection Profile Cloudsql
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/dataloss/PreventionDeidentifyTemplate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/dataloss/PreventionDeidentifyTemplate.java
@@ -24,10 +24,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Dlp Deidentify Template Basic
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/datastream/ConnectionProfile.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/datastream/ConnectionProfile.java
@@ -32,10 +32,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Datastream Connection Profile Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/diagflow/CxAgent.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/diagflow/CxAgent.java
@@ -29,10 +29,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Dialogflowcx Agent Full
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/edgecontainer/Cluster.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/edgecontainer/Cluster.java
@@ -34,10 +34,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `cluster_ca_certificate`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Edgecontainer Cluster
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/iam/WorkforcePoolProvider.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/iam/WorkforcePoolProvider.java
@@ -30,10 +30,6 @@ import javax.annotation.Nullable;
  * &gt; **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
  * billing/quota project. The account team notifies you when the project is granted access.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Iam Workforce Pool Provider Saml Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/iap/Client.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/iap/Client.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
  * 
- * &gt; **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Iap Client
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/kms/SecretCiphertext.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/kms/SecretCiphertext.java
@@ -29,8 +29,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
  * 
- * &gt; **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
- * 
  * ## Example Usage
  * ### Kms Secret Ciphertext Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/monitoring/NotificationChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/monitoring/NotificationChannel.java
@@ -42,9 +42,6 @@ import javax.annotation.Nullable;
  *     * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
  *     * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
  * 
- * &gt; **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Notification Channel Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/monitoring/UptimeCheckConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/monitoring/UptimeCheckConfig.java
@@ -31,9 +31,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
  * 
- * &gt; **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Uptime Check Config Http
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/networkservices/EdgeCacheKeyset.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/networkservices/EdgeCacheKeyset.java
@@ -27,10 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `public_key.public_key.value`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Network Services Edge Cache Keyset Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/secretmanager/SecretVersion.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/secretmanager/SecretVersion.java
@@ -19,9 +19,6 @@ import javax.annotation.Nullable;
 /**
  * A secret version resource.
  * 
- * &gt; **Warning:** All arguments including `payload.secret_data` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Secret Version Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/SourceRepresentationInstance.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/SourceRepresentationInstance.java
@@ -23,10 +23,6 @@ import javax.annotation.Nullable;
  * contains no data, requires no configuration or maintenance, and does not
  * affect billing. You cannot update the source representation instance.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `on_premises_configuration.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Sql Source Representation Instance Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/SslCert.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/SslCert.java
@@ -17,8 +17,6 @@ import javax.annotation.Nullable;
 /**
  * Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
  * 
- * &gt; **Note:** All arguments including the private key will be stored in the raw state as plain-text
- * 
  * ## Example Usage
  * 
  * Example creating a SQL Client Certificate.

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/User.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/User.java
@@ -20,8 +20,6 @@ import javax.annotation.Nullable;
 /**
  * Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
  * 
- * &gt; **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
- * 
  * ## Import
  * 
  * SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/java/src/main/java/com/pulumi/gcp/storage/HmacKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/storage/HmacKey.java
@@ -26,11 +26,7 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
  * 
- * &gt; **Warning:** All arguments including the `secret` value will be stored in the raw
- * state as plain-text. On import, the `secret` value will not be retrieved.
- * 
- * &gt; **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
+ * &gt; **Warning:** On import, the `secret` value will not be retrieved.
  * 
  * ## Example Usage
  * ### Storage Hmac Key

--- a/sdk/nodejs/activedirectory/domainTrust.ts
+++ b/sdk/nodejs/activedirectory/domainTrust.ts
@@ -13,10 +13,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trustHandshakeSecret`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Active Directory Domain Trust Basic
  *

--- a/sdk/nodejs/alloydb/cluster.ts
+++ b/sdk/nodejs/alloydb/cluster.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [AlloyDB](https://cloud.google.com/alloydb/docs/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `initial_user.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Alloydb Cluster Basic
  *

--- a/sdk/nodejs/appengine/application.ts
+++ b/sdk/nodejs/appengine/application.ts
@@ -14,9 +14,6 @@ import * as utilities from "../utilities";
  *    successfully deleted; this is a limitation of the provider, and will go away in the future.
  *    This provider is not able to delete App Engine applications.
  *
- * > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
- * state as plain-text. Read more about sensitive data in state.
- *
  * ## Example Usage
  *
  * ```typescript

--- a/sdk/nodejs/bigquery/connection.ts
+++ b/sdk/nodejs/bigquery/connection.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Bigquery Connection Cloud Resource
  *

--- a/sdk/nodejs/bigquery/dataTransferConfig.ts
+++ b/sdk/nodejs/bigquery/dataTransferConfig.ts
@@ -16,10 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Bigquerydatatransfer Config Scheduled Query
  *

--- a/sdk/nodejs/certificatemanager/certificate.ts
+++ b/sdk/nodejs/certificatemanager/certificate.ts
@@ -9,10 +9,6 @@ import * as utilities from "../utilities";
 /**
  * Certificate represents a HTTP-reachable backend for a Certificate.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Certificate Manager Google Managed Certificate Dns
  *

--- a/sdk/nodejs/certificatemanager/trustConfig.ts
+++ b/sdk/nodejs/certificatemanager/trustConfig.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Certificate Manager Trust Config
  *

--- a/sdk/nodejs/compute/backendBucketSignedUrlKey.ts
+++ b/sdk/nodejs/compute/backendBucketSignedUrlKey.ts
@@ -13,9 +13,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  *
- * > **Warning:** All arguments including `keyValue` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Backend Bucket Signed Url Key
  *

--- a/sdk/nodejs/compute/backendService.ts
+++ b/sdk/nodejs/compute/backendService.ts
@@ -20,9 +20,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
  *
- * > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Backend Service Cache Include Http Headers
  *

--- a/sdk/nodejs/compute/backendServiceSignedUrlKey.ts
+++ b/sdk/nodejs/compute/backendServiceSignedUrlKey.ts
@@ -13,9 +13,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  *
- * > **Warning:** All arguments including `keyValue` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  *
  * ## Import

--- a/sdk/nodejs/compute/caExternalAccountKey.ts
+++ b/sdk/nodejs/compute/caExternalAccountKey.ts
@@ -21,10 +21,6 @@ import * as utilities from "../utilities";
  * The EAB secret is invalidated if you don't use it within 7 days.
  * The ACME account registered by using an EAB secret has no expiration.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `keyId`, `b64MacKey`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Public Ca External Account Key
  *

--- a/sdk/nodejs/compute/regionBackendService.ts
+++ b/sdk/nodejs/compute/regionBackendService.ts
@@ -16,10 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  *
  * ## Import

--- a/sdk/nodejs/compute/regionDisk.ts
+++ b/sdk/nodejs/compute/regionDisk.ts
@@ -29,9 +29,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
  *
- * > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Region Disk Basic
  *

--- a/sdk/nodejs/compute/regionSslCertificate.ts
+++ b/sdk/nodejs/compute/regionSslCertificate.ts
@@ -15,9 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  *
- * > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Region Ssl Certificate Basic
  *

--- a/sdk/nodejs/compute/securityScanConfig.ts
+++ b/sdk/nodejs/compute/securityScanConfig.ts
@@ -15,8 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
  *
- * > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
- *
  * ## Example Usage
  * ### Scan Config Basic
  *

--- a/sdk/nodejs/compute/snapshot.ts
+++ b/sdk/nodejs/compute/snapshot.ts
@@ -26,9 +26,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
  *
- * > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Snapshot Basic
  *

--- a/sdk/nodejs/compute/sslcertificate.ts
+++ b/sdk/nodejs/compute/sslcertificate.ts
@@ -15,9 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  *
- * > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Ssl Certificate Basic
  *

--- a/sdk/nodejs/compute/vpntunnel.ts
+++ b/sdk/nodejs/compute/vpntunnel.ts
@@ -14,9 +14,6 @@ import * as utilities from "../utilities";
  *     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
  *     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
  *
- * > **Warning:** All arguments including `sharedSecret` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Vpn Tunnel Basic
  *

--- a/sdk/nodejs/databasemigrationservice/connectionProfile.ts
+++ b/sdk/nodejs/databasemigrationservice/connectionProfile.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Database Migration](https://cloud.google.com/database-migration/docs/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Database Migration Service Connection Profile Cloudsql
  *

--- a/sdk/nodejs/dataloss/preventionDeidentifyTemplate.ts
+++ b/sdk/nodejs/dataloss/preventionDeidentifyTemplate.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Dlp Deidentify Template Image Transformations
  *

--- a/sdk/nodejs/datastream/connectionProfile.ts
+++ b/sdk/nodejs/datastream/connectionProfile.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Datastream Connection Profile Basic
  *

--- a/sdk/nodejs/diagflow/cxAgent.ts
+++ b/sdk/nodejs/diagflow/cxAgent.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Dialogflowcx Agent Full
  *

--- a/sdk/nodejs/edgecontainer/cluster.ts
+++ b/sdk/nodejs/edgecontainer/cluster.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `clusterCaCertificate`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Edgecontainer Cluster
  *

--- a/sdk/nodejs/iam/workforcePoolProvider.ts
+++ b/sdk/nodejs/iam/workforcePoolProvider.ts
@@ -18,10 +18,6 @@ import * as utilities from "../utilities";
  * > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
  * billing/quota project. The account team notifies you when the project is granted access.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Iam Workforce Pool Provider Saml Basic
  *

--- a/sdk/nodejs/iap/client.ts
+++ b/sdk/nodejs/iap/client.ts
@@ -17,9 +17,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
  *
- * > **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Iap Client
  *

--- a/sdk/nodejs/kms/secretCiphertext.ts
+++ b/sdk/nodejs/kms/secretCiphertext.ts
@@ -18,8 +18,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
  *
- * > **Warning:** All arguments including `plaintext` and `additionalAuthenticatedData` will be stored in the raw state as plain-text.
- *
  * ## Example Usage
  * ### Kms Secret Ciphertext Basic
  *

--- a/sdk/nodejs/monitoring/notificationChannel.ts
+++ b/sdk/nodejs/monitoring/notificationChannel.ts
@@ -31,9 +31,6 @@ import * as utilities from "../utilities";
  *     * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
  *     * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
  *
- * > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Notification Channel Basic
  *

--- a/sdk/nodejs/monitoring/uptimeCheckConfig.ts
+++ b/sdk/nodejs/monitoring/uptimeCheckConfig.ts
@@ -15,9 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
  *
- * > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Uptime Check Config Http
  *

--- a/sdk/nodejs/networkservices/edgeCacheKeyset.ts
+++ b/sdk/nodejs/networkservices/edgeCacheKeyset.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `public_key.public_key.value`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Network Services Edge Cache Keyset Basic
  *

--- a/sdk/nodejs/secretmanager/secretVersion.ts
+++ b/sdk/nodejs/secretmanager/secretVersion.ts
@@ -7,9 +7,6 @@ import * as utilities from "../utilities";
 /**
  * A secret version resource.
  *
- * > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Secret Version Basic
  *

--- a/sdk/nodejs/sql/sourceRepresentationInstance.ts
+++ b/sdk/nodejs/sql/sourceRepresentationInstance.ts
@@ -11,10 +11,6 @@ import * as utilities from "../utilities";
  * contains no data, requires no configuration or maintenance, and does not
  * affect billing. You cannot update the source representation instance.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `on_premises_configuration.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Sql Source Representation Instance Basic
  *

--- a/sdk/nodejs/sql/sslCert.ts
+++ b/sdk/nodejs/sql/sslCert.ts
@@ -7,8 +7,6 @@ import * as utilities from "../utilities";
 /**
  * Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
  *
- * > **Note:** All arguments including the private key will be stored in the raw state as plain-text
- *
  * ## Example Usage
  *
  * Example creating a SQL Client Certificate.

--- a/sdk/nodejs/sql/user.ts
+++ b/sdk/nodejs/sql/user.ts
@@ -9,8 +9,6 @@ import * as utilities from "../utilities";
 /**
  * Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
  *
- * > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
- *
  * ## Import
  *
  * SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/nodejs/storage/hmacKey.ts
+++ b/sdk/nodejs/storage/hmacKey.ts
@@ -15,11 +15,7 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
  *
- * > **Warning:** All arguments including the `secret` value will be stored in the raw
- * state as plain-text. On import, the `secret` value will not be retrieved.
- *
- * > **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
+ * > **Warning:** On import, the `secret` value will not be retrieved.
  *
  * ## Example Usage
  * ### Storage Hmac Key

--- a/sdk/python/pulumi_gcp/activedirectory/domain_trust.py
+++ b/sdk/python/pulumi_gcp/activedirectory/domain_trust.py
@@ -332,10 +332,6 @@ class DomainTrust(pulumi.CustomResource):
         * How-to Guides
             * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_handshake_secret`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Active Directory Domain Trust Basic
 
@@ -409,10 +405,6 @@ class DomainTrust(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/managed-microsoft-ad/reference/rest/v1/projects.locations.global.domains/attachTrust)
         * How-to Guides
             * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_handshake_secret`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Active Directory Domain Trust Basic

--- a/sdk/python/pulumi_gcp/alloydb/cluster.py
+++ b/sdk/python/pulumi_gcp/alloydb/cluster.py
@@ -966,10 +966,6 @@ class Cluster(pulumi.CustomResource):
         * How-to Guides
             * [AlloyDB](https://cloud.google.com/alloydb/docs/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `initial_user.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Alloydb Cluster Basic
 
@@ -1214,10 +1210,6 @@ class Cluster(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.clusters/create)
         * How-to Guides
             * [AlloyDB](https://cloud.google.com/alloydb/docs/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `initial_user.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Alloydb Cluster Basic

--- a/sdk/python/pulumi_gcp/appengine/application.py
+++ b/sdk/python/pulumi_gcp/appengine/application.py
@@ -417,9 +417,6 @@ class Application(pulumi.CustomResource):
            successfully deleted; this is a limitation of the provider, and will go away in the future.
            This provider is not able to delete App Engine applications.
 
-        > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-        state as plain-text. Read more about sensitive data in state.
-
         ## Example Usage
 
         ```python
@@ -481,9 +478,6 @@ class Application(pulumi.CustomResource):
            entire project to delete the application. This provider will report the application has been
            successfully deleted; this is a limitation of the provider, and will go away in the future.
            This provider is not able to delete App Engine applications.
-
-        > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-        state as plain-text. Read more about sensitive data in state.
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/bigquery/connection.py
+++ b/sdk/python/pulumi_gcp/bigquery/connection.py
@@ -456,10 +456,6 @@ class Connection(pulumi.CustomResource):
         * How-to Guides
             * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Bigquery Connection Cloud Resource
 
@@ -676,10 +672,6 @@ class Connection(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection/rest/v1/projects.locations.connections/create)
         * How-to Guides
             * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Bigquery Connection Cloud Resource

--- a/sdk/python/pulumi_gcp/bigquery/data_transfer_config.py
+++ b/sdk/python/pulumi_gcp/bigquery/data_transfer_config.py
@@ -652,10 +652,6 @@ class DataTransferConfig(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Bigquerydatatransfer Config Scheduled Query
 
@@ -767,10 +763,6 @@ class DataTransferConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs/create)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Bigquerydatatransfer Config Scheduled Query

--- a/sdk/python/pulumi_gcp/certificatemanager/certificate.py
+++ b/sdk/python/pulumi_gcp/certificatemanager/certificate.py
@@ -416,10 +416,6 @@ class Certificate(pulumi.CustomResource):
         """
         Certificate represents a HTTP-reachable backend for a Certificate.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Certificate Manager Google Managed Certificate Dns
 
@@ -708,10 +704,6 @@ class Certificate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Certificate represents a HTTP-reachable backend for a Certificate.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Certificate Manager Google Managed Certificate Dns

--- a/sdk/python/pulumi_gcp/certificatemanager/trust_config.py
+++ b/sdk/python/pulumi_gcp/certificatemanager/trust_config.py
@@ -347,10 +347,6 @@ class TrustConfig(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Certificate Manager Trust Config
 
@@ -429,10 +425,6 @@ class TrustConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/certificate-manager/docs/reference/certificate-manager/rest/v1/projects.locations.trustConfigs/create)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Certificate Manager Trust Config

--- a/sdk/python/pulumi_gcp/compute/backend_bucket_signed_url_key.py
+++ b/sdk/python/pulumi_gcp/compute/backend_bucket_signed_url_key.py
@@ -196,9 +196,6 @@ class BackendBucketSignedUrlKey(pulumi.CustomResource):
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Backend Bucket Signed Url Key
 
@@ -249,9 +246,6 @@ class BackendBucketSignedUrlKey(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/backendBuckets)
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
-
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Backend Bucket Signed Url Key

--- a/sdk/python/pulumi_gcp/compute/backend_service.py
+++ b/sdk/python/pulumi_gcp/compute/backend_service.py
@@ -1274,9 +1274,6 @@ class BackendService(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
 
-        > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Backend Service Cache Include Http Headers
 
@@ -1487,9 +1484,6 @@ class BackendService(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/v1/backendServices)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
-
-        > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Backend Service Cache Include Http Headers

--- a/sdk/python/pulumi_gcp/compute/backend_service_signed_url_key.py
+++ b/sdk/python/pulumi_gcp/compute/backend_service_signed_url_key.py
@@ -196,9 +196,6 @@ class BackendServiceSignedUrlKey(pulumi.CustomResource):
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
 
         ## Import
@@ -232,9 +229,6 @@ class BackendServiceSignedUrlKey(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices)
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
-
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/compute/ca_external_account_key.py
+++ b/sdk/python/pulumi_gcp/compute/ca_external_account_key.py
@@ -174,10 +174,6 @@ class CaExternalAccountKey(pulumi.CustomResource):
         The EAB secret is invalidated if you don't use it within 7 days.
         The ACME account registered by using an EAB secret has no expiration.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Public Ca External Account Key
 
@@ -220,10 +216,6 @@ class CaExternalAccountKey(pulumi.CustomResource):
         You must use an EAB secret within 7 days of obtaining it.
         The EAB secret is invalidated if you don't use it within 7 days.
         The ACME account registered by using an EAB secret has no expiration.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Public Ca External Account Key

--- a/sdk/python/pulumi_gcp/compute/region_backend_service.py
+++ b/sdk/python/pulumi_gcp/compute/region_backend_service.py
@@ -1197,10 +1197,6 @@ class RegionBackendService(pulumi.CustomResource):
         * How-to Guides
             * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-        Read more about sensitive data in state.
-
         ## Example Usage
 
         ## Import
@@ -1336,10 +1332,6 @@ class RegionBackendService(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/latest/regionBackendServices)
         * How-to Guides
             * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-        Read more about sensitive data in state.
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/compute/region_disk.py
+++ b/sdk/python/pulumi_gcp/compute/region_disk.py
@@ -1022,9 +1022,6 @@ class RegionDisk(pulumi.CustomResource):
         * How-to Guides
             * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
 
-        > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Region Disk Basic
 
@@ -1233,9 +1230,6 @@ class RegionDisk(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionDisks)
         * How-to Guides
             * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
-
-        > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Region Disk Basic

--- a/sdk/python/pulumi_gcp/compute/region_ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/region_ssl_certificate.py
@@ -409,9 +409,6 @@ class RegionSslCertificate(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Region Ssl Certificate Basic
 
@@ -526,9 +523,6 @@ class RegionSslCertificate(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionSslCertificates)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
-
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Region Ssl Certificate Basic

--- a/sdk/python/pulumi_gcp/compute/security_scan_config.py
+++ b/sdk/python/pulumi_gcp/compute/security_scan_config.py
@@ -446,8 +446,6 @@ class SecurityScanConfig(pulumi.CustomResource):
         * How-to Guides
             * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
 
-        > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
-
         ## Example Usage
         ### Scan Config Basic
 
@@ -528,8 +526,6 @@ class SecurityScanConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/security-scanner/docs/reference/rest/v1beta/projects.scanConfigs)
         * How-to Guides
             * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
-
-        > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
 
         ## Example Usage
         ### Scan Config Basic

--- a/sdk/python/pulumi_gcp/compute/snapshot.py
+++ b/sdk/python/pulumi_gcp/compute/snapshot.py
@@ -662,9 +662,6 @@ class Snapshot(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
 
-        > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Snapshot Basic
 
@@ -802,9 +799,6 @@ class Snapshot(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/snapshots)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
-
-        > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Snapshot Basic

--- a/sdk/python/pulumi_gcp/compute/ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_certificate.py
@@ -372,9 +372,6 @@ class SSLCertificate(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Ssl Certificate Basic
 
@@ -481,9 +478,6 @@ class SSLCertificate(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
-
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Ssl Certificate Basic

--- a/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
@@ -845,9 +845,6 @@ class VPNTunnel(pulumi.CustomResource):
             * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
             * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
 
-        > **Warning:** All arguments including `shared_secret` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Vpn Tunnel Basic
 
@@ -982,9 +979,6 @@ class VPNTunnel(pulumi.CustomResource):
         * How-to Guides
             * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
             * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
-
-        > **Warning:** All arguments including `shared_secret` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Vpn Tunnel Basic

--- a/sdk/python/pulumi_gcp/databasemigrationservice/connection_profile.py
+++ b/sdk/python/pulumi_gcp/databasemigrationservice/connection_profile.py
@@ -537,10 +537,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * How-to Guides
             * [Database Migration](https://cloud.google.com/database-migration/docs/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Database Migration Service Connection Profile Cloudsql
 
@@ -742,10 +738,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/database-migration/docs/reference/rest/v1/projects.locations.connectionProfiles/create)
         * How-to Guides
             * [Database Migration](https://cloud.google.com/database-migration/docs/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Database Migration Service Connection Profile Cloudsql

--- a/sdk/python/pulumi_gcp/dataloss/prevention_deidentify_template.py
+++ b/sdk/python/pulumi_gcp/dataloss/prevention_deidentify_template.py
@@ -283,10 +283,6 @@ class PreventionDeidentifyTemplate(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Dlp Deidentify Template Image Transformations
 
@@ -374,10 +370,6 @@ class PreventionDeidentifyTemplate(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Dlp Deidentify Template Image Transformations

--- a/sdk/python/pulumi_gcp/datastream/connection_profile.py
+++ b/sdk/python/pulumi_gcp/datastream/connection_profile.py
@@ -535,10 +535,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Datastream Connection Profile Basic
 
@@ -723,10 +719,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.connectionProfiles)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Datastream Connection Profile Basic

--- a/sdk/python/pulumi_gcp/diagflow/cx_agent.py
+++ b/sdk/python/pulumi_gcp/diagflow/cx_agent.py
@@ -623,10 +623,6 @@ class CxAgent(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Dialogflowcx Agent Full
 
@@ -760,10 +756,6 @@ class CxAgent(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/projects.locations.agents)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Dialogflowcx Agent Full

--- a/sdk/python/pulumi_gcp/edgecontainer/cluster.py
+++ b/sdk/python/pulumi_gcp/edgecontainer/cluster.py
@@ -805,10 +805,6 @@ class Cluster(pulumi.CustomResource):
         * How-to Guides
             * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cluster_ca_certificate`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Edgecontainer Cluster
 
@@ -977,10 +973,6 @@ class Cluster(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/distributed-cloud/edge/latest/docs/reference/container/rest/v1/projects.locations.clusters)
         * How-to Guides
             * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cluster_ca_certificate`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Edgecontainer Cluster

--- a/sdk/python/pulumi_gcp/iam/workforce_pool_provider.py
+++ b/sdk/python/pulumi_gcp/iam/workforce_pool_provider.py
@@ -642,10 +642,6 @@ class WorkforcePoolProvider(pulumi.CustomResource):
         > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
         billing/quota project. The account team notifies you when the project is granted access.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Iam Workforce Pool Provider Saml Basic
 
@@ -870,10 +866,6 @@ class WorkforcePoolProvider(pulumi.CustomResource):
 
         > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
         billing/quota project. The account team notifies you when the project is granted access.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Iam Workforce Pool Provider Saml Basic

--- a/sdk/python/pulumi_gcp/iap/client.py
+++ b/sdk/python/pulumi_gcp/iap/client.py
@@ -164,9 +164,6 @@ class Client(pulumi.CustomResource):
         * How-to Guides
             * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
 
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Iap Client
 
@@ -237,9 +234,6 @@ class Client(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/iap/docs/reference/rest/v1/projects.brands.identityAwareProxyClients)
         * How-to Guides
             * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
-
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Iap Client

--- a/sdk/python/pulumi_gcp/kms/secret_ciphertext.py
+++ b/sdk/python/pulumi_gcp/kms/secret_ciphertext.py
@@ -184,8 +184,6 @@ class SecretCiphertext(pulumi.CustomResource):
         * How-to Guides
             * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
 
-        > **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
-
         ## Example Usage
         ### Kms Secret Ciphertext Basic
 
@@ -252,8 +250,6 @@ class SecretCiphertext(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/encrypt)
         * How-to Guides
             * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
-
-        > **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
 
         ## Example Usage
         ### Kms Secret Ciphertext Basic

--- a/sdk/python/pulumi_gcp/monitoring/notification_channel.py
+++ b/sdk/python/pulumi_gcp/monitoring/notification_channel.py
@@ -468,9 +468,6 @@ class NotificationChannel(pulumi.CustomResource):
             * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
             * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
 
-        > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Notification Channel Basic
 
@@ -580,9 +577,6 @@ class NotificationChannel(pulumi.CustomResource):
         * How-to Guides
             * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
             * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
-
-        > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Notification Channel Basic

--- a/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
+++ b/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
@@ -555,9 +555,6 @@ class UptimeCheckConfig(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
 
-        > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Uptime Check Config Http
 
@@ -796,9 +793,6 @@ class UptimeCheckConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.uptimeCheckConfigs)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
-
-        > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Uptime Check Config Http

--- a/sdk/python/pulumi_gcp/networkservices/edge_cache_keyset.py
+++ b/sdk/python/pulumi_gcp/networkservices/edge_cache_keyset.py
@@ -348,10 +348,6 @@ class EdgeCacheKeyset(pulumi.CustomResource):
         * How-to Guides
             * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `public_key.public_key.value`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Network Services Edge Cache Keyset Basic
 
@@ -462,10 +458,6 @@ class EdgeCacheKeyset(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/media-cdn/docs/reference/rest/v1/projects.locations.edgeCacheKeysets)
         * How-to Guides
             * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `public_key.public_key.value`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Network Services Edge Cache Keyset Basic

--- a/sdk/python/pulumi_gcp/secretmanager/secret_version.py
+++ b/sdk/python/pulumi_gcp/secretmanager/secret_version.py
@@ -301,9 +301,6 @@ class SecretVersion(pulumi.CustomResource):
         """
         A secret version resource.
 
-        > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Secret Version Basic
 
@@ -426,9 +423,6 @@ class SecretVersion(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A secret version resource.
-
-        > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Secret Version Basic

--- a/sdk/python/pulumi_gcp/sql/source_representation_instance.py
+++ b/sdk/python/pulumi_gcp/sql/source_representation_instance.py
@@ -466,10 +466,6 @@ class SourceRepresentationInstance(pulumi.CustomResource):
         contains no data, requires no configuration or maintenance, and does not
         affect billing. You cannot update the source representation instance.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Sql Source Representation Instance Basic
 
@@ -561,10 +557,6 @@ class SourceRepresentationInstance(pulumi.CustomResource):
         Cloud Console and appears the same as a regular Cloud SQL instance, but it
         contains no data, requires no configuration or maintenance, and does not
         affect billing. You cannot update the source representation instance.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Sql Source Representation Instance Basic

--- a/sdk/python/pulumi_gcp/sql/ssl_cert.py
+++ b/sdk/python/pulumi_gcp/sql/ssl_cert.py
@@ -261,8 +261,6 @@ class SslCert(pulumi.CustomResource):
         """
         Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
 
-        > **Note:** All arguments including the private key will be stored in the raw state as plain-text
-
         ## Example Usage
 
         Example creating a SQL Client Certificate.
@@ -304,8 +302,6 @@ class SslCert(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
-
-        > **Note:** All arguments including the private key will be stored in the raw state as plain-text
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/sql/user.py
+++ b/sdk/python/pulumi_gcp/sql/user.py
@@ -369,8 +369,6 @@ class User(pulumi.CustomResource):
         """
         Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
 
-        > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-
         ## Import
 
         SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {
@@ -433,8 +431,6 @@ class User(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
-
-        > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 
         ## Import
 

--- a/sdk/python/pulumi_gcp/storage/hmac_key.py
+++ b/sdk/python/pulumi_gcp/storage/hmac_key.py
@@ -232,11 +232,7 @@ class HmacKey(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
 
-        > **Warning:** All arguments including the `secret` value will be stored in the raw
-        state as plain-text. On import, the `secret` value will not be retrieved.
-
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
+        > **Warning:** On import, the `secret` value will not be retrieved.
 
         ## Example Usage
         ### Storage Hmac Key
@@ -304,11 +300,7 @@ class HmacKey(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
 
-        > **Warning:** All arguments including the `secret` value will be stored in the raw
-        state as plain-text. On import, the `secret` value will not be retrieved.
-
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
+        > **Warning:** On import, the `secret` value will not be retrieved.
 
         ## Example Usage
         ### Storage Hmac Key


### PR DESCRIPTION
>  All arguments including the following potentially sensitive values will be stored in the raw state as plain text

While this is true in terraform, that does not apply to Pulumi. My only change is removing lines from TF docs and then re-generating everything.

Fix https://github.com/pulumi/pulumi-gcp/issues/1195