### PR TITLE
Remove notes from upstream docs about storing secrets in plain text

### DIFF
--- a/provider/doc_edits.go
+++ b/provider/doc_edits.go
@@ -7,9 +7,10 @@ import (
 )
 
 func editRules(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
-	var result = append(defaults, fixupEffectiveLabels)
-	result = append(result, removeSecretsInPlainTextNote)
-	return result
+	return append(defaults,
+		fixupEffectiveLabels,
+		removeSecretsInPlainTextNote,
+	)
 }
 
 const effectiveLabels = `including the labels configured through Terraform`
@@ -33,7 +34,7 @@ var removeSecretsInPlainTextNote = tfbridge.DocsEdit{
 	Path: "*",
 	Edit: func(path string, content []byte) ([]byte, error) {
 		for _, r := range secretsInPlainTextNoteRegexps {
-			content = r.ReplaceAllLiteral(content, []byte(""))
+			content = r.ReplaceAllLiteral(content, nil)
 		}
 		return content, nil
 	},

--- a/provider/doc_edits_test.go
+++ b/provider/doc_edits_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestEffectiveLabels(t *testing.T) {
+	t.Parallel()
 	tests := []struct{ text, expected string }{
 		{
 			"including the labels configured through Terraform",

--- a/provider/doc_edits_test.go
+++ b/provider/doc_edits_test.go
@@ -29,3 +29,44 @@ func TestEffectiveLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestSecretsInPlainTextNote(t *testing.T) {
+	tests := []struct{ text, expected string }{
+		{
+			`Some other text.
+
+~> **Warning:** All arguments including the following potentially sensitive
+values will be stored in the raw state as plain text: ` + "`deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`" + `.
+Read more about sensitive data in state.
+
+Some more text.`,
+			"Some other text.\n\n\n\nSome more text.",
+		},
+		{
+			"This provider is not able to delete App Engine applications.\n\n> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw\nstate as plain-text. Read more about sensitive data in state.\n\n{{% examples %}}",
+			"This provider is not able to delete App Engine applications.\n\n\n\n{{% examples %}}",
+		},
+		{
+			"A> **Warning:** All arguments including `key_value` will be stored in the raw\nstate as plain-text.\n\nB",
+			"A\n\nB",
+		},
+		{
+			"A> **Note:** All arguments including the private key will be stored in the raw state as plain-text\n\nB",
+			"A\n\nB",
+		},
+		{
+			"A~> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw\nstate as plain-text. Read more about sensitive data in state.\n\nB",
+			"A\n\nB",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
+			actual, err := removeSecretsInPlainTextNote.Edit("doc.md", []byte(tt.text))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(actual))
+		})
+	}
+}

--- a/sdk/dotnet/ActiveDirectory/DomainTrust.cs
+++ b/sdk/dotnet/ActiveDirectory/DomainTrust.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.ActiveDirectory
     /// * How-to Guides
     ///     * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `trust_handshake_secret`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Active Directory Domain Trust Basic
     /// 

--- a/sdk/dotnet/Alloydb/Cluster.cs
+++ b/sdk/dotnet/Alloydb/Cluster.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.Alloydb
     /// * How-to Guides
     ///     * [AlloyDB](https://cloud.google.com/alloydb/docs/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `initial_user.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Alloydb Cluster Basic
     /// 

--- a/sdk/dotnet/AppEngine/Application.cs
+++ b/sdk/dotnet/AppEngine/Application.cs
@@ -17,9 +17,6 @@ namespace Pulumi.Gcp.AppEngine
     ///    successfully deleted; this is a limitation of the provider, and will go away in the future.
     ///    This provider is not able to delete App Engine applications.
     /// 
-    /// &gt; **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-    /// state as plain-text. Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// 
     /// ```csharp

--- a/sdk/dotnet/BigQuery/Connection.cs
+++ b/sdk/dotnet/BigQuery/Connection.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.BigQuery
     /// * How-to Guides
     ///     * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Bigquery Connection Cloud Resource
     /// 

--- a/sdk/dotnet/BigQuery/DataTransferConfig.cs
+++ b/sdk/dotnet/BigQuery/DataTransferConfig.cs
@@ -19,10 +19,6 @@ namespace Pulumi.Gcp.BigQuery
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Bigquerydatatransfer Config Scheduled Query
     /// 

--- a/sdk/dotnet/CertificateManager/Certificate.cs
+++ b/sdk/dotnet/CertificateManager/Certificate.cs
@@ -12,10 +12,6 @@ namespace Pulumi.Gcp.CertificateManager
     /// <summary>
     /// Certificate represents a HTTP-reachable backend for a Certificate.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Certificate Manager Google Managed Certificate Dns
     /// 

--- a/sdk/dotnet/CertificateManager/TrustConfig.cs
+++ b/sdk/dotnet/CertificateManager/TrustConfig.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.CertificateManager
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Certificate Manager Trust Config
     /// 

--- a/sdk/dotnet/Compute/BackendBucketSignedUrlKey.cs
+++ b/sdk/dotnet/Compute/BackendBucketSignedUrlKey.cs
@@ -18,9 +18,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
     /// 
-    /// &gt; **Warning:** All arguments including `key_value` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Backend Bucket Signed Url Key
     /// 

--- a/sdk/dotnet/Compute/BackendService.cs
+++ b/sdk/dotnet/Compute/BackendService.cs
@@ -23,9 +23,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
     /// 
-    /// &gt; **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Backend Service Cache Include Http Headers
     /// 

--- a/sdk/dotnet/Compute/BackendServiceSignedUrlKey.cs
+++ b/sdk/dotnet/Compute/BackendServiceSignedUrlKey.cs
@@ -18,9 +18,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
     /// 
-    /// &gt; **Warning:** All arguments including `key_value` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// 
     /// ## Import

--- a/sdk/dotnet/Compute/CaExternalAccountKey.cs
+++ b/sdk/dotnet/Compute/CaExternalAccountKey.cs
@@ -26,10 +26,6 @@ namespace Pulumi.Gcp.Compute
     /// The EAB secret is invalidated if you don't use it within 7 days.
     /// The ACME account registered by using an EAB secret has no expiration.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Public Ca External Account Key
     /// 

--- a/sdk/dotnet/Compute/RegionBackendService.cs
+++ b/sdk/dotnet/Compute/RegionBackendService.cs
@@ -19,10 +19,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// 
     /// ## Import

--- a/sdk/dotnet/Compute/RegionDisk.cs
+++ b/sdk/dotnet/Compute/RegionDisk.cs
@@ -32,9 +32,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
     /// 
-    /// &gt; **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Region Disk Basic
     /// 

--- a/sdk/dotnet/Compute/RegionSslCertificate.cs
+++ b/sdk/dotnet/Compute/RegionSslCertificate.cs
@@ -20,9 +20,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
     /// 
-    /// &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Region Ssl Certificate Basic
     /// 

--- a/sdk/dotnet/Compute/SSLCertificate.cs
+++ b/sdk/dotnet/Compute/SSLCertificate.cs
@@ -20,9 +20,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
     /// 
-    /// &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Ssl Certificate Basic
     /// 

--- a/sdk/dotnet/Compute/SecurityScanConfig.cs
+++ b/sdk/dotnet/Compute/SecurityScanConfig.cs
@@ -18,8 +18,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
     /// 
-    /// &gt; **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Scan Config Basic
     /// 

--- a/sdk/dotnet/Compute/Snapshot.cs
+++ b/sdk/dotnet/Compute/Snapshot.cs
@@ -29,9 +29,6 @@ namespace Pulumi.Gcp.Compute
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
     /// 
-    /// &gt; **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Snapshot Basic
     /// 

--- a/sdk/dotnet/Compute/VPNTunnel.cs
+++ b/sdk/dotnet/Compute/VPNTunnel.cs
@@ -19,9 +19,6 @@ namespace Pulumi.Gcp.Compute
     ///     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
     ///     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
     /// 
-    /// &gt; **Warning:** All arguments including `shared_secret` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Vpn Tunnel Basic
     /// 

--- a/sdk/dotnet/DataLoss/PreventionDeidentifyTemplate.cs
+++ b/sdk/dotnet/DataLoss/PreventionDeidentifyTemplate.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.DataLoss
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Dlp Deidentify Template Image Transformations
     /// 

--- a/sdk/dotnet/DatabaseMigrationService/ConnectionProfile.cs
+++ b/sdk/dotnet/DatabaseMigrationService/ConnectionProfile.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.DatabaseMigrationService
     /// * How-to Guides
     ///     * [Database Migration](https://cloud.google.com/database-migration/docs/)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Database Migration Service Connection Profile Cloudsql
     /// 

--- a/sdk/dotnet/Datastream/ConnectionProfile.cs
+++ b/sdk/dotnet/Datastream/ConnectionProfile.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.Datastream
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Datastream Connection Profile Basic
     /// 

--- a/sdk/dotnet/Diagflow/CxAgent.cs
+++ b/sdk/dotnet/Diagflow/CxAgent.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.Diagflow
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Dialogflowcx Agent Full
     /// 

--- a/sdk/dotnet/EdgeContainer/Cluster.cs
+++ b/sdk/dotnet/EdgeContainer/Cluster.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.EdgeContainer
     /// * How-to Guides
     ///     * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `cluster_ca_certificate`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Edgecontainer Cluster
     /// 

--- a/sdk/dotnet/Iam/WorkforcePoolProvider.cs
+++ b/sdk/dotnet/Iam/WorkforcePoolProvider.cs
@@ -21,10 +21,6 @@ namespace Pulumi.Gcp.Iam
     /// &gt; **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
     /// billing/quota project. The account team notifies you when the project is granted access.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Iam Workforce Pool Provider Saml Basic
     /// 

--- a/sdk/dotnet/Iap/Client.cs
+++ b/sdk/dotnet/Iap/Client.cs
@@ -22,9 +22,6 @@ namespace Pulumi.Gcp.Iap
     /// * How-to Guides
     ///     * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
     /// 
-    /// &gt; **Warning:** All arguments including `secret` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Iap Client
     /// 

--- a/sdk/dotnet/Kms/SecretCiphertext.cs
+++ b/sdk/dotnet/Kms/SecretCiphertext.cs
@@ -23,8 +23,6 @@ namespace Pulumi.Gcp.Kms
     /// * How-to Guides
     ///     * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
     /// 
-    /// &gt; **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Kms Secret Ciphertext Basic
     /// 

--- a/sdk/dotnet/Monitoring/NotificationChannel.cs
+++ b/sdk/dotnet/Monitoring/NotificationChannel.cs
@@ -34,9 +34,6 @@ namespace Pulumi.Gcp.Monitoring
     ///     * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
     ///     * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
     /// 
-    /// &gt; **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Notification Channel Basic
     /// 

--- a/sdk/dotnet/Monitoring/UptimeCheckConfig.cs
+++ b/sdk/dotnet/Monitoring/UptimeCheckConfig.cs
@@ -18,9 +18,6 @@ namespace Pulumi.Gcp.Monitoring
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
     /// 
-    /// &gt; **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Uptime Check Config Http
     /// 

--- a/sdk/dotnet/NetworkServices/EdgeCacheKeyset.cs
+++ b/sdk/dotnet/NetworkServices/EdgeCacheKeyset.cs
@@ -18,10 +18,6 @@ namespace Pulumi.Gcp.NetworkServices
     /// * How-to Guides
     ///     * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `public_key.public_key.value`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Network Services Edge Cache Keyset Basic
     /// 

--- a/sdk/dotnet/SecretManager/SecretVersion.cs
+++ b/sdk/dotnet/SecretManager/SecretVersion.cs
@@ -12,9 +12,6 @@ namespace Pulumi.Gcp.SecretManager
     /// <summary>
     /// A secret version resource.
     /// 
-    /// &gt; **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Secret Version Basic
     /// 

--- a/sdk/dotnet/Sql/SourceRepresentationInstance.cs
+++ b/sdk/dotnet/Sql/SourceRepresentationInstance.cs
@@ -16,10 +16,6 @@ namespace Pulumi.Gcp.Sql
     /// contains no data, requires no configuration or maintenance, and does not
     /// affect billing. You cannot update the source representation instance.
     /// 
-    /// &gt; **Warning:** All arguments including the following potentially sensitive
-    /// values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-    /// Read more about sensitive data in state.
-    /// 
     /// ## Example Usage
     /// ### Sql Source Representation Instance Basic
     /// 

--- a/sdk/dotnet/Sql/SslCert.cs
+++ b/sdk/dotnet/Sql/SslCert.cs
@@ -12,8 +12,6 @@ namespace Pulumi.Gcp.Sql
     /// <summary>
     /// Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
     /// 
-    /// &gt; **Note:** All arguments including the private key will be stored in the raw state as plain-text
-    /// 
     /// ## Example Usage
     /// 
     /// Example creating a SQL Client Certificate.

--- a/sdk/dotnet/Sql/User.cs
+++ b/sdk/dotnet/Sql/User.cs
@@ -12,8 +12,6 @@ namespace Pulumi.Gcp.Sql
     /// <summary>
     /// Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
     /// 
-    /// &gt; **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-    /// 
     /// ## Import
     /// 
     /// SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/dotnet/Storage/HmacKey.cs
+++ b/sdk/dotnet/Storage/HmacKey.cs
@@ -20,12 +20,6 @@ namespace Pulumi.Gcp.Storage
     /// * How-to Guides
     ///     * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
     /// 
-    /// &gt; **Warning:** All arguments including the `secret` value will be stored in the raw
-    /// state as plain-text. On import, the `secret` value will not be retrieved.
-    /// 
-    /// &gt; **Warning:** All arguments including `secret` will be stored in the raw
-    /// state as plain-text.
-    /// 
     /// ## Example Usage
     /// ### Storage Hmac Key
     /// 

--- a/sdk/go/gcp/activedirectory/domainTrust.go
+++ b/sdk/go/gcp/activedirectory/domainTrust.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `trustHandshakeSecret`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Active Directory Domain Trust Basic
 //

--- a/sdk/go/gcp/alloydb/cluster.go
+++ b/sdk/go/gcp/alloydb/cluster.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [AlloyDB](https://cloud.google.com/alloydb/docs/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `initial_user.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Alloydb Cluster Basic
 //

--- a/sdk/go/gcp/appengine/application.go
+++ b/sdk/go/gcp/appengine/application.go
@@ -20,9 +20,6 @@ import (
 //	successfully deleted; this is a limitation of the provider, and will go away in the future.
 //	This provider is not able to delete App Engine applications.
 //
-// > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-// state as plain-text. Read more about sensitive data in state.
-//
 // ## Example Usage
 //
 // ```go

--- a/sdk/go/gcp/bigquery/connection.go
+++ b/sdk/go/gcp/bigquery/connection.go
@@ -19,10 +19,6 @@ import (
 // * How-to Guides
 //   - [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Bigquery Connection Cloud Resource
 //

--- a/sdk/go/gcp/bigquery/dataTransferConfig.go
+++ b/sdk/go/gcp/bigquery/dataTransferConfig.go
@@ -21,10 +21,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Bigquerydatatransfer Config Scheduled Query
 //

--- a/sdk/go/gcp/certificatemanager/certificate.go
+++ b/sdk/go/gcp/certificatemanager/certificate.go
@@ -13,10 +13,6 @@ import (
 
 // Certificate represents a HTTP-reachable backend for a Certificate.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Certificate Manager Google Managed Certificate Dns
 //

--- a/sdk/go/gcp/certificatemanager/trustConfig.go
+++ b/sdk/go/gcp/certificatemanager/trustConfig.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/certificate-manager/docs)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Certificate Manager Trust Config
 //

--- a/sdk/go/gcp/compute/backendBucketSignedUrlKey.go
+++ b/sdk/go/gcp/compute/backendBucketSignedUrlKey.go
@@ -20,9 +20,6 @@ import (
 // * How-to Guides
 //   - [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 //
-// > **Warning:** All arguments including `keyValue` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Backend Bucket Signed Url Key
 //

--- a/sdk/go/gcp/compute/backendService.go
+++ b/sdk/go/gcp/compute/backendService.go
@@ -24,9 +24,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
 //
-// > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Backend Service Cache Include Http Headers
 //

--- a/sdk/go/gcp/compute/backendServiceSignedUrlKey.go
+++ b/sdk/go/gcp/compute/backendServiceSignedUrlKey.go
@@ -20,9 +20,6 @@ import (
 // * How-to Guides
 //   - [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 //
-// > **Warning:** All arguments including `keyValue` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 //
 // ## Import

--- a/sdk/go/gcp/compute/caExternalAccountKey.go
+++ b/sdk/go/gcp/compute/caExternalAccountKey.go
@@ -27,10 +27,6 @@ import (
 // The EAB secret is invalidated if you don't use it within 7 days.
 // The ACME account registered by using an EAB secret has no expiration.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `keyId`, `b64MacKey`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Public Ca External Account Key
 //

--- a/sdk/go/gcp/compute/regionBackendService.go
+++ b/sdk/go/gcp/compute/regionBackendService.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 //
 // ## Import

--- a/sdk/go/gcp/compute/regionDisk.go
+++ b/sdk/go/gcp/compute/regionDisk.go
@@ -34,9 +34,6 @@ import (
 // * How-to Guides
 //   - [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
 //
-// > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Region Disk Basic
 //

--- a/sdk/go/gcp/compute/regionSslCertificate.go
+++ b/sdk/go/gcp/compute/regionSslCertificate.go
@@ -22,9 +22,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 //
-// > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Region Ssl Certificate Basic
 //

--- a/sdk/go/gcp/compute/securityScanConfig.go
+++ b/sdk/go/gcp/compute/securityScanConfig.go
@@ -20,8 +20,6 @@ import (
 // * How-to Guides
 //   - [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
 //
-// > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
-//
 // ## Example Usage
 // ### Scan Config Basic
 //

--- a/sdk/go/gcp/compute/snapshot.go
+++ b/sdk/go/gcp/compute/snapshot.go
@@ -31,9 +31,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
 //
-// > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Snapshot Basic
 //

--- a/sdk/go/gcp/compute/sslcertificate.go
+++ b/sdk/go/gcp/compute/sslcertificate.go
@@ -22,9 +22,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 //
-// > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Ssl Certificate Basic
 //

--- a/sdk/go/gcp/compute/vpntunnel.go
+++ b/sdk/go/gcp/compute/vpntunnel.go
@@ -21,9 +21,6 @@ import (
 //   - [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
 //   - [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
 //
-// > **Warning:** All arguments including `sharedSecret` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Vpn Tunnel Basic
 //

--- a/sdk/go/gcp/databasemigrationservice/connectionProfile.go
+++ b/sdk/go/gcp/databasemigrationservice/connectionProfile.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Database Migration](https://cloud.google.com/database-migration/docs/)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Database Migration Service Connection Profile Cloudsql
 //

--- a/sdk/go/gcp/dataloss/preventionDeidentifyTemplate.go
+++ b/sdk/go/gcp/dataloss/preventionDeidentifyTemplate.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Dlp Deidentify Template Image Transformations
 //

--- a/sdk/go/gcp/datastream/connectionProfile.go
+++ b/sdk/go/gcp/datastream/connectionProfile.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Datastream Connection Profile Basic
 //

--- a/sdk/go/gcp/diagflow/cxAgent.go
+++ b/sdk/go/gcp/diagflow/cxAgent.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Dialogflowcx Agent Full
 //

--- a/sdk/go/gcp/edgecontainer/cluster.go
+++ b/sdk/go/gcp/edgecontainer/cluster.go
@@ -20,10 +20,6 @@ import (
 // * How-to Guides
 //   - [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `clusterCaCertificate`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Edgecontainer Cluster
 //

--- a/sdk/go/gcp/iam/workforcePoolProvider.go
+++ b/sdk/go/gcp/iam/workforcePoolProvider.go
@@ -23,10 +23,6 @@ import (
 // > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
 // billing/quota project. The account team notifies you when the project is granted access.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Iam Workforce Pool Provider Saml Basic
 //

--- a/sdk/go/gcp/iap/client.go
+++ b/sdk/go/gcp/iap/client.go
@@ -24,9 +24,6 @@ import (
 // * How-to Guides
 //   - [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
 //
-// > **Warning:** All arguments including `secret` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Iap Client
 //

--- a/sdk/go/gcp/kms/secretCiphertext.go
+++ b/sdk/go/gcp/kms/secretCiphertext.go
@@ -25,8 +25,6 @@ import (
 // * How-to Guides
 //   - [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
 //
-// > **Warning:** All arguments including `plaintext` and `additionalAuthenticatedData` will be stored in the raw state as plain-text.
-//
 // ## Example Usage
 // ### Kms Secret Ciphertext Basic
 //

--- a/sdk/go/gcp/monitoring/notificationChannel.go
+++ b/sdk/go/gcp/monitoring/notificationChannel.go
@@ -36,9 +36,6 @@ import (
 //   - [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
 //   - [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
 //
-// > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Notification Channel Basic
 //

--- a/sdk/go/gcp/monitoring/uptimeCheckConfig.go
+++ b/sdk/go/gcp/monitoring/uptimeCheckConfig.go
@@ -20,9 +20,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
 //
-// > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Uptime Check Config Http
 //

--- a/sdk/go/gcp/networkservices/edgeCacheKeyset.go
+++ b/sdk/go/gcp/networkservices/edgeCacheKeyset.go
@@ -19,10 +19,6 @@ import (
 // * How-to Guides
 //   - [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `public_key.public_key.value`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Network Services Edge Cache Keyset Basic
 //

--- a/sdk/go/gcp/secretmanager/secretVersion.go
+++ b/sdk/go/gcp/secretmanager/secretVersion.go
@@ -14,9 +14,6 @@ import (
 
 // A secret version resource.
 //
-// > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Secret Version Basic
 //

--- a/sdk/go/gcp/sql/sourceRepresentationInstance.go
+++ b/sdk/go/gcp/sql/sourceRepresentationInstance.go
@@ -18,10 +18,6 @@ import (
 // contains no data, requires no configuration or maintenance, and does not
 // affect billing. You cannot update the source representation instance.
 //
-// > **Warning:** All arguments including the following potentially sensitive
-// values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-// Read more about sensitive data in state.
-//
 // ## Example Usage
 // ### Sql Source Representation Instance Basic
 //

--- a/sdk/go/gcp/sql/sslCert.go
+++ b/sdk/go/gcp/sql/sslCert.go
@@ -14,8 +14,6 @@ import (
 
 // Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
 //
-// > **Note:** All arguments including the private key will be stored in the raw state as plain-text
-//
 // ## Example Usage
 //
 // Example creating a SQL Client Certificate.

--- a/sdk/go/gcp/sql/user.go
+++ b/sdk/go/gcp/sql/user.go
@@ -14,8 +14,6 @@ import (
 
 // Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
 //
-// > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-//
 // ## Import
 //
 // SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/go/gcp/storage/hmacKey.go
+++ b/sdk/go/gcp/storage/hmacKey.go
@@ -22,12 +22,6 @@ import (
 // * How-to Guides
 //   - [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
 //
-// > **Warning:** All arguments including the `secret` value will be stored in the raw
-// state as plain-text. On import, the `secret` value will not be retrieved.
-//
-// > **Warning:** All arguments including `secret` will be stored in the raw
-// state as plain-text.
-//
 // ## Example Usage
 // ### Storage Hmac Key
 //

--- a/sdk/java/src/main/java/com/pulumi/gcp/activedirectory/DomainTrust.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/activedirectory/DomainTrust.java
@@ -25,10 +25,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trust_handshake_secret`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Active Directory Domain Trust Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/alloydb/Cluster.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/alloydb/Cluster.java
@@ -38,10 +38,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [AlloyDB](https://cloud.google.com/alloydb/docs/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `initial_user.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Alloydb Cluster Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/appengine/Application.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/appengine/Application.java
@@ -25,9 +25,6 @@ import javax.annotation.Nullable;
  *    successfully deleted; this is a limitation of the provider, and will go away in the future.
  *    This provider is not able to delete App Engine applications.
  * 
- * &gt; **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
- * state as plain-text. Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ```java
  * package generated_program;

--- a/sdk/java/src/main/java/com/pulumi/gcp/bigquery/Connection.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/bigquery/Connection.java
@@ -29,10 +29,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Bigquery Connection Cloud Resource
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/bigquery/DataTransferConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/bigquery/DataTransferConfig.java
@@ -30,10 +30,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Bigquerydatatransfer Config Scheduled Query
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/Certificate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/Certificate.java
@@ -21,10 +21,6 @@ import javax.annotation.Nullable;
 /**
  * Certificate represents a HTTP-reachable backend for a Certificate.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Certificate Manager Google Managed Certificate Dns
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/TrustConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/certificatemanager/TrustConfig.java
@@ -26,10 +26,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Certificate Manager Trust Config
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendBucketSignedUrlKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendBucketSignedUrlKey.java
@@ -23,9 +23,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  * 
- * &gt; **Warning:** All arguments including `key_value` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Backend Bucket Signed Url Key
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendService.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendService.java
@@ -40,9 +40,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
  * 
- * &gt; **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Backend Service Basic
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendServiceSignedUrlKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/BackendServiceSignedUrlKey.java
@@ -23,9 +23,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  * 
- * &gt; **Warning:** All arguments including `key_value` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Backend Service Signed Url Key
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/CaExternalAccountKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/CaExternalAccountKey.java
@@ -32,10 +32,6 @@ import javax.annotation.Nullable;
  * The EAB secret is invalidated if you don&#39;t use it within 7 days.
  * The ACME account registered by using an EAB secret has no expiration.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Public Ca External Account Key
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionBackendService.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionBackendService.java
@@ -37,10 +37,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Region Backend Service Basic
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionDisk.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionDisk.java
@@ -44,9 +44,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
  * 
- * &gt; **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Region Disk Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionSslCertificate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/RegionSslCertificate.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  * 
- * &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Region Ssl Certificate Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/SSLCertificate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/SSLCertificate.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  * 
- * &gt; **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Ssl Certificate Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/SecurityScanConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/SecurityScanConfig.java
@@ -27,8 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
  * 
- * &gt; **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
- * 
  * ## Example Usage
  * ### Scan Config Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/Snapshot.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/Snapshot.java
@@ -39,9 +39,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
  * 
- * &gt; **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Snapshot Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/VPNTunnel.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/VPNTunnel.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  *     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
  *     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
  * 
- * &gt; **Warning:** All arguments including `shared_secret` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Vpn Tunnel Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/databasemigrationservice/ConnectionProfile.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/databasemigrationservice/ConnectionProfile.java
@@ -31,10 +31,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Database Migration](https://cloud.google.com/database-migration/docs/)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Database Migration Service Connection Profile Cloudsql
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/dataloss/PreventionDeidentifyTemplate.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/dataloss/PreventionDeidentifyTemplate.java
@@ -24,10 +24,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Dlp Deidentify Template Basic
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/datastream/ConnectionProfile.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/datastream/ConnectionProfile.java
@@ -32,10 +32,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Datastream Connection Profile Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/diagflow/CxAgent.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/diagflow/CxAgent.java
@@ -29,10 +29,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Dialogflowcx Agent Full
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/edgecontainer/Cluster.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/edgecontainer/Cluster.java
@@ -34,10 +34,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `cluster_ca_certificate`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Edgecontainer Cluster
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/iam/WorkforcePoolProvider.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/iam/WorkforcePoolProvider.java
@@ -30,10 +30,6 @@ import javax.annotation.Nullable;
  * &gt; **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
  * billing/quota project. The account team notifies you when the project is granted access.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Iam Workforce Pool Provider Saml Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/iap/Client.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/iap/Client.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
  * 
- * &gt; **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Iap Client
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/kms/SecretCiphertext.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/kms/SecretCiphertext.java
@@ -29,8 +29,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
  * 
- * &gt; **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
- * 
  * ## Example Usage
  * ### Kms Secret Ciphertext Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/monitoring/NotificationChannel.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/monitoring/NotificationChannel.java
@@ -42,9 +42,6 @@ import javax.annotation.Nullable;
  *     * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
  *     * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
  * 
- * &gt; **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Notification Channel Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/monitoring/UptimeCheckConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/monitoring/UptimeCheckConfig.java
@@ -31,9 +31,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
  * 
- * &gt; **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Uptime Check Config Http
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/networkservices/EdgeCacheKeyset.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/networkservices/EdgeCacheKeyset.java
@@ -27,10 +27,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `public_key.public_key.value`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Network Services Edge Cache Keyset Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/secretmanager/SecretVersion.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/secretmanager/SecretVersion.java
@@ -19,9 +19,6 @@ import javax.annotation.Nullable;
 /**
  * A secret version resource.
  * 
- * &gt; **Warning:** All arguments including `payload.secret_data` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Secret Version Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/SourceRepresentationInstance.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/SourceRepresentationInstance.java
@@ -23,10 +23,6 @@ import javax.annotation.Nullable;
  * contains no data, requires no configuration or maintenance, and does not
  * affect billing. You cannot update the source representation instance.
  * 
- * &gt; **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `on_premises_configuration.password`.
- * Read more about sensitive data in state.
- * 
  * ## Example Usage
  * ### Sql Source Representation Instance Basic
  * ```java

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/SslCert.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/SslCert.java
@@ -17,8 +17,6 @@ import javax.annotation.Nullable;
 /**
  * Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
  * 
- * &gt; **Note:** All arguments including the private key will be stored in the raw state as plain-text
- * 
  * ## Example Usage
  * 
  * Example creating a SQL Client Certificate.

--- a/sdk/java/src/main/java/com/pulumi/gcp/sql/User.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/sql/User.java
@@ -20,8 +20,6 @@ import javax.annotation.Nullable;
 /**
  * Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
  * 
- * &gt; **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
- * 
  * ## Import
  * 
  * SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/java/src/main/java/com/pulumi/gcp/storage/HmacKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/storage/HmacKey.java
@@ -26,12 +26,6 @@ import javax.annotation.Nullable;
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
  * 
- * &gt; **Warning:** All arguments including the `secret` value will be stored in the raw
- * state as plain-text. On import, the `secret` value will not be retrieved.
- * 
- * &gt; **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
- * 
  * ## Example Usage
  * ### Storage Hmac Key
  * ```java

--- a/sdk/nodejs/activedirectory/domainTrust.ts
+++ b/sdk/nodejs/activedirectory/domainTrust.ts
@@ -13,10 +13,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trustHandshakeSecret`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Active Directory Domain Trust Basic
  *

--- a/sdk/nodejs/alloydb/cluster.ts
+++ b/sdk/nodejs/alloydb/cluster.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [AlloyDB](https://cloud.google.com/alloydb/docs/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `initial_user.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Alloydb Cluster Basic
  *

--- a/sdk/nodejs/appengine/application.ts
+++ b/sdk/nodejs/appengine/application.ts
@@ -14,9 +14,6 @@ import * as utilities from "../utilities";
  *    successfully deleted; this is a limitation of the provider, and will go away in the future.
  *    This provider is not able to delete App Engine applications.
  *
- * > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
- * state as plain-text. Read more about sensitive data in state.
- *
  * ## Example Usage
  *
  * ```typescript

--- a/sdk/nodejs/bigquery/connection.ts
+++ b/sdk/nodejs/bigquery/connection.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Bigquery Connection Cloud Resource
  *

--- a/sdk/nodejs/bigquery/dataTransferConfig.ts
+++ b/sdk/nodejs/bigquery/dataTransferConfig.ts
@@ -16,10 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Bigquerydatatransfer Config Scheduled Query
  *

--- a/sdk/nodejs/certificatemanager/certificate.ts
+++ b/sdk/nodejs/certificatemanager/certificate.ts
@@ -9,10 +9,6 @@ import * as utilities from "../utilities";
 /**
  * Certificate represents a HTTP-reachable backend for a Certificate.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Certificate Manager Google Managed Certificate Dns
  *

--- a/sdk/nodejs/certificatemanager/trustConfig.ts
+++ b/sdk/nodejs/certificatemanager/trustConfig.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Certificate Manager Trust Config
  *

--- a/sdk/nodejs/compute/backendBucketSignedUrlKey.ts
+++ b/sdk/nodejs/compute/backendBucketSignedUrlKey.ts
@@ -13,9 +13,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  *
- * > **Warning:** All arguments including `keyValue` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Backend Bucket Signed Url Key
  *

--- a/sdk/nodejs/compute/backendService.ts
+++ b/sdk/nodejs/compute/backendService.ts
@@ -20,9 +20,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
  *
- * > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Backend Service Cache Include Http Headers
  *

--- a/sdk/nodejs/compute/backendServiceSignedUrlKey.ts
+++ b/sdk/nodejs/compute/backendServiceSignedUrlKey.ts
@@ -13,9 +13,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
  *
- * > **Warning:** All arguments including `keyValue` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  *
  * ## Import

--- a/sdk/nodejs/compute/caExternalAccountKey.ts
+++ b/sdk/nodejs/compute/caExternalAccountKey.ts
@@ -21,10 +21,6 @@ import * as utilities from "../utilities";
  * The EAB secret is invalidated if you don't use it within 7 days.
  * The ACME account registered by using an EAB secret has no expiration.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `keyId`, `b64MacKey`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Public Ca External Account Key
  *

--- a/sdk/nodejs/compute/regionBackendService.ts
+++ b/sdk/nodejs/compute/regionBackendService.ts
@@ -16,10 +16,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  *
  * ## Import

--- a/sdk/nodejs/compute/regionDisk.ts
+++ b/sdk/nodejs/compute/regionDisk.ts
@@ -29,9 +29,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
  *
- * > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Region Disk Basic
  *

--- a/sdk/nodejs/compute/regionSslCertificate.ts
+++ b/sdk/nodejs/compute/regionSslCertificate.ts
@@ -15,9 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  *
- * > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Region Ssl Certificate Basic
  *

--- a/sdk/nodejs/compute/securityScanConfig.ts
+++ b/sdk/nodejs/compute/securityScanConfig.ts
@@ -15,8 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
  *
- * > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
- *
  * ## Example Usage
  * ### Scan Config Basic
  *

--- a/sdk/nodejs/compute/snapshot.ts
+++ b/sdk/nodejs/compute/snapshot.ts
@@ -26,9 +26,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
  *
- * > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Snapshot Basic
  *

--- a/sdk/nodejs/compute/sslcertificate.ts
+++ b/sdk/nodejs/compute/sslcertificate.ts
@@ -15,9 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
  *
- * > **Warning:** All arguments including `certificate` and `privateKey` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Ssl Certificate Basic
  *

--- a/sdk/nodejs/compute/vpntunnel.ts
+++ b/sdk/nodejs/compute/vpntunnel.ts
@@ -14,9 +14,6 @@ import * as utilities from "../utilities";
  *     * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
  *     * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
  *
- * > **Warning:** All arguments including `sharedSecret` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Vpn Tunnel Basic
  *

--- a/sdk/nodejs/databasemigrationservice/connectionProfile.ts
+++ b/sdk/nodejs/databasemigrationservice/connectionProfile.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Database Migration](https://cloud.google.com/database-migration/docs/)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Database Migration Service Connection Profile Cloudsql
  *

--- a/sdk/nodejs/dataloss/preventionDeidentifyTemplate.ts
+++ b/sdk/nodejs/dataloss/preventionDeidentifyTemplate.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Dlp Deidentify Template Image Transformations
  *

--- a/sdk/nodejs/datastream/connectionProfile.ts
+++ b/sdk/nodejs/datastream/connectionProfile.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Datastream Connection Profile Basic
  *

--- a/sdk/nodejs/diagflow/cxAgent.ts
+++ b/sdk/nodejs/diagflow/cxAgent.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Dialogflowcx Agent Full
  *

--- a/sdk/nodejs/edgecontainer/cluster.ts
+++ b/sdk/nodejs/edgecontainer/cluster.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `clusterCaCertificate`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Edgecontainer Cluster
  *

--- a/sdk/nodejs/iam/workforcePoolProvider.ts
+++ b/sdk/nodejs/iam/workforcePoolProvider.ts
@@ -18,10 +18,6 @@ import * as utilities from "../utilities";
  * > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
  * billing/quota project. The account team notifies you when the project is granted access.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Iam Workforce Pool Provider Saml Basic
  *

--- a/sdk/nodejs/iap/client.ts
+++ b/sdk/nodejs/iap/client.ts
@@ -17,9 +17,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
  *
- * > **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Iap Client
  *

--- a/sdk/nodejs/kms/secretCiphertext.ts
+++ b/sdk/nodejs/kms/secretCiphertext.ts
@@ -18,8 +18,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
  *
- * > **Warning:** All arguments including `plaintext` and `additionalAuthenticatedData` will be stored in the raw state as plain-text.
- *
  * ## Example Usage
  * ### Kms Secret Ciphertext Basic
  *

--- a/sdk/nodejs/monitoring/notificationChannel.ts
+++ b/sdk/nodejs/monitoring/notificationChannel.ts
@@ -31,9 +31,6 @@ import * as utilities from "../utilities";
  *     * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
  *     * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
  *
- * > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Notification Channel Basic
  *

--- a/sdk/nodejs/monitoring/uptimeCheckConfig.ts
+++ b/sdk/nodejs/monitoring/uptimeCheckConfig.ts
@@ -15,9 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
  *
- * > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Uptime Check Config Http
  *

--- a/sdk/nodejs/networkservices/edgeCacheKeyset.ts
+++ b/sdk/nodejs/networkservices/edgeCacheKeyset.ts
@@ -15,10 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `public_key.public_key.value`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Network Services Edge Cache Keyset Basic
  *

--- a/sdk/nodejs/secretmanager/secretVersion.ts
+++ b/sdk/nodejs/secretmanager/secretVersion.ts
@@ -7,9 +7,6 @@ import * as utilities from "../utilities";
 /**
  * A secret version resource.
  *
- * > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Secret Version Basic
  *

--- a/sdk/nodejs/sql/sourceRepresentationInstance.ts
+++ b/sdk/nodejs/sql/sourceRepresentationInstance.ts
@@ -11,10 +11,6 @@ import * as utilities from "../utilities";
  * contains no data, requires no configuration or maintenance, and does not
  * affect billing. You cannot update the source representation instance.
  *
- * > **Warning:** All arguments including the following potentially sensitive
- * values will be stored in the raw state as plain text: `on_premises_configuration.password`.
- * Read more about sensitive data in state.
- *
  * ## Example Usage
  * ### Sql Source Representation Instance Basic
  *

--- a/sdk/nodejs/sql/sslCert.ts
+++ b/sdk/nodejs/sql/sslCert.ts
@@ -7,8 +7,6 @@ import * as utilities from "../utilities";
 /**
  * Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
  *
- * > **Note:** All arguments including the private key will be stored in the raw state as plain-text
- *
  * ## Example Usage
  *
  * Example creating a SQL Client Certificate.

--- a/sdk/nodejs/sql/user.ts
+++ b/sdk/nodejs/sql/user.ts
@@ -9,8 +9,6 @@ import * as utilities from "../utilities";
 /**
  * Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
  *
- * > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
- *
  * ## Import
  *
  * SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {

--- a/sdk/nodejs/storage/hmacKey.ts
+++ b/sdk/nodejs/storage/hmacKey.ts
@@ -15,12 +15,6 @@ import * as utilities from "../utilities";
  * * How-to Guides
  *     * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
  *
- * > **Warning:** All arguments including the `secret` value will be stored in the raw
- * state as plain-text. On import, the `secret` value will not be retrieved.
- *
- * > **Warning:** All arguments including `secret` will be stored in the raw
- * state as plain-text.
- *
  * ## Example Usage
  * ### Storage Hmac Key
  *

--- a/sdk/python/pulumi_gcp/activedirectory/domain_trust.py
+++ b/sdk/python/pulumi_gcp/activedirectory/domain_trust.py
@@ -332,10 +332,6 @@ class DomainTrust(pulumi.CustomResource):
         * How-to Guides
             * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_handshake_secret`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Active Directory Domain Trust Basic
 
@@ -409,10 +405,6 @@ class DomainTrust(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/managed-microsoft-ad/reference/rest/v1/projects.locations.global.domains/attachTrust)
         * How-to Guides
             * [Active Directory Trust](https://cloud.google.com/managed-microsoft-ad/docs/create-one-way-trust)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_handshake_secret`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Active Directory Domain Trust Basic

--- a/sdk/python/pulumi_gcp/alloydb/cluster.py
+++ b/sdk/python/pulumi_gcp/alloydb/cluster.py
@@ -966,10 +966,6 @@ class Cluster(pulumi.CustomResource):
         * How-to Guides
             * [AlloyDB](https://cloud.google.com/alloydb/docs/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `initial_user.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Alloydb Cluster Basic
 
@@ -1214,10 +1210,6 @@ class Cluster(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.clusters/create)
         * How-to Guides
             * [AlloyDB](https://cloud.google.com/alloydb/docs/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `initial_user.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Alloydb Cluster Basic

--- a/sdk/python/pulumi_gcp/appengine/application.py
+++ b/sdk/python/pulumi_gcp/appengine/application.py
@@ -417,9 +417,6 @@ class Application(pulumi.CustomResource):
            successfully deleted; this is a limitation of the provider, and will go away in the future.
            This provider is not able to delete App Engine applications.
 
-        > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-        state as plain-text. Read more about sensitive data in state.
-
         ## Example Usage
 
         ```python
@@ -481,9 +478,6 @@ class Application(pulumi.CustomResource):
            entire project to delete the application. This provider will report the application has been
            successfully deleted; this is a limitation of the provider, and will go away in the future.
            This provider is not able to delete App Engine applications.
-
-        > **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
-        state as plain-text. Read more about sensitive data in state.
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/bigquery/connection.py
+++ b/sdk/python/pulumi_gcp/bigquery/connection.py
@@ -456,10 +456,6 @@ class Connection(pulumi.CustomResource):
         * How-to Guides
             * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Bigquery Connection Cloud Resource
 
@@ -676,10 +672,6 @@ class Connection(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection/rest/v1/projects.locations.connections/create)
         * How-to Guides
             * [Cloud SQL federated queries](https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cloud_sql.credential.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Bigquery Connection Cloud Resource

--- a/sdk/python/pulumi_gcp/bigquery/data_transfer_config.py
+++ b/sdk/python/pulumi_gcp/bigquery/data_transfer_config.py
@@ -652,10 +652,6 @@ class DataTransferConfig(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Bigquerydatatransfer Config Scheduled Query
 
@@ -767,10 +763,6 @@ class DataTransferConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs/create)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `sensitive_params.secret_access_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Bigquerydatatransfer Config Scheduled Query

--- a/sdk/python/pulumi_gcp/certificatemanager/certificate.py
+++ b/sdk/python/pulumi_gcp/certificatemanager/certificate.py
@@ -416,10 +416,6 @@ class Certificate(pulumi.CustomResource):
         """
         Certificate represents a HTTP-reachable backend for a Certificate.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Certificate Manager Google Managed Certificate Dns
 
@@ -708,10 +704,6 @@ class Certificate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Certificate represents a HTTP-reachable backend for a Certificate.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `self_managed.certificate_pem`, `self_managed.private_key_pem`, `self_managed.pem_private_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Certificate Manager Google Managed Certificate Dns

--- a/sdk/python/pulumi_gcp/certificatemanager/trust_config.py
+++ b/sdk/python/pulumi_gcp/certificatemanager/trust_config.py
@@ -347,10 +347,6 @@ class TrustConfig(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Certificate Manager Trust Config
 
@@ -429,10 +425,6 @@ class TrustConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/certificate-manager/docs/reference/certificate-manager/rest/v1/projects.locations.trustConfigs/create)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/certificate-manager/docs)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `trust_stores.trust_stores.trust_anchors.trust_anchors.pem_certificate`, `trust_stores.trust_stores.intermediate_cas.intermediate_cas.pem_certificate`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Certificate Manager Trust Config

--- a/sdk/python/pulumi_gcp/compute/backend_bucket_signed_url_key.py
+++ b/sdk/python/pulumi_gcp/compute/backend_bucket_signed_url_key.py
@@ -196,9 +196,6 @@ class BackendBucketSignedUrlKey(pulumi.CustomResource):
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Backend Bucket Signed Url Key
 
@@ -249,9 +246,6 @@ class BackendBucketSignedUrlKey(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/backendBuckets)
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
-
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Backend Bucket Signed Url Key

--- a/sdk/python/pulumi_gcp/compute/backend_service.py
+++ b/sdk/python/pulumi_gcp/compute/backend_service.py
@@ -1274,9 +1274,6 @@ class BackendService(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
 
-        > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Backend Service Cache Include Http Headers
 
@@ -1487,9 +1484,6 @@ class BackendService(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/v1/backendServices)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
-
-        > **Warning:** All arguments including `iap.oauth2_client_secret` and `iap.oauth2_client_secret_sha256` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Backend Service Cache Include Http Headers

--- a/sdk/python/pulumi_gcp/compute/backend_service_signed_url_key.py
+++ b/sdk/python/pulumi_gcp/compute/backend_service_signed_url_key.py
@@ -196,9 +196,6 @@ class BackendServiceSignedUrlKey(pulumi.CustomResource):
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
 
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
 
         ## Import
@@ -232,9 +229,6 @@ class BackendServiceSignedUrlKey(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices)
         * How-to Guides
             * [Using Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls/)
-
-        > **Warning:** All arguments including `key_value` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/compute/ca_external_account_key.py
+++ b/sdk/python/pulumi_gcp/compute/ca_external_account_key.py
@@ -174,10 +174,6 @@ class CaExternalAccountKey(pulumi.CustomResource):
         The EAB secret is invalidated if you don't use it within 7 days.
         The ACME account registered by using an EAB secret has no expiration.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Public Ca External Account Key
 
@@ -220,10 +216,6 @@ class CaExternalAccountKey(pulumi.CustomResource):
         You must use an EAB secret within 7 days of obtaining it.
         The EAB secret is invalidated if you don't use it within 7 days.
         The ACME account registered by using an EAB secret has no expiration.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `key_id`, `b64_mac_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Public Ca External Account Key

--- a/sdk/python/pulumi_gcp/compute/region_backend_service.py
+++ b/sdk/python/pulumi_gcp/compute/region_backend_service.py
@@ -1197,10 +1197,6 @@ class RegionBackendService(pulumi.CustomResource):
         * How-to Guides
             * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-        Read more about sensitive data in state.
-
         ## Example Usage
 
         ## Import
@@ -1336,10 +1332,6 @@ class RegionBackendService(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/latest/regionBackendServices)
         * How-to Guides
             * [Internal TCP/UDP Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `iap.oauth2_client_secret`, `iap.oauth2_client_secret_sha256`.
-        Read more about sensitive data in state.
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/compute/region_disk.py
+++ b/sdk/python/pulumi_gcp/compute/region_disk.py
@@ -1022,9 +1022,6 @@ class RegionDisk(pulumi.CustomResource):
         * How-to Guides
             * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
 
-        > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Region Disk Basic
 
@@ -1233,9 +1230,6 @@ class RegionDisk(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionDisks)
         * How-to Guides
             * [Adding or Resizing Regional Persistent Disks](https://cloud.google.com/compute/docs/disks/regional-persistent-disk)
-
-        > **Warning:** All arguments including `disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Region Disk Basic

--- a/sdk/python/pulumi_gcp/compute/region_ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/region_ssl_certificate.py
@@ -409,9 +409,6 @@ class RegionSslCertificate(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Region Ssl Certificate Basic
 
@@ -526,9 +523,6 @@ class RegionSslCertificate(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/regionSslCertificates)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
-
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Region Ssl Certificate Basic

--- a/sdk/python/pulumi_gcp/compute/security_scan_config.py
+++ b/sdk/python/pulumi_gcp/compute/security_scan_config.py
@@ -446,8 +446,6 @@ class SecurityScanConfig(pulumi.CustomResource):
         * How-to Guides
             * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
 
-        > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
-
         ## Example Usage
         ### Scan Config Basic
 
@@ -528,8 +526,6 @@ class SecurityScanConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/security-scanner/docs/reference/rest/v1beta/projects.scanConfigs)
         * How-to Guides
             * [Using Cloud Security Scanner](https://cloud.google.com/security-scanner/docs/scanning)
-
-        > **Warning:** All arguments including `authentication.google_account.password` and `authentication.custom_account.password` will be stored in the raw state as plain-text.
 
         ## Example Usage
         ### Scan Config Basic

--- a/sdk/python/pulumi_gcp/compute/snapshot.py
+++ b/sdk/python/pulumi_gcp/compute/snapshot.py
@@ -662,9 +662,6 @@ class Snapshot(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
 
-        > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Snapshot Basic
 
@@ -802,9 +799,6 @@ class Snapshot(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/snapshots)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/compute/docs/disks/create-snapshots)
-
-        > **Warning:** All arguments including `snapshot_encryption_key.raw_key` and `source_disk_encryption_key.raw_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Snapshot Basic

--- a/sdk/python/pulumi_gcp/compute/ssl_certificate.py
+++ b/sdk/python/pulumi_gcp/compute/ssl_certificate.py
@@ -372,9 +372,6 @@ class SSLCertificate(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
 
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Ssl Certificate Basic
 
@@ -481,9 +478,6 @@ class SSLCertificate(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates)
-
-        > **Warning:** All arguments including `certificate` and `private_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Ssl Certificate Basic

--- a/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
+++ b/sdk/python/pulumi_gcp/compute/vpn_tunnel.py
@@ -845,9 +845,6 @@ class VPNTunnel(pulumi.CustomResource):
             * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
             * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
 
-        > **Warning:** All arguments including `shared_secret` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Vpn Tunnel Basic
 
@@ -982,9 +979,6 @@ class VPNTunnel(pulumi.CustomResource):
         * How-to Guides
             * [Cloud VPN Overview](https://cloud.google.com/vpn/docs/concepts/overview)
             * [Networks and Tunnel Routing](https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)
-
-        > **Warning:** All arguments including `shared_secret` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Vpn Tunnel Basic

--- a/sdk/python/pulumi_gcp/databasemigrationservice/connection_profile.py
+++ b/sdk/python/pulumi_gcp/databasemigrationservice/connection_profile.py
@@ -537,10 +537,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * How-to Guides
             * [Database Migration](https://cloud.google.com/database-migration/docs/)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Database Migration Service Connection Profile Cloudsql
 
@@ -742,10 +738,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/database-migration/docs/reference/rest/v1/projects.locations.connectionProfiles/create)
         * How-to Guides
             * [Database Migration](https://cloud.google.com/database-migration/docs/)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `mysql.password`, `mysql.ssl.client_key`, `mysql.ssl.client_certificate`, `mysql.ssl.ca_certificate`, `postgresql.password`, `postgresql.ssl.client_key`, `postgresql.ssl.client_certificate`, `postgresql.ssl.ca_certificate`, `oracle.password`, `oracle.ssl.client_key`, `oracle.ssl.client_certificate`, `oracle.ssl.ca_certificate`, `oracle.forward_ssh_connectivity.password`, `oracle.forward_ssh_connectivity.private_key`, `cloudsql.settings.root_password`, `alloydb.settings.initial_user.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Database Migration Service Connection Profile Cloudsql

--- a/sdk/python/pulumi_gcp/dataloss/prevention_deidentify_template.py
+++ b/sdk/python/pulumi_gcp/dataloss/prevention_deidentify_template.py
@@ -283,10 +283,6 @@ class PreventionDeidentifyTemplate(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Dlp Deidentify Template Image Transformations
 
@@ -374,10 +370,6 @@ class PreventionDeidentifyTemplate(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dlp/docs/concepts-templates)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_replace_ffx_fpe_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_hash_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.date_shift_config.crypto_key.unwrapped.key`, `deidentify_config.record_transformations.field_transformations.field_transformations.info_type_transformations.transformations.transformations.primitive_transformation.crypto_deterministic_config.crypto_key.unwrapped.key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Dlp Deidentify Template Image Transformations

--- a/sdk/python/pulumi_gcp/datastream/connection_profile.py
+++ b/sdk/python/pulumi_gcp/datastream/connection_profile.py
@@ -535,10 +535,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Datastream Connection Profile Basic
 
@@ -723,10 +719,6 @@ class ConnectionProfile(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.connectionProfiles)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/datastream/docs/create-connection-profiles)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oracle_profile.password`, `mysql_profile.password`, `mysql_profile.ssl_config.client_key`, `mysql_profile.ssl_config.client_certificate`, `mysql_profile.ssl_config.ca_certificate`, `postgresql_profile.password`, `forward_ssh_connectivity.password`, `forward_ssh_connectivity.private_key`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Datastream Connection Profile Basic

--- a/sdk/python/pulumi_gcp/diagflow/cx_agent.py
+++ b/sdk/python/pulumi_gcp/diagflow/cx_agent.py
@@ -623,10 +623,6 @@ class CxAgent(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Dialogflowcx Agent Full
 
@@ -760,10 +756,6 @@ class CxAgent(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/projects.locations.agents)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/dialogflow/cx/docs)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `git_integration_settings.github_settings.access_token`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Dialogflowcx Agent Full

--- a/sdk/python/pulumi_gcp/edgecontainer/cluster.py
+++ b/sdk/python/pulumi_gcp/edgecontainer/cluster.py
@@ -805,10 +805,6 @@ class Cluster(pulumi.CustomResource):
         * How-to Guides
             * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cluster_ca_certificate`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Edgecontainer Cluster
 
@@ -977,10 +973,6 @@ class Cluster(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/distributed-cloud/edge/latest/docs/reference/container/rest/v1/projects.locations.clusters)
         * How-to Guides
             * [Create and manage clusters](https://cloud.google.com/distributed-cloud/edge/latest/docs/clusters)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `cluster_ca_certificate`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Edgecontainer Cluster

--- a/sdk/python/pulumi_gcp/iam/workforce_pool_provider.py
+++ b/sdk/python/pulumi_gcp/iam/workforce_pool_provider.py
@@ -642,10 +642,6 @@ class WorkforcePoolProvider(pulumi.CustomResource):
         > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
         billing/quota project. The account team notifies you when the project is granted access.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Iam Workforce Pool Provider Saml Basic
 
@@ -870,10 +866,6 @@ class WorkforcePoolProvider(pulumi.CustomResource):
 
         > **Note:** Ask your Google Cloud account team to request access to workforce identity federation for your
         billing/quota project. The account team notifies you when the project is granted access.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `oidc.client_secret.value.plain_text`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Iam Workforce Pool Provider Saml Basic

--- a/sdk/python/pulumi_gcp/iap/client.py
+++ b/sdk/python/pulumi_gcp/iap/client.py
@@ -164,9 +164,6 @@ class Client(pulumi.CustomResource):
         * How-to Guides
             * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
 
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Iap Client
 
@@ -237,9 +234,6 @@ class Client(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/iap/docs/reference/rest/v1/projects.brands.identityAwareProxyClients)
         * How-to Guides
             * [Setting up IAP Client](https://cloud.google.com/iap/docs/authentication-howto)
-
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Iap Client

--- a/sdk/python/pulumi_gcp/kms/secret_ciphertext.py
+++ b/sdk/python/pulumi_gcp/kms/secret_ciphertext.py
@@ -184,8 +184,6 @@ class SecretCiphertext(pulumi.CustomResource):
         * How-to Guides
             * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
 
-        > **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
-
         ## Example Usage
         ### Kms Secret Ciphertext Basic
 
@@ -252,8 +250,6 @@ class SecretCiphertext(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/encrypt)
         * How-to Guides
             * [Encrypting and decrypting data with a symmetric key](https://cloud.google.com/kms/docs/encrypt-decrypt)
-
-        > **Warning:** All arguments including `plaintext` and `additional_authenticated_data` will be stored in the raw state as plain-text.
 
         ## Example Usage
         ### Kms Secret Ciphertext Basic

--- a/sdk/python/pulumi_gcp/monitoring/notification_channel.py
+++ b/sdk/python/pulumi_gcp/monitoring/notification_channel.py
@@ -468,9 +468,6 @@ class NotificationChannel(pulumi.CustomResource):
             * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
             * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
 
-        > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Notification Channel Basic
 
@@ -580,9 +577,6 @@ class NotificationChannel(pulumi.CustomResource):
         * How-to Guides
             * [Notification Options](https://cloud.google.com/monitoring/support/notification-options)
             * [Monitoring API Documentation](https://cloud.google.com/monitoring/api/v3/)
-
-        > **Warning:** All arguments including `sensitive_labels.auth_token`, `sensitive_labels.password`, and `sensitive_labels.service_key` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Notification Channel Basic

--- a/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
+++ b/sdk/python/pulumi_gcp/monitoring/uptime_check_config.py
@@ -555,9 +555,6 @@ class UptimeCheckConfig(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
 
-        > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Uptime Check Config Http
 
@@ -796,9 +793,6 @@ class UptimeCheckConfig(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.uptimeCheckConfigs)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/monitoring/uptime-checks/)
-
-        > **Warning:** All arguments including `http_check.auth_info.password` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Uptime Check Config Http

--- a/sdk/python/pulumi_gcp/networkservices/edge_cache_keyset.py
+++ b/sdk/python/pulumi_gcp/networkservices/edge_cache_keyset.py
@@ -348,10 +348,6 @@ class EdgeCacheKeyset(pulumi.CustomResource):
         * How-to Guides
             * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `public_key.public_key.value`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Network Services Edge Cache Keyset Basic
 
@@ -462,10 +458,6 @@ class EdgeCacheKeyset(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/media-cdn/docs/reference/rest/v1/projects.locations.edgeCacheKeysets)
         * How-to Guides
             * [Create keysets](https://cloud.google.com/media-cdn/docs/create-keyset)
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `public_key.public_key.value`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Network Services Edge Cache Keyset Basic

--- a/sdk/python/pulumi_gcp/secretmanager/secret_version.py
+++ b/sdk/python/pulumi_gcp/secretmanager/secret_version.py
@@ -301,9 +301,6 @@ class SecretVersion(pulumi.CustomResource):
         """
         A secret version resource.
 
-        > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Secret Version Basic
 
@@ -426,9 +423,6 @@ class SecretVersion(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A secret version resource.
-
-        > **Warning:** All arguments including `payload.secret_data` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Secret Version Basic

--- a/sdk/python/pulumi_gcp/sql/source_representation_instance.py
+++ b/sdk/python/pulumi_gcp/sql/source_representation_instance.py
@@ -466,10 +466,6 @@ class SourceRepresentationInstance(pulumi.CustomResource):
         contains no data, requires no configuration or maintenance, and does not
         affect billing. You cannot update the source representation instance.
 
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-        Read more about sensitive data in state.
-
         ## Example Usage
         ### Sql Source Representation Instance Basic
 
@@ -561,10 +557,6 @@ class SourceRepresentationInstance(pulumi.CustomResource):
         Cloud Console and appears the same as a regular Cloud SQL instance, but it
         contains no data, requires no configuration or maintenance, and does not
         affect billing. You cannot update the source representation instance.
-
-        > **Warning:** All arguments including the following potentially sensitive
-        values will be stored in the raw state as plain text: `on_premises_configuration.password`.
-        Read more about sensitive data in state.
 
         ## Example Usage
         ### Sql Source Representation Instance Basic

--- a/sdk/python/pulumi_gcp/sql/ssl_cert.py
+++ b/sdk/python/pulumi_gcp/sql/ssl_cert.py
@@ -261,8 +261,6 @@ class SslCert(pulumi.CustomResource):
         """
         Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
 
-        > **Note:** All arguments including the private key will be stored in the raw state as plain-text
-
         ## Example Usage
 
         Example creating a SQL Client Certificate.
@@ -304,8 +302,6 @@ class SslCert(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
-
-        > **Note:** All arguments including the private key will be stored in the raw state as plain-text
 
         ## Example Usage
 

--- a/sdk/python/pulumi_gcp/sql/user.py
+++ b/sdk/python/pulumi_gcp/sql/user.py
@@ -369,8 +369,6 @@ class User(pulumi.CustomResource):
         """
         Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
 
-        > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-
         ## Import
 
         SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g. * `{{project_id}}/{{instance}}/{{host}}/{{name}}` SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g. * `{{project_id}}/{{instance}}/{{name}}` In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For exampletf MySQL database import {
@@ -433,8 +431,6 @@ class User(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
-
-        > **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 
         ## Import
 

--- a/sdk/python/pulumi_gcp/storage/hmac_key.py
+++ b/sdk/python/pulumi_gcp/storage/hmac_key.py
@@ -232,12 +232,6 @@ class HmacKey(pulumi.CustomResource):
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
 
-        > **Warning:** All arguments including the `secret` value will be stored in the raw
-        state as plain-text. On import, the `secret` value will not be retrieved.
-
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
-
         ## Example Usage
         ### Storage Hmac Key
 
@@ -303,12 +297,6 @@ class HmacKey(pulumi.CustomResource):
         * [API documentation](https://cloud.google.com/storage/docs/json_api/v1/projects/hmacKeys)
         * How-to Guides
             * [Official Documentation](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
-
-        > **Warning:** All arguments including the `secret` value will be stored in the raw
-        state as plain-text. On import, the `secret` value will not be retrieved.
-
-        > **Warning:** All arguments including `secret` will be stored in the raw
-        state as plain-text.
 
         ## Example Usage
         ### Storage Hmac Key


### PR DESCRIPTION
Overhall of https://github.com/pulumi/pulumi-gcp/pull/1376

>  All arguments including the following potentially sensitive values will be stored in the raw state as plain text

While this is true in terraform, that does not apply to Pulumi. I added a function to edit docs that uses two regular expressions to find plain-text warnings and replace them with empty strings.

Fix https://github.com/pulumi/pulumi-gcp/issues/1195