### PR TITLE
Fix: current google_compute_autoscaler token is ...Autoscaler

### DIFF
--- a/provider/cmd/pulumi-resource-gcp/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-gcp/bridge-metadata.json
@@ -4380,7 +4380,7 @@
                 "majorVersion": 7
             },
             "google_compute_autoscaler": {
-                "current": "gcp:compute/autoscalar:Autoscalar",
+                "current": "gcp:compute/autoscalar:Autoscaler",
                 "past": [
                     {
                         "name": "gcp:compute/autoscalar:Autoscalar",

--- a/provider/cmd/pulumi-resource-gcp/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-gcp/bridge-metadata.json
@@ -4380,7 +4380,7 @@
                 "majorVersion": 7
             },
             "google_compute_autoscaler": {
-                "current": "gcp:compute/autoscalar:Autoscaler",
+                "current": "gcp:compute/autoscaler:Autoscaler",
                 "past": [
                     {
                         "name": "gcp:compute/autoscalar:Autoscalar",


### PR DESCRIPTION
The correct current token for google_compute_autoscaler token is Autoscaler not Autoscaler. The version with the typo remains an alias from the past history. 