### PR TITLE
Enroll GCP into PlanState diff strategy

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -215,6 +215,9 @@ func TestBucketBooleanLabel(t *testing.T) {
 }
 
 func TestNodePoolGpuAcceleratorPanic(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
 	replay.ReplaySequence(t, providerServer(t), `
 	[	
 		{

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -213,3 +213,71 @@ func TestBucketBooleanLabel(t *testing.T) {
 	  }
 	]`)
 }
+
+func TestNodePoolGpuAcceleratorPanic(t *testing.T) {
+	replay.ReplaySequence(t, providerServer(t), `
+	[	
+		{
+			"method": "/pulumirpc.ResourceProvider/Configure",
+			"request": {
+			  "variables": {
+			"gcp:config:project": "pulumi-development"
+			  },
+			  "args": {
+			"project": "pulumi-development",
+			"version": "7.2.1"
+			  },
+			  "acceptSecrets": true,
+			  "acceptResources": true,
+			  "sendsOldInputs": true,
+			  "sendsOldInputsToDelete": true
+			},
+			"response": {
+			  "supportsPreview": true
+			}
+		},
+		{
+		"method": "/pulumirpc.ResourceProvider/Create",
+		"request": {
+			"urn": "urn:pulumi:dev::gcp_node_pool::gcp:container/nodePool:NodePool::gpu-node-pool",
+			"properties": {
+				"__defaults": [
+					"name"
+				],
+				"cluster": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				"initialNodeCount": 1,
+				"name": "gpu-node-pool-c90bfc0",
+				"nodeConfig": {
+					"__defaults": [
+						"preemptible",
+						"spot"
+					],
+					"diskSizeGb": 50,
+					"guestAccelerators": [
+						{
+							"__defaults": [],
+							"count": 1,
+							"type": "nvidia-tesla-t4"
+						}
+					],
+					"machineType": "n1-highmem-8",
+					"oauthScopes": [
+						"https://www.googleapis.com/auth/cloud-platform"
+					],
+					"preemptible": false,
+					"spot": false
+				}
+			},
+			"preview": true
+		},
+		"response": {
+			"id": "gpu-node-pool-c90bfc0"
+		},
+		"metadata": {
+			"kind": "resource",
+			"mode": "client",
+			"name": "gcp"
+		}
+	}]`,
+	)
+}

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -271,7 +271,61 @@ func TestNodePoolGpuAcceleratorPanic(t *testing.T) {
 			"preview": true
 		},
 		"response": {
-			"id": "gpu-node-pool-c90bfc0"
+			"properties": {
+				"id": "",
+				"initialNodeCount": 1,
+				"name": "gpu-node-pool-c90bfc0",
+				"nodeConfig": {
+				  "advancedMachineFeatures": null,
+				  "bootDiskKmsKey": "",
+				  "confidentialNodes": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "diskSizeGb": 50,
+				  "diskType": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "effectiveTaints": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "enableConfidentialStorage": false,
+				  "ephemeralStorageConfig": null,
+				  "ephemeralStorageLocalSsdConfig": null,
+				  "fastSocket": null,
+				  "gcfsConfig": null,
+				  "guestAccelerators": [
+					{
+					  "count": 1,
+					  "gpuDriverInstallationConfig": null,
+					  "gpuPartitionSize": "",
+					  "gpuSharingConfig": null,
+					  "type": "nvidia-tesla-t4"
+					}
+				  ],
+				  "gvnic": null,
+				  "hostMaintenancePolicy": null,
+				  "imageType": "",
+				  "kubeletConfig": null,
+				  "labels": {},
+				  "linuxNodeConfig": null,
+				  "localNvmeSsdBlockConfig": null,
+				  "localSsdCount": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "loggingVariant": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "machineType": "n1-highmem-8",
+				  "metadata": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "minCpuPlatform": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "nodeGroup": "",
+				  "oauthScopes": [
+					"https://www.googleapis.com/auth/cloud-platform"
+				  ],
+				  "preemptible": false,
+				  "reservationAffinity": null,
+				  "resourceLabels": {},
+				  "sandboxConfig": null,
+				  "serviceAccount": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "shieldedInstanceConfig": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+				  "soleTenantConfig": null,
+				  "spot": false,
+				  "tags": [],
+				  "taints": [],
+				  "workloadMetadataConfig": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+				},
+				"project": "pulumi-development"
+			  }
 		},
 		"metadata": {
 			"kind": "resource",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -385,7 +385,7 @@ var metadata []byte
 func Provider() tfbridge.ProviderInfo {
 	p := pf.MuxShimWithDisjointgPF(
 		context.Background(),
-		shimv2.NewProvider(gcpProvider.Provider()),
+		shimv2.NewProvider(gcpProvider.Provider(), shimv2.WithDiffStrategy(shimv2.PlanState)),
 		gcpPFProvider.New(version.Version)) // this probably should be TF version but it does not seem to matter
 	prov := tfbridge.ProviderInfo{
 		P:                           p,


### PR DESCRIPTION
Enroll GCP into PlanState diff strategy.

This fixes https://github.com/pulumi/pulumi-gcp/issues/1435.

This PR also has a regression test for it.