### PR TITLE
Stricter integration test settings

### DIFF
--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -30,6 +30,9 @@ func TestAccAppServiceCs(t *testing.T) {
 			ExtraRuntimeValidation: validateAPITest(func(body string) {
 				assert.Equal(t, body, "Hello World!")
 			}),
+
+			// TODO[pulumi/pulumi-gcp#1487] Non-empty diff when refreshing programs using overlay callbacks
+			SkipRefresh: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+//go:build dotnet || all
 // +build dotnet all
 
 package examples
@@ -26,9 +27,6 @@ func TestAccAppServiceCs(t *testing.T) {
 	test := getCSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "serverless-cs"),
-			// One change is known to occur during refresh of the resources in this example:
-			// BucketObject has a source change
-			ExpectRefreshChanges: true,
 			ExtraRuntimeValidation: validateAPITest(func(body string) {
 				assert.Equal(t, body, "Hello World!")
 			}),

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -48,6 +48,9 @@ func TestAccTopic(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "topic"),
+
+			// TODO[pulumi/pulumi-gcp#1487] Non-empty diff when refreshing programs using overlay callbacks
+			SkipRefresh: true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -82,6 +85,9 @@ func TestAccServerless(t *testing.T) {
 			ExtraRuntimeValidation: validateAPITest(func(body string) {
 				assert.Equal(t, "Hello World!", body)
 			}),
+
+			// TODO[pulumi/pulumi-gcp#1487] Non-empty diff when refreshing programs using overlay callbacks
+			SkipRefresh: true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -29,10 +29,6 @@ func TestAccWebserverNode(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "webserver"),
-			// TODO[pulumi/pulumi-terraform#241] This test currently triggers a bug in refresh, so we'll skip
-			// running the refresh step for now.
-			SkipRefresh:   true,
-			RunUpdateTest: true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -43,11 +39,6 @@ func TestAccLoadbalancer(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "loadbalancer"),
-			// TODO[pulumi/pulumi-terraform#241] This test currently triggers a bug in refresh, so we'll skip
-			// running the refresh step for now.
-			SkipRefresh:   true,
-			RunUpdateTest: true,
-			SkipPreview:   true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -57,9 +48,6 @@ func TestAccTopic(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "topic"),
-			// One change is known to occur during refresh of the resources in this example:
-			// * `~  gcp:storage:Bucket f-bucket updated changes: + websites`
-			ExpectRefreshChanges: true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -70,9 +58,6 @@ func TestAccBucket(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "bucket"),
-			// One change is known to occur during refresh of the resources in this example:
-			// * `~  gcp:storage:Bucket f-bucket updated changes: + websites`
-			ExpectRefreshChanges: true,
 			// GCP buckets seem to be eventually consistent, so we need to retry on failure when deploying a cloud function
 			// that uses the bucket as a trigger.
 			RetryFailedSteps: true,
@@ -94,9 +79,6 @@ func TestAccServerless(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "serverless"),
-			// One change is known to occur during refresh of the resources in this example:
-			// * `~  gcp:storage:Bucket f-bucket updated changes: + websites`
-			ExpectRefreshChanges: true,
 			ExtraRuntimeValidation: validateAPITest(func(body string) {
 				assert.Equal(t, "Hello World!", body)
 			}),

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -25,8 +25,7 @@ func getPythonBaseOptions(t *testing.T) integration.ProgramTestOptions {
 func TestAccDatasourcePy(t *testing.T) {
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "datasource-py"),
-			RunUpdateTest: true,
+			Dir: filepath.Join(getCwd(t), "datasource-py"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -35,8 +34,7 @@ func TestAccDatasourcePy(t *testing.T) {
 func TestAccBucketPy(t *testing.T) {
 	test := getPythonBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "bucket-py"),
-			RunUpdateTest: true,
+			Dir: filepath.Join(getCwd(t), "bucket-py"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -57,9 +55,7 @@ func TestAccWebserverPy(t *testing.T) {
 		t.Run(dir, func(t *testing.T) {
 			test := getPythonBaseOptions(t).
 				With(integration.ProgramTestOptions{
-					Dir:                  filepath.Join(getCwd(t), dir),
-					RunUpdateTest:        true,
-					ExpectRefreshChanges: true,
+					Dir: filepath.Join(getCwd(t), dir),
 				})
 
 			integration.ProgramTest(t, &test)


### PR DESCRIPTION
Unlike AWS, there's no indication that GCP has lax testing defaults. This change is a simple pass over existing tests that have relaxed integration settings where they are either removed or confirmed to be necessary and newly correlated to the issue tracker.