### PR TITLE
Add auto-naming for gcp:organizations:Project's project_id

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -338,3 +338,33 @@ func TestNodePoolGpuAcceleratorPanic(t *testing.T) {
 	}]`,
 	)
 }
+
+func TestOrganizationsProjectAutoNaming(t *testing.T) {
+	replay.Replay(t, providerServer(t), `
+{
+    "method": "/pulumirpc.ResourceProvider/Check",
+    "request": {
+        "urn": "urn:pulumi:dev::dev-yaml::gcp:organizations/project:Project::my-proj",
+        "olds": {},
+        "news": {},
+        "randomSeed": "ZgqzJVOmtvl2Ni5Y/2HRvTkquku0LpRubgZVUzBO1nc="
+    },
+    "response": {
+        "inputs": {
+            "__defaults": [
+                "autoCreateNetwork",
+                "name",
+                "projectId"
+            ],
+            "autoCreateNetwork": true,
+            "name": "my-proj",
+            "projectId": "my-proj-760b06d"
+        }
+    },
+    "metadata": {
+        "kind": "resource",
+        "mode": "client",
+        "name": "gcp"
+    }
+}`)
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -318,9 +318,7 @@ func lowercaseAutoName() *tfbridge.SchemaInfo {
 		Separator: "-",
 		Maxlen:    63,
 		Randlen:   7,
-		Transform: func(name string) string {
-			return strings.ToLower(name)
-		},
+		Transform: strings.ToLower,
 	})
 }
 
@@ -928,6 +926,34 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"google_project": {
 				Tok: gcpResource(gcpOrganization, "Project"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// A project ID is a unique string used to differentiate your project from all
+					// others in Google Cloud. After you enter a project name, the Google Cloud
+					// console generates a unique project ID that can be a combination of letters,
+					// numbers, and hyphens. We recommend you use the generated project ID, but you
+					// can edit it during project creation. After the project has been created, the
+					// project ID is permanent.
+
+					// A project ID has the following requirements:
+
+					// - Must be 6 to 30 characters in length.
+					// - Can only contain lowercase letters, numbers, and hyphens.
+					// - Must start with a letter.
+					// - Cannot end with a hyphen.
+					// - Cannot be in use or previously used; this includes deleted projects.
+					// - Cannot contain restricted strings, such as google, null, undefined, and ssl.
+					"project_id": tfbridge.AutoNameWithCustomOptions("",
+						tfbridge.AutoNameOptions{
+							Separator: "-",
+							Maxlen:    30,
+							Randlen:   7,
+							Transform: strings.ToLower,
+						}),
+
+					"name": tfbridge.AutoNameWithCustomOptions("name",
+						// Name is auto-named without any suffix.
+						tfbridge.AutoNameOptions{Randlen: 0}),
+				},
 				Docs: &tfbridge.DocInfo{
 					Source: "google_project.html.markdown",
 				},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -933,15 +933,17 @@ func Provider() tfbridge.ProviderInfo {
 					// numbers, and hyphens. We recommend you use the generated project ID, but you
 					// can edit it during project creation. After the project has been created, the
 					// project ID is permanent.
-
+					//
 					// A project ID has the following requirements:
-
+					//
 					// - Must be 6 to 30 characters in length.
 					// - Can only contain lowercase letters, numbers, and hyphens.
 					// - Must start with a letter.
 					// - Cannot end with a hyphen.
 					// - Cannot be in use or previously used; this includes deleted projects.
 					// - Cannot contain restricted strings, such as google, null, undefined, and ssl.
+					//
+					// From https://cloud.google.com/resource-manager/docs/creating-managing-projects
 					"project_id": tfbridge.AutoNameWithCustomOptions("",
 						tfbridge.AutoNameOptions{
 							Separator: "-",

--- a/sdk/dotnet/AccessContextManager/AccessPolicy.cs
+++ b/sdk/dotnet/AccessContextManager/AccessPolicy.cs
@@ -60,7 +60,6 @@ namespace Pulumi.Gcp.AccessContextManager
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
     ///         OrgId = "123456789",
-    ///         ProjectId = "acm-test-proj-123",
     ///     });
     /// 
     ///     var access_policy = new Gcp.AccessContextManager.AccessPolicy("access-policy", new()

--- a/sdk/dotnet/ActiveDirectory/Peering.cs
+++ b/sdk/dotnet/ActiveDirectory/Peering.cs
@@ -47,7 +47,6 @@ namespace Pulumi.Gcp.ActiveDirectory
     /// 
     ///     var peered_project = new Gcp.Organizations.Project("peered-project", new()
     ///     {
-    ///         ProjectId = "my-peered-project",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     }, new CustomResourceOptions

--- a/sdk/dotnet/Apigee/EnvGroupAttachment.cs
+++ b/sdk/dotnet/Apigee/EnvGroupAttachment.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Gcp.Apigee
     /// {
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "",
     ///         BillingAccount = "",
     ///     });

--- a/sdk/dotnet/Apigee/InstanceAttachment.cs
+++ b/sdk/dotnet/Apigee/InstanceAttachment.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Gcp.Apigee
     /// {
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "",
     ///         BillingAccount = "",
     ///     });

--- a/sdk/dotnet/Apigee/KeystoresAliasesSelfSignedCert.cs
+++ b/sdk/dotnet/Apigee/KeystoresAliasesSelfSignedCert.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Gcp.Apigee
     /// {
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     });

--- a/sdk/dotnet/Apigee/SyncAuthorization.cs
+++ b/sdk/dotnet/Apigee/SyncAuthorization.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Gcp.Apigee
     /// {
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     });

--- a/sdk/dotnet/Apigee/TargetServer.cs
+++ b/sdk/dotnet/Apigee/TargetServer.cs
@@ -31,7 +31,6 @@ namespace Pulumi.Gcp.Apigee
     /// {
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     });

--- a/sdk/dotnet/AppEngine/Application.cs
+++ b/sdk/dotnet/AppEngine/Application.cs
@@ -29,7 +29,6 @@ namespace Pulumi.Gcp.AppEngine
     /// {
     ///     var myProject = new Gcp.Organizations.Project("myProject", new()
     ///     {
-    ///         ProjectId = "your-project-id",
     ///         OrgId = "1234567",
     ///     });
     /// 

--- a/sdk/dotnet/AppEngine/FirewallRule.cs
+++ b/sdk/dotnet/AppEngine/FirewallRule.cs
@@ -32,7 +32,6 @@ namespace Pulumi.Gcp.AppEngine
     /// {
     ///     var myProject = new Gcp.Organizations.Project("myProject", new()
     ///     {
-    ///         ProjectId = "ae-project",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     });

--- a/sdk/dotnet/AppEngine/FlexibleAppVersion.cs
+++ b/sdk/dotnet/AppEngine/FlexibleAppVersion.cs
@@ -37,7 +37,6 @@ namespace Pulumi.Gcp.AppEngine
     /// {
     ///     var myProject = new Gcp.Organizations.Project("myProject", new()
     ///     {
-    ///         ProjectId = "appeng-flex",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     });

--- a/sdk/dotnet/Compute/NetworkAttachment.cs
+++ b/sdk/dotnet/Compute/NetworkAttachment.cs
@@ -41,7 +41,6 @@ namespace Pulumi.Gcp.Compute
     /// 
     ///     var rejectedProducerProject = new Gcp.Organizations.Project("rejectedProducerProject", new()
     ///     {
-    ///         ProjectId = "prj-rejected",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     }, new CustomResourceOptions
@@ -51,7 +50,6 @@ namespace Pulumi.Gcp.Compute
     /// 
     ///     var acceptedProducerProject = new Gcp.Organizations.Project("acceptedProducerProject", new()
     ///     {
-    ///         ProjectId = "prj-accepted",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///     }, new CustomResourceOptions

--- a/sdk/dotnet/Compute/NodeGroup.cs
+++ b/sdk/dotnet/Compute/NodeGroup.cs
@@ -132,7 +132,6 @@ namespace Pulumi.Gcp.Compute
     /// {
     ///     var guestProject = new Gcp.Organizations.Project("guestProject", new()
     ///     {
-    ///         ProjectId = "project-id",
     ///         OrgId = "123456789",
     ///     });
     /// 

--- a/sdk/dotnet/Diagflow/Intent.cs
+++ b/sdk/dotnet/Diagflow/Intent.cs
@@ -62,7 +62,6 @@ namespace Pulumi.Gcp.Diagflow
     /// {
     ///     var agentProjectProject = new Gcp.Organizations.Project("agentProjectProject", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///     });
     /// 

--- a/sdk/dotnet/Firebase/DatabaseInstance.cs
+++ b/sdk/dotnet/Firebase/DatabaseInstance.cs
@@ -69,7 +69,6 @@ namespace Pulumi.Gcp.Firebase
     /// {
     ///     var defaultProject = new Gcp.Organizations.Project("defaultProject", new()
     ///     {
-    ///         ProjectId = "rtdb-project",
     ///         OrgId = "123456789",
     ///         Labels = 
     ///         {

--- a/sdk/dotnet/Firebase/Project.cs
+++ b/sdk/dotnet/Firebase/Project.cs
@@ -34,7 +34,6 @@ namespace Pulumi.Gcp.Firebase
     /// {
     ///     var defaultProject = new Gcp.Organizations.Project("defaultProject", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///         Labels = 
     ///         {

--- a/sdk/dotnet/Folder/AccessApprovalSettings.cs
+++ b/sdk/dotnet/Folder/AccessApprovalSettings.cs
@@ -70,7 +70,6 @@ namespace Pulumi.Gcp.Folder
     /// 
     ///     var myProject = new Gcp.Organizations.Project("myProject", new()
     ///     {
-    ///         ProjectId = "your-project-id",
     ///         FolderId = myFolder.Name,
     ///     });
     /// 

--- a/sdk/dotnet/Iap/Brand.cs
+++ b/sdk/dotnet/Iap/Brand.cs
@@ -23,7 +23,6 @@ namespace Pulumi.Gcp.Iap
     /// {
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///     });
     /// 

--- a/sdk/dotnet/Iap/Client.cs
+++ b/sdk/dotnet/Iap/Client.cs
@@ -35,7 +35,6 @@ namespace Pulumi.Gcp.Iap
     /// {
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///     });
     /// 

--- a/sdk/dotnet/IdentityPlatform/Config.cs
+++ b/sdk/dotnet/IdentityPlatform/Config.cs
@@ -37,7 +37,6 @@ namespace Pulumi.Gcp.IdentityPlatform
     /// {
     ///     var defaultProject = new Gcp.Organizations.Project("defaultProject", new()
     ///     {
-    ///         ProjectId = "my-project",
     ///         OrgId = "123456789",
     ///         BillingAccount = "000000-0000000-0000000-000000",
     ///         Labels = 

--- a/sdk/dotnet/Monitoring/MonitoredProject.cs
+++ b/sdk/dotnet/Monitoring/MonitoredProject.cs
@@ -36,7 +36,6 @@ namespace Pulumi.Gcp.Monitoring
     /// 
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
-    ///         ProjectId = "m-id",
     ///         OrgId = "123456789",
     ///     });
     /// 

--- a/sdk/dotnet/OrgPolicy/Policy.cs
+++ b/sdk/dotnet/OrgPolicy/Policy.cs
@@ -30,7 +30,6 @@ namespace Pulumi.Gcp.OrgPolicy
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
     ///         OrgId = "123456789",
-    ///         ProjectId = "id",
     ///     });
     /// 
     ///     var primary = new Gcp.OrgPolicy.Policy("primary", new()
@@ -118,7 +117,6 @@ namespace Pulumi.Gcp.OrgPolicy
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
     ///         OrgId = "123456789",
-    ///         ProjectId = "id",
     ///     });
     /// 
     ///     var primary = new Gcp.OrgPolicy.Policy("primary", new()

--- a/sdk/dotnet/Organizations/AccessApprovalSettings.cs
+++ b/sdk/dotnet/Organizations/AccessApprovalSettings.cs
@@ -63,7 +63,6 @@ namespace Pulumi.Gcp.Organizations
     /// {
     ///     var myProject = new Gcp.Organizations.Project("myProject", new()
     ///     {
-    ///         ProjectId = "your-project-id",
     ///         OrgId = "123456789",
     ///     });
     /// 

--- a/sdk/dotnet/Organizations/GetBillingAccount.cs
+++ b/sdk/dotnet/Organizations/GetBillingAccount.cs
@@ -30,7 +30,6 @@ namespace Pulumi.Gcp.Organizations
         /// 
         ///     var myProject = new Gcp.Organizations.Project("myProject", new()
         ///     {
-        ///         ProjectId = "your-project-id",
         ///         OrgId = "1234567",
         ///         BillingAccount = acct.Apply(getBillingAccountResult =&gt; getBillingAccountResult.Id),
         ///     });
@@ -60,7 +59,6 @@ namespace Pulumi.Gcp.Organizations
         /// 
         ///     var myProject = new Gcp.Organizations.Project("myProject", new()
         ///     {
-        ///         ProjectId = "your-project-id",
         ///         OrgId = "1234567",
         ///         BillingAccount = acct.Apply(getBillingAccountResult =&gt; getBillingAccountResult.Id),
         ///     });

--- a/sdk/dotnet/Organizations/Project.cs
+++ b/sdk/dotnet/Organizations/Project.cs
@@ -41,7 +41,6 @@ namespace Pulumi.Gcp.Organizations
     ///     var myProject = new Gcp.Organizations.Project("myProject", new()
     ///     {
     ///         OrgId = "1234567",
-    ///         ProjectId = "your-project-id",
     ///     });
     /// 
     /// });
@@ -65,7 +64,6 @@ namespace Pulumi.Gcp.Organizations
     /// 
     ///     var myProject_in_a_folder = new Gcp.Organizations.Project("myProject-in-a-folder", new()
     ///     {
-    ///         ProjectId = "your-project-id",
     ///         FolderId = department1.Name,
     ///     });
     /// 
@@ -183,7 +181,7 @@ namespace Pulumi.Gcp.Organizations
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public Project(string name, ProjectArgs args, CustomResourceOptions? options = null)
+        public Project(string name, ProjectArgs? args = null, CustomResourceOptions? options = null)
             : base("gcp:organizations/project:Project", name, args ?? new ProjectArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -288,8 +286,8 @@ namespace Pulumi.Gcp.Organizations
         /// <summary>
         /// The project ID. Changing this forces a new project to be created.
         /// </summary>
-        [Input("projectId", required: true)]
-        public Input<string> ProjectId { get; set; } = null!;
+        [Input("projectId")]
+        public Input<string>? ProjectId { get; set; }
 
         /// <summary>
         /// If true, the resource can be deleted

--- a/sdk/dotnet/Projects/ApiKey.cs
+++ b/sdk/dotnet/Projects/ApiKey.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Gcp.Projects
     /// {
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
-    ///         ProjectId = "app",
     ///         OrgId = "123456789",
     ///     });
     /// 
@@ -74,7 +73,6 @@ namespace Pulumi.Gcp.Projects
     /// {
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
-    ///         ProjectId = "app",
     ///         OrgId = "123456789",
     ///     });
     /// 
@@ -119,7 +117,6 @@ namespace Pulumi.Gcp.Projects
     /// {
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
-    ///         ProjectId = "app",
     ///         OrgId = "123456789",
     ///     });
     /// 
@@ -164,7 +161,6 @@ namespace Pulumi.Gcp.Projects
     /// {
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
-    ///         ProjectId = "app",
     ///         OrgId = "123456789",
     ///     });
     /// 
@@ -188,7 +184,6 @@ namespace Pulumi.Gcp.Projects
     /// {
     ///     var basic = new Gcp.Organizations.Project("basic", new()
     ///     {
-    ///         ProjectId = "app",
     ///         OrgId = "123456789",
     ///     });
     /// 

--- a/sdk/dotnet/Projects/UsageExportBucket.cs
+++ b/sdk/dotnet/Projects/UsageExportBucket.cs
@@ -41,7 +41,6 @@ namespace Pulumi.Gcp.Projects
     ///     var myProject = new Gcp.Organizations.Project("myProject", new()
     ///     {
     ///         OrgId = "1234567",
-    ///         ProjectId = "your-project-id",
     ///     });
     /// 
     /// });
@@ -65,7 +64,6 @@ namespace Pulumi.Gcp.Projects
     /// 
     ///     var myProject_in_a_folder = new Gcp.Organizations.Project("myProject-in-a-folder", new()
     ///     {
-    ///         ProjectId = "your-project-id",
     ///         FolderId = department1.Name,
     ///     });
     /// 

--- a/sdk/dotnet/ResourceManager/Lien.cs
+++ b/sdk/dotnet/ResourceManager/Lien.cs
@@ -23,10 +23,7 @@ namespace Pulumi.Gcp.ResourceManager
     /// 
     /// return await Deployment.RunAsync(() =&gt; 
     /// {
-    ///     var project = new Gcp.Organizations.Project("project", new()
-    ///     {
-    ///         ProjectId = "staging-project",
-    ///     });
+    ///     var project = new Gcp.Organizations.Project("project");
     /// 
     ///     var lien = new Gcp.ResourceManager.Lien("lien", new()
     ///     {

--- a/sdk/dotnet/Tags/LocationTagBinding.cs
+++ b/sdk/dotnet/Tags/LocationTagBinding.cs
@@ -34,7 +34,6 @@ namespace Pulumi.Gcp.Tags
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
     ///         OrgId = "123456789",
-    ///         ProjectId = "project_id",
     ///     });
     /// 
     ///     var key = new Gcp.Tags.TagKey("key", new()
@@ -73,7 +72,6 @@ namespace Pulumi.Gcp.Tags
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
     ///         OrgId = "123456789",
-    ///         ProjectId = "project_id",
     ///     });
     /// 
     ///     var key = new Gcp.Tags.TagKey("key", new()

--- a/sdk/dotnet/Tags/TagBinding.cs
+++ b/sdk/dotnet/Tags/TagBinding.cs
@@ -32,7 +32,6 @@ namespace Pulumi.Gcp.Tags
     ///     var project = new Gcp.Organizations.Project("project", new()
     ///     {
     ///         OrgId = "123456789",
-    ///         ProjectId = "project_id",
     ///     });
     /// 
     ///     var key = new Gcp.Tags.TagKey("key", new()

--- a/sdk/go/gcp/accesscontextmanager/accessPolicy.go
+++ b/sdk/go/gcp/accesscontextmanager/accessPolicy.go
@@ -75,8 +75,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("123456789"),
-//				ProjectId: pulumi.String("acm-test-proj-123"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/activedirectory/peering.go
+++ b/sdk/go/gcp/activedirectory/peering.go
@@ -48,7 +48,6 @@ import (
 //				return err
 //			}
 //			_, err = organizations.NewProject(ctx, "peered-project", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("my-peered-project"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			}, pulumi.Provider(google_beta))

--- a/sdk/go/gcp/apigee/envGroupAttachment.go
+++ b/sdk/go/gcp/apigee/envGroupAttachment.go
@@ -40,7 +40,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("my-project"),
 //				OrgId:          pulumi.String(""),
 //				BillingAccount: pulumi.String(""),
 //			})

--- a/sdk/go/gcp/apigee/instanceAttachment.go
+++ b/sdk/go/gcp/apigee/instanceAttachment.go
@@ -40,7 +40,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("my-project"),
 //				OrgId:          pulumi.String(""),
 //				BillingAccount: pulumi.String(""),
 //			})

--- a/sdk/go/gcp/apigee/keystoresAliasesSelfSignedCert.go
+++ b/sdk/go/gcp/apigee/keystoresAliasesSelfSignedCert.go
@@ -40,7 +40,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("my-project"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			})

--- a/sdk/go/gcp/apigee/syncAuthorization.go
+++ b/sdk/go/gcp/apigee/syncAuthorization.go
@@ -41,7 +41,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("my-project"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			})

--- a/sdk/go/gcp/apigee/targetServer.go
+++ b/sdk/go/gcp/apigee/targetServer.go
@@ -40,7 +40,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("my-project"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			})

--- a/sdk/go/gcp/appengine/application.go
+++ b/sdk/go/gcp/appengine/application.go
@@ -36,8 +36,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			myProject, err := organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("your-project-id"),
-//				OrgId:     pulumi.String("1234567"),
+//				OrgId: pulumi.String("1234567"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/appengine/firewallRule.go
+++ b/sdk/go/gcp/appengine/firewallRule.go
@@ -38,7 +38,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			myProject, err := organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("ae-project"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			})

--- a/sdk/go/gcp/appengine/flexibleAppVersion.go
+++ b/sdk/go/gcp/appengine/flexibleAppVersion.go
@@ -48,7 +48,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			myProject, err := organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("appeng-flex"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			})

--- a/sdk/go/gcp/compute/networkAttachment.go
+++ b/sdk/go/gcp/compute/networkAttachment.go
@@ -43,7 +43,6 @@ import (
 //				return err
 //			}
 //			rejectedProducerProject, err := organizations.NewProject(ctx, "rejectedProducerProject", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("prj-rejected"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			}, pulumi.Provider(google_beta))
@@ -51,7 +50,6 @@ import (
 //				return err
 //			}
 //			acceptedProducerProject, err := organizations.NewProject(ctx, "acceptedProducerProject", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("prj-accepted"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //			}, pulumi.Provider(google_beta))

--- a/sdk/go/gcp/compute/nodeGroup.go
+++ b/sdk/go/gcp/compute/nodeGroup.go
@@ -157,8 +157,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			guestProject, err := organizations.NewProject(ctx, "guestProject", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("project-id"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/diagflow/intent.go
+++ b/sdk/go/gcp/diagflow/intent.go
@@ -77,8 +77,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			agentProjectProject, err := organizations.NewProject(ctx, "agentProjectProject", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("my-project"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/firebase/databaseInstance.go
+++ b/sdk/go/gcp/firebase/databaseInstance.go
@@ -86,8 +86,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			defaultProject, err := organizations.NewProject(ctx, "defaultProject", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("rtdb-project"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //				Labels: pulumi.StringMap{
 //					"firebase": pulumi.String("enabled"),
 //				},

--- a/sdk/go/gcp/firebase/project.go
+++ b/sdk/go/gcp/firebase/project.go
@@ -39,8 +39,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			defaultProject, err := organizations.NewProject(ctx, "defaultProject", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("my-project"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //				Labels: pulumi.StringMap{
 //					"firebase": pulumi.String("enabled"),
 //				},

--- a/sdk/go/gcp/folder/accessApprovalSettings.go
+++ b/sdk/go/gcp/folder/accessApprovalSettings.go
@@ -88,8 +88,7 @@ import (
 //				return err
 //			}
 //			myProject, err := organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("your-project-id"),
-//				FolderId:  myFolder.Name,
+//				FolderId: myFolder.Name,
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/iap/brand.go
+++ b/sdk/go/gcp/iap/brand.go
@@ -30,8 +30,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("my-project"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/iap/client.go
+++ b/sdk/go/gcp/iap/client.go
@@ -42,8 +42,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("my-project"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/identityplatform/config.go
+++ b/sdk/go/gcp/identityplatform/config.go
@@ -43,7 +43,6 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			defaultProject, err := organizations.NewProject(ctx, "defaultProject", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("my-project"),
 //				OrgId:          pulumi.String("123456789"),
 //				BillingAccount: pulumi.String("000000-0000000-0000000-000000"),
 //				Labels: pulumi.StringMap{

--- a/sdk/go/gcp/monitoring/monitoredProject.go
+++ b/sdk/go/gcp/monitoring/monitoredProject.go
@@ -43,8 +43,7 @@ import (
 //				return err
 //			}
 //			_, err = organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("m-id"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/organizations/accessApprovalSettings.go
+++ b/sdk/go/gcp/organizations/accessApprovalSettings.go
@@ -76,8 +76,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			myProject, err := organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("your-project-id"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/organizations/getBillingAccount.go
+++ b/sdk/go/gcp/organizations/getBillingAccount.go
@@ -33,7 +33,6 @@ import (
 //				return err
 //			}
 //			_, err = organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				ProjectId:      pulumi.String("your-project-id"),
 //				OrgId:          pulumi.String("1234567"),
 //				BillingAccount: *pulumi.String(acct.Id),
 //			})

--- a/sdk/go/gcp/organizations/project.go
+++ b/sdk/go/gcp/organizations/project.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -45,8 +44,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("1234567"),
-//				ProjectId: pulumi.String("your-project-id"),
+//				OrgId: pulumi.String("1234567"),
 //			})
 //			if err != nil {
 //				return err
@@ -79,8 +77,7 @@ import (
 //				return err
 //			}
 //			_, err = organizations.NewProject(ctx, "myProject-in-a-folder", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("your-project-id"),
-//				FolderId:  department1.Name,
+//				FolderId: department1.Name,
 //			})
 //			if err != nil {
 //				return err
@@ -159,12 +156,9 @@ type Project struct {
 func NewProject(ctx *pulumi.Context,
 	name string, args *ProjectArgs, opts ...pulumi.ResourceOption) (*Project, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &ProjectArgs{}
 	}
 
-	if args.ProjectId == nil {
-		return nil, errors.New("invalid value for required argument 'ProjectId'")
-	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"effectiveLabels",
 		"pulumiLabels",
@@ -313,7 +307,7 @@ type projectArgs struct {
 	// organization.
 	OrgId *string `pulumi:"orgId"`
 	// The project ID. Changing this forces a new project to be created.
-	ProjectId string `pulumi:"projectId"`
+	ProjectId *string `pulumi:"projectId"`
 	// If true, the resource can be deleted
 	// without deleting the Project via the Google API.
 	SkipDelete *bool `pulumi:"skipDelete"`
@@ -351,7 +345,7 @@ type ProjectArgs struct {
 	// organization.
 	OrgId pulumi.StringPtrInput
 	// The project ID. Changing this forces a new project to be created.
-	ProjectId pulumi.StringInput
+	ProjectId pulumi.StringPtrInput
 	// If true, the resource can be deleted
 	// without deleting the Project via the Google API.
 	SkipDelete pulumi.BoolPtrInput

--- a/sdk/go/gcp/orgpolicy/policy.go
+++ b/sdk/go/gcp/orgpolicy/policy.go
@@ -37,8 +37,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			basic, err := organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("123456789"),
-//				ProjectId: pulumi.String("id"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err
@@ -150,8 +149,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			basic, err := organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("123456789"),
-//				ProjectId: pulumi.String("id"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/projects/apiKey.go
+++ b/sdk/go/gcp/projects/apiKey.go
@@ -30,8 +30,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			basic, err := organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("app"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err
@@ -82,8 +81,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			basic, err := organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("app"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err
@@ -131,8 +129,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			basic, err := organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("app"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err
@@ -180,8 +177,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			basic, err := organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("app"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err
@@ -214,8 +210,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			basic, err := organizations.NewProject(ctx, "basic", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("app"),
-//				OrgId:     pulumi.String("123456789"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/projects/usageExportBucket.go
+++ b/sdk/go/gcp/projects/usageExportBucket.go
@@ -45,8 +45,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			_, err := organizations.NewProject(ctx, "myProject", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("1234567"),
-//				ProjectId: pulumi.String("your-project-id"),
+//				OrgId: pulumi.String("1234567"),
 //			})
 //			if err != nil {
 //				return err
@@ -79,8 +78,7 @@ import (
 //				return err
 //			}
 //			_, err = organizations.NewProject(ctx, "myProject-in-a-folder", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("your-project-id"),
-//				FolderId:  department1.Name,
+//				FolderId: department1.Name,
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/resourcemanager/lien.go
+++ b/sdk/go/gcp/resourcemanager/lien.go
@@ -32,9 +32,7 @@ import (
 //
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
-//			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				ProjectId: pulumi.String("staging-project"),
-//			})
+//			project, err := organizations.NewProject(ctx, "project", nil)
 //			if err != nil {
 //				return err
 //			}

--- a/sdk/go/gcp/tags/locationTagBinding.go
+++ b/sdk/go/gcp/tags/locationTagBinding.go
@@ -41,8 +41,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("123456789"),
-//				ProjectId: pulumi.String("project_id"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err
@@ -100,8 +99,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("123456789"),
-//				ProjectId: pulumi.String("project_id"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/go/gcp/tags/tagBinding.go
+++ b/sdk/go/gcp/tags/tagBinding.go
@@ -39,8 +39,7 @@ import (
 //	func main() {
 //		pulumi.Run(func(ctx *pulumi.Context) error {
 //			project, err := organizations.NewProject(ctx, "project", &organizations.ProjectArgs{
-//				OrgId:     pulumi.String("123456789"),
-//				ProjectId: pulumi.String("project_id"),
+//				OrgId: pulumi.String("123456789"),
 //			})
 //			if err != nil {
 //				return err

--- a/sdk/java/src/main/java/com/pulumi/gcp/accesscontextmanager/AccessPolicy.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/accesscontextmanager/AccessPolicy.java
@@ -90,7 +90,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;123456789&#34;)
- *             .projectId(&#34;acm-test-proj-123&#34;)
  *             .build());
  * 
  *         var access_policy = new AccessPolicy(&#34;access-policy&#34;, AccessPolicyArgs.builder()        

--- a/sdk/java/src/main/java/com/pulumi/gcp/activedirectory/Peering.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/activedirectory/Peering.java
@@ -63,7 +63,6 @@ import javax.annotation.Nullable;
  *                 .build());
  * 
  *         var peered_project = new Project(&#34;peered-project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-peered-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build(), CustomResourceOptions.builder()

--- a/sdk/java/src/main/java/com/pulumi/gcp/apigee/EnvGroupAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/apigee/EnvGroupAttachment.java
@@ -63,7 +63,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;&#34;)
  *             .billingAccount(&#34;&#34;)
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/apigee/InstanceAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/apigee/InstanceAttachment.java
@@ -63,7 +63,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;&#34;)
  *             .billingAccount(&#34;&#34;)
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/apigee/KeystoresAliasesSelfSignedCert.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/apigee/KeystoresAliasesSelfSignedCert.java
@@ -70,7 +70,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/apigee/SyncAuthorization.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/apigee/SyncAuthorization.java
@@ -58,7 +58,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/apigee/TargetServer.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/apigee/TargetServer.java
@@ -65,7 +65,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/appengine/Application.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/appengine/Application.java
@@ -50,7 +50,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;your-project-id&#34;)
  *             .orgId(&#34;1234567&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/appengine/FirewallRule.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/appengine/FirewallRule.java
@@ -53,7 +53,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;ae-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/appengine/FlexibleAppVersion.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/appengine/FlexibleAppVersion.java
@@ -92,7 +92,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;appeng-flex&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/NetworkAttachment.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/NetworkAttachment.java
@@ -62,7 +62,6 @@ import javax.annotation.Nullable;
  *                 .build());
  * 
  *         var rejectedProducerProject = new Project(&#34;rejectedProducerProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;prj-rejected&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build(), CustomResourceOptions.builder()
@@ -70,7 +69,6 @@ import javax.annotation.Nullable;
  *                 .build());
  * 
  *         var acceptedProducerProject = new Project(&#34;acceptedProducerProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;prj-accepted&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .build(), CustomResourceOptions.builder()

--- a/sdk/java/src/main/java/com/pulumi/gcp/compute/NodeGroup.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/compute/NodeGroup.java
@@ -195,7 +195,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var guestProject = new Project(&#34;guestProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;project-id&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/diagflow/Intent.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/diagflow/Intent.java
@@ -103,7 +103,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var agentProjectProject = new Project(&#34;agentProjectProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/firebase/DatabaseInstance.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/firebase/DatabaseInstance.java
@@ -116,7 +116,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var defaultProject = new Project(&#34;defaultProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;rtdb-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .labels(Map.of(&#34;firebase&#34;, &#34;enabled&#34;))
  *             .build(), CustomResourceOptions.builder()

--- a/sdk/java/src/main/java/com/pulumi/gcp/firebase/Project.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/firebase/Project.java
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var defaultProject = new Project(&#34;defaultProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .labels(Map.of(&#34;firebase&#34;, &#34;enabled&#34;))
  *             .build(), CustomResourceOptions.builder()

--- a/sdk/java/src/main/java/com/pulumi/gcp/folder/AccessApprovalSettings.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/folder/AccessApprovalSettings.java
@@ -113,7 +113,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;your-project-id&#34;)
  *             .folderId(myFolder.name())
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/iap/Brand.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/iap/Brand.java
@@ -43,7 +43,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/iap/Client.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/iap/Client.java
@@ -57,7 +57,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/identityplatform/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/identityplatform/Config.java
@@ -73,7 +73,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var defaultProject = new Project(&#34;defaultProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;my-project&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .billingAccount(&#34;000000-0000000-0000000-000000&#34;)
  *             .labels(Map.of(&#34;firebase&#34;, &#34;enabled&#34;))

--- a/sdk/java/src/main/java/com/pulumi/gcp/logging/ProjectBucketConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/logging/ProjectBucketConfig.java
@@ -51,7 +51,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var default_ = new Project(&#34;default&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;your-project-id&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/monitoring/MonitoredProject.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/monitoring/MonitoredProject.java
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;m-id&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/organizations/AccessApprovalSettings.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/organizations/AccessApprovalSettings.java
@@ -104,7 +104,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;your-project-id&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/organizations/OrganizationsFunctions.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/organizations/OrganizationsFunctions.java
@@ -218,7 +218,6 @@ public final class OrganizationsFunctions {
      *             .build());
      * 
      *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
-     *             .projectId(&#34;your-project-id&#34;)
      *             .orgId(&#34;1234567&#34;)
      *             .billingAccount(acct.applyValue(getBillingAccountResult -&gt; getBillingAccountResult.id()))
      *             .build());
@@ -262,7 +261,6 @@ public final class OrganizationsFunctions {
      *             .build());
      * 
      *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
-     *             .projectId(&#34;your-project-id&#34;)
      *             .orgId(&#34;1234567&#34;)
      *             .billingAccount(acct.applyValue(getBillingAccountResult -&gt; getBillingAccountResult.id()))
      *             .build());
@@ -306,7 +304,6 @@ public final class OrganizationsFunctions {
      *             .build());
      * 
      *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
-     *             .projectId(&#34;your-project-id&#34;)
      *             .orgId(&#34;1234567&#34;)
      *             .billingAccount(acct.applyValue(getBillingAccountResult -&gt; getBillingAccountResult.id()))
      *             .build());
@@ -350,7 +347,6 @@ public final class OrganizationsFunctions {
      *             .build());
      * 
      *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
-     *             .projectId(&#34;your-project-id&#34;)
      *             .orgId(&#34;1234567&#34;)
      *             .billingAccount(acct.applyValue(getBillingAccountResult -&gt; getBillingAccountResult.id()))
      *             .build());
@@ -394,7 +390,6 @@ public final class OrganizationsFunctions {
      *             .build());
      * 
      *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
-     *             .projectId(&#34;your-project-id&#34;)
      *             .orgId(&#34;1234567&#34;)
      *             .billingAccount(acct.applyValue(getBillingAccountResult -&gt; getBillingAccountResult.id()))
      *             .build());
@@ -438,7 +433,6 @@ public final class OrganizationsFunctions {
      *             .build());
      * 
      *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
-     *             .projectId(&#34;your-project-id&#34;)
      *             .orgId(&#34;1234567&#34;)
      *             .billingAccount(acct.applyValue(getBillingAccountResult -&gt; getBillingAccountResult.id()))
      *             .build());

--- a/sdk/java/src/main/java/com/pulumi/gcp/organizations/Project.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/organizations/Project.java
@@ -60,7 +60,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;1234567&#34;)
- *             .projectId(&#34;your-project-id&#34;)
  *             .build());
  * 
  *     }
@@ -97,7 +96,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var myProject_in_a_folder = new Project(&#34;myProject-in-a-folder&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;your-project-id&#34;)
  *             .folderId(department1.name())
  *             .build());
  * 
@@ -327,7 +325,7 @@ public class Project extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public Project(String name, ProjectArgs args) {
+    public Project(String name, @Nullable ProjectArgs args) {
         this(name, args, null);
     }
     /**
@@ -336,7 +334,7 @@ public class Project extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public Project(String name, ProjectArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public Project(String name, @Nullable ProjectArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("gcp:organizations/project:Project", name, args == null ? ProjectArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/gcp/organizations/ProjectArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/organizations/ProjectArgs.java
@@ -5,7 +5,6 @@ package com.pulumi.gcp.organizations;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Map;
@@ -146,15 +145,15 @@ public final class ProjectArgs extends com.pulumi.resources.ResourceArgs {
      * The project ID. Changing this forces a new project to be created.
      * 
      */
-    @Import(name="projectId", required=true)
-    private Output<String> projectId;
+    @Import(name="projectId")
+    private @Nullable Output<String> projectId;
 
     /**
      * @return The project ID. Changing this forces a new project to be created.
      * 
      */
-    public Output<String> projectId() {
-        return this.projectId;
+    public Optional<Output<String>> projectId() {
+        return Optional.ofNullable(this.projectId);
     }
 
     /**
@@ -371,7 +370,7 @@ public final class ProjectArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder projectId(Output<String> projectId) {
+        public Builder projectId(@Nullable Output<String> projectId) {
             $.projectId = projectId;
             return this;
         }
@@ -410,9 +409,6 @@ public final class ProjectArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ProjectArgs build() {
-            if ($.projectId == null) {
-                throw new MissingRequiredPropertyException("ProjectArgs", "projectId");
-            }
             return $;
         }
     }

--- a/sdk/java/src/main/java/com/pulumi/gcp/orgpolicy/Policy.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/orgpolicy/Policy.java
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;123456789&#34;)
- *             .projectId(&#34;id&#34;)
  *             .build());
  * 
  *         var primary = new Policy(&#34;primary&#34;, PolicyArgs.builder()        
@@ -173,7 +172,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;123456789&#34;)
- *             .projectId(&#34;id&#34;)
  *             .build());
  * 
  *         var primary = new Policy(&#34;primary&#34;, PolicyArgs.builder()        

--- a/sdk/java/src/main/java/com/pulumi/gcp/projects/ApiKey.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/projects/ApiKey.java
@@ -48,7 +48,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;app&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 
@@ -100,7 +99,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;app&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 
@@ -149,7 +147,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;app&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 
@@ -196,7 +193,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;app&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 
@@ -236,7 +232,6 @@ import javax.annotation.Nullable;
  * 
  *     public static void stack(Context ctx) {
  *         var basic = new Project(&#34;basic&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;app&#34;)
  *             .orgId(&#34;123456789&#34;)
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/projects/UsageExportBucket.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/projects/UsageExportBucket.java
@@ -57,7 +57,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var myProject = new Project(&#34;myProject&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;1234567&#34;)
- *             .projectId(&#34;your-project-id&#34;)
  *             .build());
  * 
  *     }
@@ -94,7 +93,6 @@ import javax.annotation.Nullable;
  *             .build());
  * 
  *         var myProject_in_a_folder = new Project(&#34;myProject-in-a-folder&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;your-project-id&#34;)
  *             .folderId(department1.name())
  *             .build());
  * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/resourcemanager/Lien.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/resourcemanager/Lien.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
  * import com.pulumi.Pulumi;
  * import com.pulumi.core.Output;
  * import com.pulumi.gcp.organizations.Project;
- * import com.pulumi.gcp.organizations.ProjectArgs;
  * import com.pulumi.gcp.resourcemanager.Lien;
  * import com.pulumi.gcp.resourcemanager.LienArgs;
  * import java.util.List;
@@ -42,9 +41,7 @@ import javax.annotation.Nullable;
  *     }
  * 
  *     public static void stack(Context ctx) {
- *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
- *             .projectId(&#34;staging-project&#34;)
- *             .build());
+ *         var project = new Project(&#34;project&#34;);
  * 
  *         var lien = new Lien(&#34;lien&#34;, LienArgs.builder()        
  *             .origin(&#34;machine-readable-explanation&#34;)

--- a/sdk/java/src/main/java/com/pulumi/gcp/tags/LocationTagBinding.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/tags/LocationTagBinding.java
@@ -56,7 +56,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;123456789&#34;)
- *             .projectId(&#34;project_id&#34;)
  *             .build());
  * 
  *         var key = new TagKey(&#34;key&#34;, TagKeyArgs.builder()        
@@ -110,7 +109,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;123456789&#34;)
- *             .projectId(&#34;project_id&#34;)
  *             .build());
  * 
  *         var key = new TagKey(&#34;key&#34;, TagKeyArgs.builder()        

--- a/sdk/java/src/main/java/com/pulumi/gcp/tags/TagBinding.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/tags/TagBinding.java
@@ -53,7 +53,6 @@ import javax.annotation.Nullable;
  *     public static void stack(Context ctx) {
  *         var project = new Project(&#34;project&#34;, ProjectArgs.builder()        
  *             .orgId(&#34;123456789&#34;)
- *             .projectId(&#34;project_id&#34;)
  *             .build());
  * 
  *         var key = new TagKey(&#34;key&#34;, TagKeyArgs.builder()        

--- a/sdk/nodejs/accesscontextmanager/accessPolicy.ts
+++ b/sdk/nodejs/accesscontextmanager/accessPolicy.ts
@@ -41,10 +41,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const project = new gcp.organizations.Project("project", {
- *     orgId: "123456789",
- *     projectId: "acm-test-proj-123",
- * });
+ * const project = new gcp.organizations.Project("project", {orgId: "123456789"});
  * const access_policy = new gcp.accesscontextmanager.AccessPolicy("access-policy", {
  *     parent: "organizations/123456789",
  *     scopes: pulumi.interpolate`projects/${project.number}`,

--- a/sdk/nodejs/activedirectory/peering.ts
+++ b/sdk/nodejs/activedirectory/peering.ts
@@ -24,7 +24,6 @@ import * as utilities from "../utilities";
  *     provider: google_beta,
  * });
  * const peered_project = new gcp.organizations.Project("peered-project", {
- *     projectId: "my-peered-project",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * }, {

--- a/sdk/nodejs/apigee/envGroupAttachment.ts
+++ b/sdk/nodejs/apigee/envGroupAttachment.ts
@@ -21,7 +21,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const project = new gcp.organizations.Project("project", {
- *     projectId: "my-project",
  *     orgId: "",
  *     billingAccount: "",
  * });

--- a/sdk/nodejs/apigee/instanceAttachment.ts
+++ b/sdk/nodejs/apigee/instanceAttachment.ts
@@ -21,7 +21,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const project = new gcp.organizations.Project("project", {
- *     projectId: "my-project",
  *     orgId: "",
  *     billingAccount: "",
  * });

--- a/sdk/nodejs/apigee/keystoresAliasesSelfSignedCert.ts
+++ b/sdk/nodejs/apigee/keystoresAliasesSelfSignedCert.ts
@@ -23,7 +23,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const project = new gcp.organizations.Project("project", {
- *     projectId: "my-project",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * });

--- a/sdk/nodejs/apigee/syncAuthorization.ts
+++ b/sdk/nodejs/apigee/syncAuthorization.ts
@@ -21,7 +21,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const project = new gcp.organizations.Project("project", {
- *     projectId: "my-project",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * });

--- a/sdk/nodejs/apigee/targetServer.ts
+++ b/sdk/nodejs/apigee/targetServer.ts
@@ -23,7 +23,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const project = new gcp.organizations.Project("project", {
- *     projectId: "my-project",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * });

--- a/sdk/nodejs/appengine/application.ts
+++ b/sdk/nodejs/appengine/application.ts
@@ -20,10 +20,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const myProject = new gcp.organizations.Project("myProject", {
- *     projectId: "your-project-id",
- *     orgId: "1234567",
- * });
+ * const myProject = new gcp.organizations.Project("myProject", {orgId: "1234567"});
  * const app = new gcp.appengine.Application("app", {
  *     project: myProject.projectId,
  *     locationId: "us-central",

--- a/sdk/nodejs/appengine/firewallRule.ts
+++ b/sdk/nodejs/appengine/firewallRule.ts
@@ -22,7 +22,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const myProject = new gcp.organizations.Project("myProject", {
- *     projectId: "ae-project",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * });

--- a/sdk/nodejs/appengine/flexibleAppVersion.ts
+++ b/sdk/nodejs/appengine/flexibleAppVersion.ts
@@ -29,7 +29,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const myProject = new gcp.organizations.Project("myProject", {
- *     projectId: "appeng-flex",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * });

--- a/sdk/nodejs/compute/networkAttachment.ts
+++ b/sdk/nodejs/compute/networkAttachment.ts
@@ -25,14 +25,12 @@ import * as utilities from "../utilities";
  *     provider: google_beta,
  * });
  * const rejectedProducerProject = new gcp.organizations.Project("rejectedProducerProject", {
- *     projectId: "prj-rejected",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * }, {
  *     provider: google_beta,
  * });
  * const acceptedProducerProject = new gcp.organizations.Project("acceptedProducerProject", {
- *     projectId: "prj-accepted",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  * }, {

--- a/sdk/nodejs/compute/nodeGroup.ts
+++ b/sdk/nodejs/compute/nodeGroup.ts
@@ -92,10 +92,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const guestProject = new gcp.organizations.Project("guestProject", {
- *     projectId: "project-id",
- *     orgId: "123456789",
- * });
+ * const guestProject = new gcp.organizations.Project("guestProject", {orgId: "123456789"});
  * const soletenant_tmpl = new gcp.compute.NodeTemplate("soletenant-tmpl", {
  *     region: "us-central1",
  *     nodeType: "n1-node-96-624",

--- a/sdk/nodejs/diagflow/intent.ts
+++ b/sdk/nodejs/diagflow/intent.ts
@@ -38,10 +38,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const agentProjectProject = new gcp.organizations.Project("agentProjectProject", {
- *     projectId: "my-project",
- *     orgId: "123456789",
- * });
+ * const agentProjectProject = new gcp.organizations.Project("agentProjectProject", {orgId: "123456789"});
  * const agentProjectService = new gcp.projects.Service("agentProjectService", {
  *     project: agentProjectProject.projectId,
  *     service: "dialogflow.googleapis.com",

--- a/sdk/nodejs/firebase/databaseInstance.ts
+++ b/sdk/nodejs/firebase/databaseInstance.ts
@@ -43,7 +43,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const defaultProject = new gcp.organizations.Project("defaultProject", {
- *     projectId: "rtdb-project",
  *     orgId: "123456789",
  *     labels: {
  *         firebase: "enabled",

--- a/sdk/nodejs/firebase/project.ts
+++ b/sdk/nodejs/firebase/project.ts
@@ -24,7 +24,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const defaultProject = new gcp.organizations.Project("defaultProject", {
- *     projectId: "my-project",
  *     orgId: "123456789",
  *     labels: {
  *         firebase: "enabled",

--- a/sdk/nodejs/folder/accessApprovalSettings.ts
+++ b/sdk/nodejs/folder/accessApprovalSettings.ts
@@ -45,10 +45,7 @@ import * as utilities from "../utilities";
  *     displayName: "my-folder",
  *     parent: "organizations/123456789",
  * });
- * const myProject = new gcp.organizations.Project("myProject", {
- *     projectId: "your-project-id",
- *     folderId: myFolder.name,
- * });
+ * const myProject = new gcp.organizations.Project("myProject", {folderId: myFolder.name});
  * const keyRing = new gcp.kms.KeyRing("keyRing", {
  *     location: "global",
  *     project: myProject.projectId,

--- a/sdk/nodejs/iap/brand.ts
+++ b/sdk/nodejs/iap/brand.ts
@@ -12,10 +12,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const project = new gcp.organizations.Project("project", {
- *     projectId: "my-project",
- *     orgId: "123456789",
- * });
+ * const project = new gcp.organizations.Project("project", {orgId: "123456789"});
  * const projectService = new gcp.projects.Service("projectService", {
  *     project: project.projectId,
  *     service: "iap.googleapis.com",

--- a/sdk/nodejs/iap/client.ts
+++ b/sdk/nodejs/iap/client.ts
@@ -24,10 +24,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const project = new gcp.organizations.Project("project", {
- *     projectId: "my-project",
- *     orgId: "123456789",
- * });
+ * const project = new gcp.organizations.Project("project", {orgId: "123456789"});
  * const projectService = new gcp.projects.Service("projectService", {
  *     project: project.projectId,
  *     service: "iap.googleapis.com",

--- a/sdk/nodejs/identityplatform/config.ts
+++ b/sdk/nodejs/identityplatform/config.ts
@@ -29,7 +29,6 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const defaultProject = new gcp.organizations.Project("defaultProject", {
- *     projectId: "my-project",
  *     orgId: "123456789",
  *     billingAccount: "000000-0000000-0000000-000000",
  *     labels: {

--- a/sdk/nodejs/monitoring/monitoredProject.ts
+++ b/sdk/nodejs/monitoring/monitoredProject.ts
@@ -21,10 +21,7 @@ import * as utilities from "../utilities";
  * import * as gcp from "@pulumi/gcp";
  *
  * const primary = new gcp.monitoring.MonitoredProject("primary", {metricsScope: "my-project-name"});
- * const basic = new gcp.organizations.Project("basic", {
- *     projectId: "m-id",
- *     orgId: "123456789",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * ```
  *
  * ## Import

--- a/sdk/nodejs/organizations/accessApprovalSettings.ts
+++ b/sdk/nodejs/organizations/accessApprovalSettings.ts
@@ -43,10 +43,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const myProject = new gcp.organizations.Project("myProject", {
- *     projectId: "your-project-id",
- *     orgId: "123456789",
- * });
+ * const myProject = new gcp.organizations.Project("myProject", {orgId: "123456789"});
  * const keyRing = new gcp.kms.KeyRing("keyRing", {
  *     location: "global",
  *     project: myProject.projectId,

--- a/sdk/nodejs/organizations/getBillingAccount.ts
+++ b/sdk/nodejs/organizations/getBillingAccount.ts
@@ -16,7 +16,6 @@ import * as utilities from "../utilities";
  *     open: true,
  * });
  * const myProject = new gcp.organizations.Project("myProject", {
- *     projectId: "your-project-id",
  *     orgId: "1234567",
  *     billingAccount: acct.then(acct => acct.id),
  * });
@@ -93,7 +92,6 @@ export interface GetBillingAccountResult {
  *     open: true,
  * });
  * const myProject = new gcp.organizations.Project("myProject", {
- *     projectId: "your-project-id",
  *     orgId: "1234567",
  *     billingAccount: acct.then(acct => acct.id),
  * });

--- a/sdk/nodejs/organizations/project.ts
+++ b/sdk/nodejs/organizations/project.ts
@@ -29,10 +29,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const myProject = new gcp.organizations.Project("myProject", {
- *     orgId: "1234567",
- *     projectId: "your-project-id",
- * });
+ * const myProject = new gcp.organizations.Project("myProject", {orgId: "1234567"});
  * ```
  *
  * To create a project under a specific folder
@@ -45,10 +42,7 @@ import * as utilities from "../utilities";
  *     displayName: "Department 1",
  *     parent: "organizations/1234567",
  * });
- * const myProject_in_a_folder = new gcp.organizations.Project("myProject-in-a-folder", {
- *     projectId: "your-project-id",
- *     folderId: department1.name,
- * });
+ * const myProject_in_a_folder = new gcp.organizations.Project("myProject-in-a-folder", {folderId: department1.name});
  * ```
  *
  * ## Import
@@ -165,7 +159,7 @@ export class Project extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ProjectArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: ProjectArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: ProjectArgs | ProjectState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -184,9 +178,6 @@ export class Project extends pulumi.CustomResource {
             resourceInputs["skipDelete"] = state ? state.skipDelete : undefined;
         } else {
             const args = argsOrState as ProjectArgs | undefined;
-            if ((!args || args.projectId === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'projectId'");
-            }
             resourceInputs["autoCreateNetwork"] = args ? args.autoCreateNetwork : undefined;
             resourceInputs["billingAccount"] = args ? args.billingAccount : undefined;
             resourceInputs["folderId"] = args ? args.folderId : undefined;
@@ -322,7 +313,7 @@ export interface ProjectArgs {
     /**
      * The project ID. Changing this forces a new project to be created.
      */
-    projectId: pulumi.Input<string>;
+    projectId?: pulumi.Input<string>;
     /**
      * If true, the resource can be deleted
      * without deleting the Project via the Google API.

--- a/sdk/nodejs/orgpolicy/policy.ts
+++ b/sdk/nodejs/orgpolicy/policy.ts
@@ -20,10 +20,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const basic = new gcp.organizations.Project("basic", {
- *     orgId: "123456789",
- *     projectId: "id",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * const primary = new gcp.orgpolicy.Policy("primary", {
  *     parent: pulumi.interpolate`projects/${basic.name}`,
  *     spec: {
@@ -72,10 +69,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const basic = new gcp.organizations.Project("basic", {
- *     orgId: "123456789",
- *     projectId: "id",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * const primary = new gcp.orgpolicy.Policy("primary", {
  *     parent: pulumi.interpolate`projects/${basic.name}`,
  *     spec: {

--- a/sdk/nodejs/projects/apiKey.ts
+++ b/sdk/nodejs/projects/apiKey.ts
@@ -16,10 +16,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const basic = new gcp.organizations.Project("basic", {
- *     projectId: "app",
- *     orgId: "123456789",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * const primary = new gcp.projects.ApiKey("primary", {
  *     displayName: "sample-key",
  *     project: basic.name,
@@ -43,10 +40,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const basic = new gcp.organizations.Project("basic", {
- *     projectId: "app",
- *     orgId: "123456789",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * const primary = new gcp.projects.ApiKey("primary", {
  *     displayName: "sample-key",
  *     project: basic.name,
@@ -67,10 +61,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const basic = new gcp.organizations.Project("basic", {
- *     projectId: "app",
- *     orgId: "123456789",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * const primary = new gcp.projects.ApiKey("primary", {
  *     displayName: "sample-key",
  *     project: basic.name,
@@ -91,10 +82,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const basic = new gcp.organizations.Project("basic", {
- *     projectId: "app",
- *     orgId: "123456789",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * const primary = new gcp.projects.ApiKey("primary", {
  *     displayName: "sample-key",
  *     project: basic.name,
@@ -106,10 +94,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const basic = new gcp.organizations.Project("basic", {
- *     projectId: "app",
- *     orgId: "123456789",
- * });
+ * const basic = new gcp.organizations.Project("basic", {orgId: "123456789"});
  * const primary = new gcp.projects.ApiKey("primary", {
  *     displayName: "sample-key",
  *     project: basic.name,

--- a/sdk/nodejs/projects/usageExportBucket.ts
+++ b/sdk/nodejs/projects/usageExportBucket.ts
@@ -29,10 +29,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const myProject = new gcp.organizations.Project("myProject", {
- *     orgId: "1234567",
- *     projectId: "your-project-id",
- * });
+ * const myProject = new gcp.organizations.Project("myProject", {orgId: "1234567"});
  * ```
  *
  * To create a project under a specific folder
@@ -45,10 +42,7 @@ import * as utilities from "../utilities";
  *     displayName: "Department 1",
  *     parent: "organizations/1234567",
  * });
- * const myProject_in_a_folder = new gcp.organizations.Project("myProject-in-a-folder", {
- *     projectId: "your-project-id",
- *     folderId: department1.name,
- * });
+ * const myProject_in_a_folder = new gcp.organizations.Project("myProject-in-a-folder", {folderId: department1.name});
  * ```
  *
  * ## Import

--- a/sdk/nodejs/resourcemanager/lien.ts
+++ b/sdk/nodejs/resourcemanager/lien.ts
@@ -14,7 +14,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const project = new gcp.organizations.Project("project", {projectId: "staging-project"});
+ * const project = new gcp.organizations.Project("project", {});
  * const lien = new gcp.resourcemanager.Lien("lien", {
  *     origin: "machine-readable-explanation",
  *     parent: pulumi.interpolate`projects/${project.number}`,

--- a/sdk/nodejs/tags/locationTagBinding.ts
+++ b/sdk/nodejs/tags/locationTagBinding.ts
@@ -22,10 +22,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const project = new gcp.organizations.Project("project", {
- *     orgId: "123456789",
- *     projectId: "project_id",
- * });
+ * const project = new gcp.organizations.Project("project", {orgId: "123456789"});
  * const key = new gcp.tags.TagKey("key", {
  *     description: "For keyname resources.",
  *     parent: "organizations/123456789",
@@ -48,10 +45,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const project = new gcp.organizations.Project("project", {
- *     orgId: "123456789",
- *     projectId: "project_id",
- * });
+ * const project = new gcp.organizations.Project("project", {orgId: "123456789"});
  * const key = new gcp.tags.TagKey("key", {
  *     description: "For keyname resources.",
  *     parent: "organizations/123456789",

--- a/sdk/nodejs/tags/tagBinding.ts
+++ b/sdk/nodejs/tags/tagBinding.ts
@@ -20,10 +20,7 @@ import * as utilities from "../utilities";
  * import * as pulumi from "@pulumi/pulumi";
  * import * as gcp from "@pulumi/gcp";
  *
- * const project = new gcp.organizations.Project("project", {
- *     orgId: "123456789",
- *     projectId: "project_id",
- * });
+ * const project = new gcp.organizations.Project("project", {orgId: "123456789"});
  * const key = new gcp.tags.TagKey("key", {
  *     description: "For keyname resources.",
  *     parent: "organizations/123456789",

--- a/sdk/python/pulumi_gcp/accesscontextmanager/access_policy.py
+++ b/sdk/python/pulumi_gcp/accesscontextmanager/access_policy.py
@@ -234,9 +234,7 @@ class AccessPolicy(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="acm-test-proj-123")
+        project = gcp.organizations.Project("project", org_id="123456789")
         access_policy = gcp.accesscontextmanager.AccessPolicy("access-policy",
             parent="organizations/123456789",
             scopes=project.number.apply(lambda number: f"projects/{number}"),
@@ -312,9 +310,7 @@ class AccessPolicy(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="acm-test-proj-123")
+        project = gcp.organizations.Project("project", org_id="123456789")
         access_policy = gcp.accesscontextmanager.AccessPolicy("access-policy",
             parent="organizations/123456789",
             scopes=project.number.apply(lambda number: f"projects/{number}"),

--- a/sdk/python/pulumi_gcp/activedirectory/peering.py
+++ b/sdk/python/pulumi_gcp/activedirectory/peering.py
@@ -339,7 +339,6 @@ class Peering(pulumi.CustomResource):
             authorized_networks=[source_network.id],
             opts=pulumi.ResourceOptions(provider=google_beta))
         peered_project = gcp.organizations.Project("peered-project",
-            project_id="my-peered-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             opts=pulumi.ResourceOptions(provider=google_beta))
@@ -398,7 +397,6 @@ class Peering(pulumi.CustomResource):
             authorized_networks=[source_network.id],
             opts=pulumi.ResourceOptions(provider=google_beta))
         peered_project = gcp.organizations.Project("peered-project",
-            project_id="my-peered-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             opts=pulumi.ResourceOptions(provider=google_beta))

--- a/sdk/python/pulumi_gcp/apigee/env_group_attachment.py
+++ b/sdk/python/pulumi_gcp/apigee/env_group_attachment.py
@@ -146,7 +146,6 @@ class EnvGroupAttachment(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="",
             billing_account="")
         apigee = gcp.projects.Service("apigee",
@@ -243,7 +242,6 @@ class EnvGroupAttachment(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="",
             billing_account="")
         apigee = gcp.projects.Service("apigee",

--- a/sdk/python/pulumi_gcp/apigee/instance_attachment.py
+++ b/sdk/python/pulumi_gcp/apigee/instance_attachment.py
@@ -146,7 +146,6 @@ class InstanceAttachment(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="",
             billing_account="")
         apigee = gcp.projects.Service("apigee",
@@ -243,7 +242,6 @@ class InstanceAttachment(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="",
             billing_account="")
         apigee = gcp.projects.Service("apigee",

--- a/sdk/python/pulumi_gcp/apigee/keystores_aliases_self_signed_cert.py
+++ b/sdk/python/pulumi_gcp/apigee/keystores_aliases_self_signed_cert.py
@@ -393,7 +393,6 @@ class KeystoresAliasesSelfSignedCert(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         apigee = gcp.projects.Service("apigee",
@@ -509,7 +508,6 @@ class KeystoresAliasesSelfSignedCert(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         apigee = gcp.projects.Service("apigee",

--- a/sdk/python/pulumi_gcp/apigee/sync_authorization.py
+++ b/sdk/python/pulumi_gcp/apigee/sync_authorization.py
@@ -157,7 +157,6 @@ class SyncAuthorization(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         apigee = gcp.projects.Service("apigee",
@@ -233,7 +232,6 @@ class SyncAuthorization(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         apigee = gcp.projects.Service("apigee",

--- a/sdk/python/pulumi_gcp/apigee/target_server.py
+++ b/sdk/python/pulumi_gcp/apigee/target_server.py
@@ -337,7 +337,6 @@ class TargetServer(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         apigee = gcp.projects.Service("apigee",
@@ -444,7 +443,6 @@ class TargetServer(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         project = gcp.organizations.Project("project",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         apigee = gcp.projects.Service("apigee",

--- a/sdk/python/pulumi_gcp/appengine/application.py
+++ b/sdk/python/pulumi_gcp/appengine/application.py
@@ -423,9 +423,7 @@ class Application(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            project_id="your-project-id",
-            org_id="1234567")
+        my_project = gcp.organizations.Project("myProject", org_id="1234567")
         app = gcp.appengine.Application("app",
             project=my_project.project_id,
             location_id="us-central")
@@ -485,9 +483,7 @@ class Application(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            project_id="your-project-id",
-            org_id="1234567")
+        my_project = gcp.organizations.Project("myProject", org_id="1234567")
         app = gcp.appengine.Application("app",
             project=my_project.project_id,
             location_id="us-central")

--- a/sdk/python/pulumi_gcp/appengine/firewall_rule.py
+++ b/sdk/python/pulumi_gcp/appengine/firewall_rule.py
@@ -250,7 +250,6 @@ class FirewallRule(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         my_project = gcp.organizations.Project("myProject",
-            project_id="ae-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         app = gcp.appengine.Application("app",
@@ -328,7 +327,6 @@ class FirewallRule(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         my_project = gcp.organizations.Project("myProject",
-            project_id="ae-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         app = gcp.appengine.Application("app",

--- a/sdk/python/pulumi_gcp/appengine/flexible_app_version.py
+++ b/sdk/python/pulumi_gcp/appengine/flexible_app_version.py
@@ -1129,7 +1129,6 @@ class FlexibleAppVersion(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         my_project = gcp.organizations.Project("myProject",
-            project_id="appeng-flex",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         app = gcp.appengine.Application("app",
@@ -1313,7 +1312,6 @@ class FlexibleAppVersion(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         my_project = gcp.organizations.Project("myProject",
-            project_id="appeng-flex",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000")
         app = gcp.appengine.Application("app",

--- a/sdk/python/pulumi_gcp/compute/network_attachment.py
+++ b/sdk/python/pulumi_gcp/compute/network_attachment.py
@@ -451,12 +451,10 @@ class NetworkAttachment(pulumi.CustomResource):
             ip_cidr_range="10.0.0.0/16",
             opts=pulumi.ResourceOptions(provider=google_beta))
         rejected_producer_project = gcp.organizations.Project("rejectedProducerProject",
-            project_id="prj-rejected",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             opts=pulumi.ResourceOptions(provider=google_beta))
         accepted_producer_project = gcp.organizations.Project("acceptedProducerProject",
-            project_id="prj-accepted",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             opts=pulumi.ResourceOptions(provider=google_beta))
@@ -573,12 +571,10 @@ class NetworkAttachment(pulumi.CustomResource):
             ip_cidr_range="10.0.0.0/16",
             opts=pulumi.ResourceOptions(provider=google_beta))
         rejected_producer_project = gcp.organizations.Project("rejectedProducerProject",
-            project_id="prj-rejected",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             opts=pulumi.ResourceOptions(provider=google_beta))
         accepted_producer_project = gcp.organizations.Project("acceptedProducerProject",
-            project_id="prj-accepted",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             opts=pulumi.ResourceOptions(provider=google_beta))

--- a/sdk/python/pulumi_gcp/compute/node_group.py
+++ b/sdk/python/pulumi_gcp/compute/node_group.py
@@ -575,9 +575,7 @@ class NodeGroup(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        guest_project = gcp.organizations.Project("guestProject",
-            project_id="project-id",
-            org_id="123456789")
+        guest_project = gcp.organizations.Project("guestProject", org_id="123456789")
         soletenant_tmpl = gcp.compute.NodeTemplate("soletenant-tmpl",
             region="us-central1",
             node_type="n1-node-96-624")
@@ -734,9 +732,7 @@ class NodeGroup(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        guest_project = gcp.organizations.Project("guestProject",
-            project_id="project-id",
-            org_id="123456789")
+        guest_project = gcp.organizations.Project("guestProject", org_id="123456789")
         soletenant_tmpl = gcp.compute.NodeTemplate("soletenant-tmpl",
             region="us-central1",
             node_type="n1-node-96-624")

--- a/sdk/python/pulumi_gcp/diagflow/intent.py
+++ b/sdk/python/pulumi_gcp/diagflow/intent.py
@@ -598,9 +598,7 @@ class Intent(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        agent_project_project = gcp.organizations.Project("agentProjectProject",
-            project_id="my-project",
-            org_id="123456789")
+        agent_project_project = gcp.organizations.Project("agentProjectProject", org_id="123456789")
         agent_project_service = gcp.projects.Service("agentProjectService",
             project=agent_project_project.project_id,
             service="dialogflow.googleapis.com",
@@ -720,9 +718,7 @@ class Intent(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        agent_project_project = gcp.organizations.Project("agentProjectProject",
-            project_id="my-project",
-            org_id="123456789")
+        agent_project_project = gcp.organizations.Project("agentProjectProject", org_id="123456789")
         agent_project_service = gcp.projects.Service("agentProjectService",
             project=agent_project_project.project_id,
             service="dialogflow.googleapis.com",

--- a/sdk/python/pulumi_gcp/firebase/database_instance.py
+++ b/sdk/python/pulumi_gcp/firebase/database_instance.py
@@ -331,7 +331,6 @@ class DatabaseInstance(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         default_project = gcp.organizations.Project("defaultProject",
-            project_id="rtdb-project",
             org_id="123456789",
             labels={
                 "firebase": "enabled",
@@ -440,7 +439,6 @@ class DatabaseInstance(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         default_project = gcp.organizations.Project("defaultProject",
-            project_id="rtdb-project",
             org_id="123456789",
             labels={
                 "firebase": "enabled",

--- a/sdk/python/pulumi_gcp/firebase/project.py
+++ b/sdk/python/pulumi_gcp/firebase/project.py
@@ -122,7 +122,6 @@ class Project(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         default_project = gcp.organizations.Project("defaultProject",
-            project_id="my-project",
             org_id="123456789",
             labels={
                 "firebase": "enabled",
@@ -183,7 +182,6 @@ class Project(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         default_project = gcp.organizations.Project("defaultProject",
-            project_id="my-project",
             org_id="123456789",
             labels={
                 "firebase": "enabled",

--- a/sdk/python/pulumi_gcp/folder/access_approval_settings.py
+++ b/sdk/python/pulumi_gcp/folder/access_approval_settings.py
@@ -303,9 +303,7 @@ class AccessApprovalSettings(pulumi.CustomResource):
         my_folder = gcp.organizations.Folder("myFolder",
             display_name="my-folder",
             parent="organizations/123456789")
-        my_project = gcp.organizations.Project("myProject",
-            project_id="your-project-id",
-            folder_id=my_folder.name)
+        my_project = gcp.organizations.Project("myProject", folder_id=my_folder.name)
         key_ring = gcp.kms.KeyRing("keyRing",
             location="global",
             project=my_project.project_id)
@@ -407,9 +405,7 @@ class AccessApprovalSettings(pulumi.CustomResource):
         my_folder = gcp.organizations.Folder("myFolder",
             display_name="my-folder",
             parent="organizations/123456789")
-        my_project = gcp.organizations.Project("myProject",
-            project_id="your-project-id",
-            folder_id=my_folder.name)
+        my_project = gcp.organizations.Project("myProject", folder_id=my_folder.name)
         key_ring = gcp.kms.KeyRing("keyRing",
             location="global",
             project=my_project.project_id)

--- a/sdk/python/pulumi_gcp/iap/brand.py
+++ b/sdk/python/pulumi_gcp/iap/brand.py
@@ -208,9 +208,7 @@ class Brand(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            project_id="my-project",
-            org_id="123456789")
+        project = gcp.organizations.Project("project", org_id="123456789")
         project_service = gcp.projects.Service("projectService",
             project=project.project_id,
             service="iap.googleapis.com")
@@ -272,9 +270,7 @@ class Brand(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            project_id="my-project",
-            org_id="123456789")
+        project = gcp.organizations.Project("project", org_id="123456789")
         project_service = gcp.projects.Service("projectService",
             project=project.project_id,
             service="iap.googleapis.com")

--- a/sdk/python/pulumi_gcp/iap/client.py
+++ b/sdk/python/pulumi_gcp/iap/client.py
@@ -171,9 +171,7 @@ class Client(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            project_id="my-project",
-            org_id="123456789")
+        project = gcp.organizations.Project("project", org_id="123456789")
         project_service = gcp.projects.Service("projectService",
             project=project.project_id,
             service="iap.googleapis.com")
@@ -242,9 +240,7 @@ class Client(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            project_id="my-project",
-            org_id="123456789")
+        project = gcp.organizations.Project("project", org_id="123456789")
         project_service = gcp.projects.Service("projectService",
             project=project.project_id,
             service="iap.googleapis.com")

--- a/sdk/python/pulumi_gcp/identityplatform/config.py
+++ b/sdk/python/pulumi_gcp/identityplatform/config.py
@@ -325,7 +325,6 @@ class Config(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         default_project = gcp.organizations.Project("defaultProject",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             labels={
@@ -454,7 +453,6 @@ class Config(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         default_project = gcp.organizations.Project("defaultProject",
-            project_id="my-project",
             org_id="123456789",
             billing_account="000000-0000000-0000000-000000",
             labels={

--- a/sdk/python/pulumi_gcp/monitoring/monitored_project.py
+++ b/sdk/python/pulumi_gcp/monitoring/monitored_project.py
@@ -143,9 +143,7 @@ class MonitoredProject(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         primary = gcp.monitoring.MonitoredProject("primary", metrics_scope="my-project-name")
-        basic = gcp.organizations.Project("basic",
-            project_id="m-id",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         ```
 
         ## Import
@@ -199,9 +197,7 @@ class MonitoredProject(pulumi.CustomResource):
         import pulumi_gcp as gcp
 
         primary = gcp.monitoring.MonitoredProject("primary", metrics_scope="my-project-name")
-        basic = gcp.organizations.Project("basic",
-            project_id="m-id",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         ```
 
         ## Import

--- a/sdk/python/pulumi_gcp/organizations/access_approval_settings.py
+++ b/sdk/python/pulumi_gcp/organizations/access_approval_settings.py
@@ -297,9 +297,7 @@ class AccessApprovalSettings(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            project_id="your-project-id",
-            org_id="123456789")
+        my_project = gcp.organizations.Project("myProject", org_id="123456789")
         key_ring = gcp.kms.KeyRing("keyRing",
             location="global",
             project=my_project.project_id)
@@ -400,9 +398,7 @@ class AccessApprovalSettings(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            project_id="your-project-id",
-            org_id="123456789")
+        my_project = gcp.organizations.Project("myProject", org_id="123456789")
         key_ring = gcp.kms.KeyRing("keyRing",
             location="global",
             project=my_project.project_id)

--- a/sdk/python/pulumi_gcp/organizations/get_billing_account.py
+++ b/sdk/python/pulumi_gcp/organizations/get_billing_account.py
@@ -120,7 +120,6 @@ def get_billing_account(billing_account: Optional[str] = None,
     acct = gcp.organizations.get_billing_account(display_name="My Billing Account",
         open=True)
     my_project = gcp.organizations.Project("myProject",
-        project_id="your-project-id",
         org_id="1234567",
         billing_account=acct.id)
     ```
@@ -168,7 +167,6 @@ def get_billing_account_output(billing_account: Optional[pulumi.Input[Optional[s
     acct = gcp.organizations.get_billing_account(display_name="My Billing Account",
         open=True)
     my_project = gcp.organizations.Project("myProject",
-        project_id="your-project-id",
         org_id="1234567",
         billing_account=acct.id)
     ```

--- a/sdk/python/pulumi_gcp/organizations/project.py
+++ b/sdk/python/pulumi_gcp/organizations/project.py
@@ -14,17 +14,16 @@ __all__ = ['ProjectArgs', 'Project']
 @pulumi.input_type
 class ProjectArgs:
     def __init__(__self__, *,
-                 project_id: pulumi.Input[str],
                  auto_create_network: Optional[pulumi.Input[bool]] = None,
                  billing_account: Optional[pulumi.Input[str]] = None,
                  folder_id: Optional[pulumi.Input[str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  org_id: Optional[pulumi.Input[str]] = None,
+                 project_id: Optional[pulumi.Input[str]] = None,
                  skip_delete: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a Project resource.
-        :param pulumi.Input[str] project_id: The project ID. Changing this forces a new project to be created.
         :param pulumi.Input[bool] auto_create_network: Create the 'default' network automatically. Default true. If set to false, the default network will be deleted. Note
                that, for quota purposes, you will still need to have 1 network slot available to create the project successfully, even
                if you set auto_create_network to false, since the network will exist momentarily.
@@ -48,10 +47,10 @@ class ProjectArgs:
                specified then the project is created at the top level. Changing
                this forces the project to be migrated to the newly specified
                organization.
+        :param pulumi.Input[str] project_id: The project ID. Changing this forces a new project to be created.
         :param pulumi.Input[bool] skip_delete: If true, the resource can be deleted
                without deleting the Project via the Google API.
         """
-        pulumi.set(__self__, "project_id", project_id)
         if auto_create_network is not None:
             pulumi.set(__self__, "auto_create_network", auto_create_network)
         if billing_account is not None:
@@ -64,20 +63,10 @@ class ProjectArgs:
             pulumi.set(__self__, "name", name)
         if org_id is not None:
             pulumi.set(__self__, "org_id", org_id)
+        if project_id is not None:
+            pulumi.set(__self__, "project_id", project_id)
         if skip_delete is not None:
             pulumi.set(__self__, "skip_delete", skip_delete)
-
-    @property
-    @pulumi.getter(name="projectId")
-    def project_id(self) -> pulumi.Input[str]:
-        """
-        The project ID. Changing this forces a new project to be created.
-        """
-        return pulumi.get(self, "project_id")
-
-    @project_id.setter
-    def project_id(self, value: pulumi.Input[str]):
-        pulumi.set(self, "project_id", value)
 
     @property
     @pulumi.getter(name="autoCreateNetwork")
@@ -167,6 +156,18 @@ class ProjectArgs:
     @org_id.setter
     def org_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "org_id", value)
+
+    @property
+    @pulumi.getter(name="projectId")
+    def project_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The project ID. Changing this forces a new project to be created.
+        """
+        return pulumi.get(self, "project_id")
+
+    @project_id.setter
+    def project_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "project_id", value)
 
     @property
     @pulumi.getter(name="skipDelete")
@@ -441,9 +442,7 @@ class Project(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            org_id="1234567",
-            project_id="your-project-id")
+        my_project = gcp.organizations.Project("myProject", org_id="1234567")
         ```
 
         To create a project under a specific folder
@@ -455,9 +454,7 @@ class Project(pulumi.CustomResource):
         department1 = gcp.organizations.Folder("department1",
             display_name="Department 1",
             parent="organizations/1234567")
-        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder",
-            project_id="your-project-id",
-            folder_id=department1.name)
+        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder", folder_id=department1.name)
         ```
 
         ## Import
@@ -509,7 +506,7 @@ class Project(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: ProjectArgs,
+                 args: Optional[ProjectArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Allows creation and management of a Google Cloud Platform project.
@@ -536,9 +533,7 @@ class Project(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            org_id="1234567",
-            project_id="your-project-id")
+        my_project = gcp.organizations.Project("myProject", org_id="1234567")
         ```
 
         To create a project under a specific folder
@@ -550,9 +545,7 @@ class Project(pulumi.CustomResource):
         department1 = gcp.organizations.Folder("department1",
             display_name="Department 1",
             parent="organizations/1234567")
-        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder",
-            project_id="your-project-id",
-            folder_id=department1.name)
+        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder", folder_id=department1.name)
         ```
 
         ## Import
@@ -609,8 +602,6 @@ class Project(pulumi.CustomResource):
             __props__.__dict__["labels"] = labels
             __props__.__dict__["name"] = name
             __props__.__dict__["org_id"] = org_id
-            if project_id is None and not opts.urn:
-                raise TypeError("Missing required property 'project_id'")
             __props__.__dict__["project_id"] = project_id
             __props__.__dict__["skip_delete"] = skip_delete
             __props__.__dict__["effective_labels"] = None

--- a/sdk/python/pulumi_gcp/orgpolicy/policy.py
+++ b/sdk/python/pulumi_gcp/orgpolicy/policy.py
@@ -196,9 +196,7 @@ class Policy(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            org_id="123456789",
-            project_id="id")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.orgpolicy.Policy("primary",
             parent=basic.name.apply(lambda name: f"projects/{name}"),
             spec=gcp.orgpolicy.PolicySpecArgs(
@@ -243,9 +241,7 @@ class Policy(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            org_id="123456789",
-            project_id="id")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.orgpolicy.Policy("primary",
             parent=basic.name.apply(lambda name: f"projects/{name}"),
             spec=gcp.orgpolicy.PolicySpecArgs(
@@ -344,9 +340,7 @@ class Policy(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            org_id="123456789",
-            project_id="id")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.orgpolicy.Policy("primary",
             parent=basic.name.apply(lambda name: f"projects/{name}"),
             spec=gcp.orgpolicy.PolicySpecArgs(
@@ -391,9 +385,7 @@ class Policy(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            org_id="123456789",
-            project_id="id")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.orgpolicy.Policy("primary",
             parent=basic.name.apply(lambda name: f"projects/{name}"),
             spec=gcp.orgpolicy.PolicySpecArgs(

--- a/sdk/python/pulumi_gcp/projects/api_key.py
+++ b/sdk/python/pulumi_gcp/projects/api_key.py
@@ -209,9 +209,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,
@@ -234,9 +232,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,
@@ -256,9 +252,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,
@@ -278,9 +272,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name)
@@ -291,9 +283,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,
@@ -355,9 +345,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,
@@ -380,9 +368,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,
@@ -402,9 +388,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,
@@ -424,9 +408,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name)
@@ -437,9 +419,7 @@ class ApiKey(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        basic = gcp.organizations.Project("basic",
-            project_id="app",
-            org_id="123456789")
+        basic = gcp.organizations.Project("basic", org_id="123456789")
         primary = gcp.projects.ApiKey("primary",
             display_name="sample-key",
             project=basic.name,

--- a/sdk/python/pulumi_gcp/projects/usage_export_bucket.py
+++ b/sdk/python/pulumi_gcp/projects/usage_export_bucket.py
@@ -156,9 +156,7 @@ class UsageExportBucket(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            org_id="1234567",
-            project_id="your-project-id")
+        my_project = gcp.organizations.Project("myProject", org_id="1234567")
         ```
 
         To create a project under a specific folder
@@ -170,9 +168,7 @@ class UsageExportBucket(pulumi.CustomResource):
         department1 = gcp.organizations.Folder("department1",
             display_name="Department 1",
             parent="organizations/1234567")
-        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder",
-            project_id="your-project-id",
-            folder_id=department1.name)
+        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder", folder_id=department1.name)
         ```
 
         ## Import
@@ -228,9 +224,7 @@ class UsageExportBucket(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        my_project = gcp.organizations.Project("myProject",
-            org_id="1234567",
-            project_id="your-project-id")
+        my_project = gcp.organizations.Project("myProject", org_id="1234567")
         ```
 
         To create a project under a specific folder
@@ -242,9 +236,7 @@ class UsageExportBucket(pulumi.CustomResource):
         department1 = gcp.organizations.Folder("department1",
             display_name="Department 1",
             parent="organizations/1234567")
-        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder",
-            project_id="your-project-id",
-            folder_id=department1.name)
+        my_project_in_a_folder = gcp.organizations.Project("myProject-in-a-folder", folder_id=department1.name)
         ```
 
         ## Import

--- a/sdk/python/pulumi_gcp/resourcemanager/lien.py
+++ b/sdk/python/pulumi_gcp/resourcemanager/lien.py
@@ -255,7 +255,7 @@ class Lien(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project", project_id="staging-project")
+        project = gcp.organizations.Project("project")
         lien = gcp.resourcemanager.Lien("lien",
             origin="machine-readable-explanation",
             parent=project.number.apply(lambda number: f"projects/{number}"),
@@ -315,7 +315,7 @@ class Lien(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project", project_id="staging-project")
+        project = gcp.organizations.Project("project")
         lien = gcp.resourcemanager.Lien("lien",
             origin="machine-readable-explanation",
             parent=project.number.apply(lambda number: f"projects/{number}"),

--- a/sdk/python/pulumi_gcp/tags/location_tag_binding.py
+++ b/sdk/python/pulumi_gcp/tags/location_tag_binding.py
@@ -172,9 +172,7 @@ class LocationTagBinding(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="project_id")
+        project = gcp.organizations.Project("project", org_id="123456789")
         key = gcp.tags.TagKey("key",
             description="For keyname resources.",
             parent="organizations/123456789",
@@ -194,9 +192,7 @@ class LocationTagBinding(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="project_id")
+        project = gcp.organizations.Project("project", org_id="123456789")
         key = gcp.tags.TagKey("key",
             description="For keyname resources.",
             parent="organizations/123456789",
@@ -259,9 +255,7 @@ class LocationTagBinding(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="project_id")
+        project = gcp.organizations.Project("project", org_id="123456789")
         key = gcp.tags.TagKey("key",
             description="For keyname resources.",
             parent="organizations/123456789",
@@ -281,9 +275,7 @@ class LocationTagBinding(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="project_id")
+        project = gcp.organizations.Project("project", org_id="123456789")
         key = gcp.tags.TagKey("key",
             description="For keyname resources.",
             parent="organizations/123456789",

--- a/sdk/python/pulumi_gcp/tags/tag_binding.py
+++ b/sdk/python/pulumi_gcp/tags/tag_binding.py
@@ -141,9 +141,7 @@ class TagBinding(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="project_id")
+        project = gcp.organizations.Project("project", org_id="123456789")
         key = gcp.tags.TagKey("key",
             description="For keyname resources.",
             parent="organizations/123456789",
@@ -207,9 +205,7 @@ class TagBinding(pulumi.CustomResource):
         import pulumi
         import pulumi_gcp as gcp
 
-        project = gcp.organizations.Project("project",
-            org_id="123456789",
-            project_id="project_id")
+        project = gcp.organizations.Project("project", org_id="123456789")
         key = gcp.tags.TagKey("key",
             description="For keyname resources.",
             parent="organizations/123456789",


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-gcp/issues/1492

The `name` field of `gcp:organizations:Project` is cosmetic and does not need to be unique. It doesn't benefit from a random suffix.

The `project_id` field is structural and globally unique. To allow replaces (and ease of use), it should be auto-named.