### PR TITLE
Add more test programs

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -80,6 +80,14 @@ func TestCloudFunction(t *testing.T) {
 	runTest(t, test(t, "test-programs/cloudfunctions-function"))
 }
 
+func TestNetwork(t *testing.T) {
+	runTest(t, test(t, "test-programs/network"))
+}
+
+func TestCluster(t *testing.T) {
+	runTest(t, test(t, "test-programs/cluster"))
+}
+
 // Test programs that were automatically extracted from examples without autocorrection.
 func TestAutoExtractedPrograms(t *testing.T) {
 	type testCase struct {

--- a/provider/test-programs/cluster/Pulumi.yaml
+++ b/provider/test-programs/cluster/Pulumi.yaml
@@ -1,0 +1,31 @@
+name: cluster
+runtime: yaml
+description: A minimal Google Cloud Pulumi YAML program
+resources:
+  serviceAccount:
+    type: gcp:serviceaccount:Account
+    properties:
+      accountId: service-account-1234
+      displayName: Service Account
+  primary:
+    type: gcp:container:Cluster
+    properties:
+      location: us-central1
+      # We can't create a cluster with no node pool defined, but we want to only use
+      #   # separately managed node pools. So we create the smallest possible default
+      #   # node pool and immediately delete it.
+      removeDefaultNodePool: true
+      initialNodeCount: 1
+  primarypreemptiblenodes:
+    type: gcp:container/nodePool:NodePool
+    properties:
+      name: 
+      location: us-central1
+      cluster: ${primary.name}
+      nodeCount: 1
+      nodeConfig:
+        preemptible: true
+        machineType: e2-medium
+        serviceAccount: ${serviceAccount.email}
+        oauthScopes:
+          - https://www.googleapis.com/auth/cloud-platform

--- a/provider/test-programs/network/Pulumi.yaml
+++ b/provider/test-programs/network/Pulumi.yaml
@@ -1,0 +1,26 @@
+name: network
+runtime: yaml
+description: A minimal Google Cloud Pulumi YAML program
+resources:
+  exampleNetwork:
+    type: gcp:compute/network:Network
+    properties:
+      name: pulumi-network
+      autoCreateSubnetworks: false  # We'll create our own subnetwork
+
+  exampleSubnetwork:
+    type: gcp:compute/subnetwork:Subnetwork
+    properties:
+      name: pulumi-subnetwork
+      network: ${exampleNetwork.id}
+      ipCidrRange: "10.2.0.0/16"
+      region: us-central1
+      
+  exampleRouter:
+    type: gcp:compute/router:Router
+    properties:
+      name: pulumi-router
+      network: ${exampleNetwork.id}
+      region: us-central1
+      bgp:
+        asn: 64514


### PR DESCRIPTION
Partially addresses https://github.com/pulumi/pulumi-gcp/issues/1500, at least for the resources accessible with our current credentials.

This adds tests for:
 - gcp:container/cluster:Cluster
 - gcp:serviceAccount/account:Account
 -  gcp:container/nodePool:NodePool
 - gcp:compute/subnetwork:Subnetwork
 -  gcp:compute/router:Router