### PR TITLE
Do not pin Java version

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -30,7 +30,6 @@ plugins:
 team: ecosystem
 goBuildParallelism: 2
 skipGoReleaserHooks: true
-javaGenVersion: v0.9.7
 runner:
   publish: pulumi-ubuntu-8core
   prerequisites: pulumi-ubuntu-8core

--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -56,7 +56,6 @@ jobs:
         automerge: ${{ inputs.automerge }}
         target-bridge-version: ${{ inputs.target-bridge-version }}
         target-pulumi-version: ${{ inputs.target-pulumi-version }}
-        target-java-version: v0.9.7
         pr-reviewers: ${{ inputs.pr-reviewers }}
         pr-description: ${{ inputs.pr-description }}
     - name: Call upgrade provider action

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -13,7 +13,6 @@ jobs:
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
         kind: all
-        target-java-version: v0.9.7
         email: bot@pulumi.com
         username: pulumi-bot
     - env:

--- a/.upgrade-config.yml
+++ b/.upgrade-config.yml
@@ -5,4 +5,3 @@ upstream-provider-name: terraform-provider-google-beta
 pulumi-infer-version: true
 remove-plugins: true
 pr-reviewers: iwahbe # Team: pulumi/Providers
-javaVersion: "v0.9.7"


### PR DESCRIPTION
An automatic upgrade failed today with an extra `v` in the java version path:
https://github.com/pulumi/pulumi-gcp/commit/5ce0cfb56a3daf6d71ae07516f1fb73a015999a2/checks

This provider [is already on JavaGen v0.9.9](https://github.com/pulumi/pulumi-gcp/blob/master/sdk/java/build.gradle#L47) - this change makes it so CI follows this pattern.


