### PR TITLE
Disable Network and Cluster tests

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -82,10 +82,12 @@ func TestCloudFunction(t *testing.T) {
 }
 
 func TestNetwork(t *testing.T) {
+	t.Skipf("skipping due to https://github.com/pulumi/pulumi-gcp/issues/1577")
 	runTest(t, test(t, "test-programs/network"))
 }
 
 func TestCluster(t *testing.T) {
+	t.Skipf("skipping due to https://github.com/pulumi/pulumi-gcp/issues/1577")
 	runTest(t, test(t, "test-programs/cluster"))
 }
 


### PR DESCRIPTION
Due to https://github.com/pulumi/pulumi-gcp/issues/1577 we should disable these tests to avoid a panic on a more recent providertest version.
