### PR TITLE
Fix secret_manager_secret migration from v6 to v7

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -459,3 +459,77 @@ func TestCheckConfigWrongRegion(t *testing.T) {
 `,
 	)
 }
+
+func TestRegress1488(t *testing.T) {
+	// Test that going from replication.automatic: true (v6-style) to replication.auto: {}
+	// (v7-style) is not a replacement.
+	replay.ReplaySequence(t, providerServer(t), `[
+	{
+	  "method": "/pulumirpc.ResourceProvider/Configure",
+	  "request": {
+	    "variables": {
+	      "gcp:config:project": "pulumi-development"
+	    },
+	    "args": {
+	      "project": "pulumi-development",
+	      "version": "7.4.0"
+	    },
+	    "acceptSecrets": true,
+	    "acceptResources": true,
+	    "sendsOldInputs": true,
+	    "sendsOldInputsToDelete": true
+	  },
+	  "response": {
+	    "supportsPreview": true
+	  }
+	},
+	{
+	  "method": "/pulumirpc.ResourceProvider/Diff",
+	  "request": {
+	    "id": "projects/pulumi-development/secrets/my-secr",
+	    "urn": "urn:pulumi:dev::gcp-1488::gcp:secretmanager/secret:Secret::my-secr",
+	    "olds": {
+	      "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":1200000000000,\"delete\":1200000000000,\"update\":1200000000000}}",
+	      "createTime": "2024-01-31T22:23:26.772032Z",
+	      "expireTime": "",
+	      "id": "projects/pulumi-development/secrets/my-secr",
+	      "labels": {},
+	      "name": "projects/921927215178/secrets/my-secr",
+	      "project": "pulumi-development",
+	      "replication": {
+		"automatic": true,
+		"userManaged": null
+	      },
+	      "rotation": null,
+	      "secretId": "my-secr",
+	      "topics": []
+	    },
+	    "news": {
+	      "__defaults": [],
+	      "project": "pulumi-development",
+	      "replication": {
+		"__defaults": [],
+		"auto": {
+		  "__defaults": []
+		}
+	      },
+	      "secretId": "my-secr"
+	    },
+	    "oldInputs": {
+	      "__defaults": [],
+	      "project": "pulumi-development",
+	      "replication": {
+		"__defaults": [],
+		"automatic": true
+	      },
+	      "secretId": "my-secr"
+	    }
+	  },
+	  "response": {
+	    "stables": "*",
+	    "changes": "*",
+	    "hasDetailedDiff": "*"
+	  }
+	}
+	]`)
+}

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -18,6 +18,7 @@
 package gcp
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -461,17 +462,25 @@ func TestCheckConfigWrongRegion(t *testing.T) {
 }
 
 func TestRegress1488(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Only run in long mode, since we want credentials.")
+	}
+
 	// Test that going from replication.automatic: true (v6-style) to replication.auto: {}
 	// (v7-style) is not a replacement.
-	replay.ReplaySequence(t, providerServer(t), `[
+	proj := os.Getenv("GOOGLE_PROJECT")
+	if proj == "" {
+		proj = "pulumi-development"
+	}
+	replay.ReplaySequence(t, providerServer(t), fmt.Sprintf(`[
 	{
 	  "method": "/pulumirpc.ResourceProvider/Configure",
 	  "request": {
 	    "variables": {
-	      "gcp:config:project": "pulumi-development"
+	      "gcp:config:project": %q
 	    },
 	    "args": {
-	      "project": "pulumi-development",
+	      "project": %q,
 	      "version": "7.4.0"
 	    },
 	    "acceptSecrets": true,
@@ -531,5 +540,5 @@ func TestRegress1488(t *testing.T) {
 	    "hasDetailedDiff": "*"
 	  }
 	}
-	]`)
+	]`, proj, proj))
 }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2559,9 +2559,7 @@ func Provider() tfbridge.ProviderInfo {
 			"google_identity_platform_tenant": {Tok: gcpResource(gcpIdentityPlatform, "Tenant")},
 
 			// Secret Manager
-			"google_secret_manager_secret": {
-				DeleteBeforeReplace: true,
-			},
+			"google_secret_manager_secret": resourceSecretManagerSecret(),
 			"google_secret_manager_secret_iam_binding": {
 				Docs: &tfbridge.DocInfo{
 					Source: "secret_manager_secret_iam.html.markdown",

--- a/provider/secret_manager.go
+++ b/provider/secret_manager.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2024, Pulumi Corporation.  All rights reserved.
+
+package gcp
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func resourceSecretManagerSecret() *tfbridge.ResourceInfo {
+	// Between v6..v7 upstream changed the schema from replication.auto to replication.automatic
+	// but due to pulumi/pulumi-terraform-bridge#1667 it is not handled correctly in the bridged
+	// provider causing unexpected replacements. To compensate, this bit of code auto-migrates
+	// Pulumi state into a form that works well with the v7-style schema.
+	//
+	// replication.automatic: true  --> replication.auto: {}
+	//
+	// The case of automatic: false or missing automatic does not seem to exist in practice
+	// because GCP v6 rejects this and insists on the user setting replication to user_managed.
+	fixReplicationAuto := func(pm resource.PropertyMap) resource.PropertyMap {
+		pmCopy := pm.Copy()
+		replication, gotReplication := pmCopy["replication"]
+		if !gotReplication || !replication.IsObject() {
+			return pmCopy
+		}
+		replicationCopy := replication.ObjectValue().Copy()
+		automatic, gotAutomatic := replicationCopy["automatic"]
+		if !gotAutomatic {
+			return pmCopy
+		}
+		_, gotAuto := replicationCopy["auto"]
+		if automatic.IsBool() && automatic.BoolValue() == true && !gotAuto {
+			auto := resource.NewObjectProperty(resource.PropertyMap{})
+			replicationCopy["auto"] = auto
+		}
+		delete(replicationCopy, "automatic")
+		pmCopy["replication"] = resource.NewObjectProperty(replicationCopy)
+		return pmCopy
+	}
+
+	return &tfbridge.ResourceInfo{
+		DeleteBeforeReplace: true,
+		TransformFromState: func(
+			ctx context.Context, pm resource.PropertyMap,
+		) (resource.PropertyMap, error) {
+			return fixReplicationAuto(pm), nil
+		},
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-gcp/issues/1488 - with this change users can now upgrade from v6 to v7 version of the provider without replacing gcp.secretmanager.Secret resources that use automatic replication.

That is going from this code in V6:

```python
    secret = gcp.secretmanager.Secret(
        "my-secr",
        project="pulumi-development",
        secret_id="my-secr",
        replication=gcp.secretmanager.SecretReplicationArgs(
            automatic=True
        )
    )
```

To the following code in V7:

```python
    secret = gcp.secretmanager.Secret(
        "my-secr",
        project="pulumi-development",
        secret_id="my-secr",
        replication=gcp.secretmanager.SecretReplicationArgs(
            auto=gcp.secretmanager.SecretReplicationAutoArgs()
        )
    )
```


Now produces an Update, and not a Replace plan.

Fixes: https://github.com/pulumi/pulumi-gcp/pull/1623