### PR TITLE
Fix TestWarningsNotDuplicated test

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -49,7 +49,8 @@ func TestWarningsNotDuplicated(t *testing.T) {
 		SkipRefresh:   true,
 		Env:           []string{"GOOGLE_PROJECT=", "GOOGLE_APPLICATION_CREDENTIALS="},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.LessOrEqual(t, 1, strings.Count(outputBuf.String(), "Pulumi will rely on per-resource settings for this operation"))
+			actualCount := strings.Count(outputBuf.String(), "Pulumi will rely on per-resource settings for this operation")
+			assert.LessOrEqual(t, actualCount, 1)
 		},
 	}
 	integration.ProgramTest(t, &opts)


### PR DESCRIPTION
Looks like we accidentally flipped the sign in the assert, which caused it to eventually fail blocking a release. 