### PR TITLE
Reintroduce region checks

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -7,6 +7,7 @@ package examples
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -54,4 +55,12 @@ func TestWarningsNotDuplicated(t *testing.T) {
 		},
 	}
 	integration.ProgramTest(t, &opts)
+}
+
+func TestInvalidExplicitProviderProject(t *testing.T) {
+	gcpProject := os.Getenv("GCP_PROJECT")
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join(getCwd(t), "non-existent-project"),
+		Config: map[string]string{"gcpProj": gcpProject},
+	})
 }

--- a/examples/non-existent-project/Pulumi.yaml
+++ b/examples/non-existent-project/Pulumi.yaml
@@ -1,0 +1,15 @@
+name: non-existent-project
+runtime: yaml
+config:
+  gcpProj: string
+resources:
+  _:
+    type: pulumi:providers:gcp
+    properties:
+      project: an-invalid-project
+    defaultProvider: true
+  b:
+    type: gcp:storage:Bucket
+    properties:
+      project: ${gcpProj}
+      location: us-west1

--- a/provider/errors/no_credentials.txt
+++ b/provider/errors/no_credentials.txt
@@ -1,0 +1,5 @@
+failed to load application credentials.
+To use your default gcloud credentials, run:
+	`gcloud auth application-default login`
+See https://www.pulumi.com/registry/packages/gcp/installation-configuration/ for details.
+Expanded error message: %w

--- a/provider/errors/no_project.txt
+++ b/provider/errors/no_project.txt
@@ -1,0 +1,4 @@
+unable to detect a global setting for GCP Project.
+Pulumi will rely on per-resource settings for this operation.
+Set the GCP Project by using:
+    `pulumi config set gcp:project <project>`

--- a/provider/errors/wrong_region.txt
+++ b/provider/errors/wrong_region.txt
@@ -1,0 +1,2 @@
+region %q is not available for project %q.
+Please see https://cloud.google.com/compute/docs/regions-zones/viewing-regions-zones#viewing_a_list_of_available_regions for a list of available regions

--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -1,0 +1,99 @@
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+func WithoutAuthentication(options *preConfigureCallbackOpts) {
+	options.gcpClientOpts = append(options.gcpClientOpts, option.WithoutAuthentication())
+}
+
+func WithEndpoint(endpoint string) func(*preConfigureCallbackOpts) {
+	return func(options *preConfigureCallbackOpts) {
+		options.gcpClientOpts = append(options.gcpClientOpts, option.WithEndpoint(endpoint))
+	}
+}
+
+func RegionListReturnHandler(regions []string) func (http.ResponseWriter, *http.Request) {
+	regionList := make([]*compute.Region, 0, len(regions))
+	for _, region := range regions {
+		regionList = append(regionList, &compute.Region{Name: region})
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := &compute.RegionList{
+			Items: regionList,
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write(b)
+	}
+}
+
+func TestPreConfigureCallbackNoErrWhenRegionMatches(t *testing.T) {
+	var credentialsValidationRun atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(RegionListReturnHandler([]string{"region1"})))
+	defer ts.Close()
+
+	t.Setenv("GOOGLE_PROJECT", "myproject")
+	t.Setenv("GOOGLE_REGION", "region1")
+
+	preConfigureCall := preConfigureCallbackWithLogger(
+		&credentialsValidationRun, WithoutAuthentication, WithEndpoint(ts.URL),
+	)
+	err := preConfigureCall(context.Background(), nil, nil, nil)
+	require.NoError(t, err)
+}
+
+func TestPreConfigureCallbackErrWhenRegionDifferent(t *testing.T) {
+	var credentialsValidationRun atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(RegionListReturnHandler([]string{"region1"})))
+	defer ts.Close()
+
+	t.Setenv("GOOGLE_PROJECT", "myproject")
+	t.Setenv("GOOGLE_REGION", "region2")
+
+	preConfigureCall := preConfigureCallbackWithLogger(
+		&credentialsValidationRun, WithoutAuthentication, WithEndpoint(ts.URL),
+	)
+	err := preConfigureCall(context.Background(), nil, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `region "region2" is not available for project "myproject"`)
+}
+
+func RegionListErrorHandler(message string, status int) func (http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, message, status)
+	}
+}
+
+func TestPreConfigureCallbackNoErrWhenRegionListCallErrors(t *testing.T) {
+	var credentialsValidationRun atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		RegionListErrorHandler("Error with region list", http.StatusBadRequest)),
+	)
+	defer ts.Close()
+
+	t.Setenv("GOOGLE_PROJECT", "myproject")
+	t.Setenv("GOOGLE_REGION", "region2")
+
+	preConfigureCall := preConfigureCallbackWithLogger(
+		&credentialsValidationRun, WithoutAuthentication, WithEndpoint(ts.URL),
+	)
+	err := preConfigureCall(context.Background(), nil, nil, nil)
+	require.NoError(t, err)
+}

--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -32,6 +32,9 @@ func RegionListReturnHandler(regions []string) func(http.ResponseWriter, *http.R
 }
 
 func TestPreConfigureCallbackNoErrWhenRegionMatches(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
 	var credentialsValidationRun atomic.Bool
 
 	ts := httptest.NewServer(http.HandlerFunc(RegionListReturnHandler([]string{"region1"})))
@@ -50,6 +53,9 @@ func TestPreConfigureCallbackNoErrWhenRegionMatches(t *testing.T) {
 }
 
 func TestPreConfigureCallbackErrWhenRegionDifferent(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
 	var credentialsValidationRun atomic.Bool
 
 	ts := httptest.NewServer(http.HandlerFunc(RegionListReturnHandler([]string{"region1"})))
@@ -70,6 +76,9 @@ func TestPreConfigureCallbackErrWhenRegionDifferent(t *testing.T) {
 }
 
 func TestPreConfigureCallbackNoErrWhenRegionCheckSkipped(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
 	var credentialsValidationRun atomic.Bool
 
 	ts := httptest.NewServer(http.HandlerFunc(RegionListReturnHandler([]string{"region1"})))
@@ -96,6 +105,9 @@ func RegionListErrorHandler(message string, status int) func(http.ResponseWriter
 }
 
 func TestPreConfigureCallbackNoErrWhenRegionListCallErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
 	var credentialsValidationRun atomic.Bool
 
 	ts := httptest.NewServer(http.HandlerFunc(

--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-func RegionListReturnHandler(regions []string) func (http.ResponseWriter, *http.Request) {
+func RegionListReturnHandler(regions []string) func(http.ResponseWriter, *http.Request) {
 	regionList := make([]*compute.Region, 0, len(regions))
 	for _, region := range regions {
 		regionList = append(regionList, &compute.Region{Name: region})
@@ -89,7 +89,7 @@ func TestPreConfigureCallbackNoErrWhenRegionCheckSkipped(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func RegionListErrorHandler(message string, status int) func (http.ResponseWriter, *http.Request) {
+func RegionListErrorHandler(message string, status int) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, status)
 	}

--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -52,7 +52,7 @@ func TestPreConfigureCallbackNoErrWhenRegionMatches(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPreConfigureCallbackErrWhenRegionDifferent(t *testing.T) {
+func TestPreConfigureCallbackNoErrWhenRegionDifferent(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
 	}
@@ -71,8 +71,7 @@ func TestPreConfigureCallbackErrWhenRegionDifferent(t *testing.T) {
 	)
 
 	err := preConfigureCall(context.Background(), nil, nil, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), `region "region2" is not available for project "myproject"`)
+	require.NoError(t, err)
 }
 
 func TestPreConfigureCallbackNoErrWhenRegionCheckSkipped(t *testing.T) {

--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -13,16 +13,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-func WithoutAuthentication(options *preConfigureCallbackOpts) {
-	options.gcpClientOpts = append(options.gcpClientOpts, option.WithoutAuthentication())
-}
-
-func WithEndpoint(endpoint string) func(*preConfigureCallbackOpts) {
-	return func(options *preConfigureCallbackOpts) {
-		options.gcpClientOpts = append(options.gcpClientOpts, option.WithEndpoint(endpoint))
-	}
-}
-
 func RegionListReturnHandler(regions []string) func (http.ResponseWriter, *http.Request) {
 	regionList := make([]*compute.Region, 0, len(regions))
 	for _, region := range regions {
@@ -51,7 +41,9 @@ func TestPreConfigureCallbackNoErrWhenRegionMatches(t *testing.T) {
 	t.Setenv("GOOGLE_REGION", "region1")
 
 	preConfigureCall := preConfigureCallbackWithLogger(
-		&credentialsValidationRun, WithoutAuthentication, WithEndpoint(ts.URL),
+		&credentialsValidationRun, []option.ClientOption{
+			option.WithoutAuthentication(), option.WithEndpoint(ts.URL),
+		},
 	)
 	err := preConfigureCall(context.Background(), nil, nil, nil)
 	require.NoError(t, err)
@@ -67,8 +59,11 @@ func TestPreConfigureCallbackErrWhenRegionDifferent(t *testing.T) {
 	t.Setenv("GOOGLE_REGION", "region2")
 
 	preConfigureCall := preConfigureCallbackWithLogger(
-		&credentialsValidationRun, WithoutAuthentication, WithEndpoint(ts.URL),
+		&credentialsValidationRun, []option.ClientOption{
+			option.WithoutAuthentication(), option.WithEndpoint(ts.URL),
+		},
 	)
+
 	err := preConfigureCall(context.Background(), nil, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `region "region2" is not available for project "myproject"`)
@@ -92,7 +87,9 @@ func TestPreConfigureCallbackNoErrWhenRegionListCallErrors(t *testing.T) {
 	t.Setenv("GOOGLE_REGION", "region2")
 
 	preConfigureCall := preConfigureCallbackWithLogger(
-		&credentialsValidationRun, WithoutAuthentication, WithEndpoint(ts.URL),
+		&credentialsValidationRun, []option.ClientOption{
+			option.WithoutAuthentication(), option.WithEndpoint(ts.URL),
+		},
 	)
 	err := preConfigureCall(context.Background(), nil, nil, nil)
 	require.NoError(t, err)

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,6 +3,7 @@ module github.com/pulumi/pulumi-gcp/provider/v7
 go 1.21.0
 
 require (
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/terraform-provider-google-beta v0.0.0
 	github.com/pulumi/providertest v0.0.10
 	github.com/pulumi/pulumi-terraform-bridge/pf v0.27.0
@@ -10,6 +11,7 @@ require (
 	github.com/pulumi/pulumi/pkg/v3 v3.105.0
 	github.com/pulumi/pulumi/sdk/v3 v3.105.0
 	github.com/stretchr/testify v1.8.4
+	google.golang.org/api v0.157.0
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600
 )
 
@@ -154,7 +156,6 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.21.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-mux v0.14.0 // indirect
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/vault/api v1.8.2 // indirect
@@ -261,7 +262,6 @@ require (
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
-	google.golang.org/api v0.156.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -3282,8 +3282,8 @@ google.golang.org/api v0.108.0/go.mod h1:2Ts0XTHNVWxypznxWOYUeI4g3WdP9Pk2Qk58+a/
 google.golang.org/api v0.110.0/go.mod h1:7FC4Vvx1Mooxh8C5HWjzZHcavuS2f6pmJpZx60ca7iI=
 google.golang.org/api v0.111.0/go.mod h1:qtFHvU9mhgTJegR31csQ+rwxyUTHOKFqCKWp1J0fdw0=
 google.golang.org/api v0.114.0/go.mod h1:ifYI2ZsFK6/uGddGfAD5BMxlnkBqCmqHSDUVi45N5Yg=
-google.golang.org/api v0.156.0 h1:yloYcGbBtVYjLKQe4enCunxvwn3s2w/XPrrhVf6MsvQ=
-google.golang.org/api v0.156.0/go.mod h1:bUSmn4KFO0Q+69zo9CNIDp4Psi6BqM0np0CbzKRSiSY=
+google.golang.org/api v0.157.0 h1:ORAeqmbrrozeyw5NjnMxh7peHO0UzV4wWYSwZeCUb20=
+google.golang.org/api v0.157.0/go.mod h1:+z4v4ufbZ1WEpld6yMGHyggs+PmAHiaLNj5ytP3N01g=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -54,6 +54,8 @@ func testProviderUpgradeWithConfig(t *testing.T, dir, baselineVersion string, co
 			test.SetConfig(k, v)
 		}
 	}
+	// The SetConfig above does not seem to be working here.
+	t.Setenv("PULUMI_GCP_SKIP_REGION_VALIDATION", "true")
 	result := providertest.PreviewProviderUpgrade(test, providerName, baselineVersion, optproviderupgrade.DisableAttach())
 	assertpreview.HasNoReplacements(t, result)
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
 	"github.com/pulumi/providertest/pulumitest/opttest"
-
-	"github.com/pulumi/pulumi-gcp/provider/v7/pkg/version"
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-gcp/provider/v7/pkg/version"
 )
 
 const (

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -18,8 +18,10 @@
 package gcp
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/providertest/replay"
@@ -392,4 +394,151 @@ func TestOrganizationsProjectAutoNaming(t *testing.T) {
         "name": "gcp"
     }
 }`)
+}
+
+func TestCheckConfigNoCredentials(t *testing.T) {
+	if !testing.Short() {
+		t.Skip("Only run in short mode, since we want to NOT have credentials.")
+	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("GOOGLE_GHA_CREDS_PATH", "")
+	t.Setenv("GOOGLE_PROJECT", "")
+	t.Setenv("GOOGLE_ZONE", "")
+	t.Setenv("GOOGLE_REGION", "")
+	replay.Replay(t, providerServer(t), strings.ReplaceAll(`
+{
+	"method": "/pulumirpc.ResourceProvider/CheckConfig",
+    "request": {
+        "urn": "urn:pulumi:dev::gcp_vm::pulumi:providers:gcp::default_7_6_0",
+        "olds": {
+        },
+        "news": {
+            "version": "7.6.0"
+        }
+    },
+    "errors": [
+        "failed to load application credentials.\nTo use your default gcloud credentials, run:\n\t$gcloud auth application-default login$\nSee https://www.pulumi.com/registry/packages/gcp/installation-configuration/ for details.\nExpanded error message: Attempted to load application default credentials since neither $credentials$ nor $access_token$ was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: google: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information"
+    ],
+    "metadata": {
+        "kind": "resource",
+        "mode": "client",
+        "name": "gcp"
+    }
+}
+`, "$", "`"),
+	)
+}
+
+func TestCheckConfigWrongRegion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Only run in long mode, since we want credentials.")
+	}
+	t.Setenv("GOOGLE_REGION", "")
+	t.Setenv("GOOGLE_ZONE", "")
+	proj := os.Getenv("GOOGLE_PROJECT")
+	replay.Replay(t, providerServer(t), `
+	{
+		"method": "/pulumirpc.ResourceProvider/CheckConfig",
+		"request": {
+			"urn": "urn:pulumi:dev::gcp_vm::pulumi:providers:gcp::default_7_6_0",
+			"olds": {
+			},
+			"news": {
+				"region": "westus",
+				"version": "7.6.0"
+			}
+		},
+		"errors": [
+			"region \"westus\" is not available for project \"`+proj+`\".\nPlease see https://cloud.google.com/compute/docs/regions-zones/viewing-regions-zones#viewing_a_list_of_available_regions for a list of available regions"
+		],
+		"metadata": {
+			"kind": "resource",
+			"mode": "client",
+			"name": "gcp"
+		}
+	}
+`,
+	)
+}
+
+func TestRegress1488(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Only run in long mode, since we want credentials.")
+	}
+
+	// Test that going from replication.automatic: true (v6-style) to replication.auto: {}
+	// (v7-style) is not a replacement.
+	proj := os.Getenv("GOOGLE_PROJECT")
+	if proj == "" {
+		proj = "pulumi-development"
+	}
+	replay.ReplaySequence(t, providerServer(t), fmt.Sprintf(`[
+	{
+	  "method": "/pulumirpc.ResourceProvider/Configure",
+	  "request": {
+	    "variables": {
+	      "gcp:config:project": %q
+	    },
+	    "args": {
+	      "project": %q,
+	      "version": "7.4.0"
+	    },
+	    "acceptSecrets": true,
+	    "acceptResources": true,
+	    "sendsOldInputs": true,
+	    "sendsOldInputsToDelete": true
+	  },
+	  "response": {
+	    "supportsPreview": true
+	  }
+	},
+	{
+	  "method": "/pulumirpc.ResourceProvider/Diff",
+	  "request": {
+	    "id": "projects/pulumi-development/secrets/my-secr",
+	    "urn": "urn:pulumi:dev::gcp-1488::gcp:secretmanager/secret:Secret::my-secr",
+	    "olds": {
+	      "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":1200000000000,\"delete\":1200000000000,\"update\":1200000000000}}",
+	      "createTime": "2024-01-31T22:23:26.772032Z",
+	      "expireTime": "",
+	      "id": "projects/pulumi-development/secrets/my-secr",
+	      "labels": {},
+	      "name": "projects/921927215178/secrets/my-secr",
+	      "project": "pulumi-development",
+	      "replication": {
+		"automatic": true,
+		"userManaged": null
+	      },
+	      "rotation": null,
+	      "secretId": "my-secr",
+	      "topics": []
+	    },
+	    "news": {
+	      "__defaults": [],
+	      "project": "pulumi-development",
+	      "replication": {
+		"__defaults": [],
+		"auto": {
+		  "__defaults": []
+		}
+	      },
+	      "secretId": "my-secr"
+	    },
+	    "oldInputs": {
+	      "__defaults": [],
+	      "project": "pulumi-development",
+	      "replication": {
+		"__defaults": [],
+		"automatic": true
+	      },
+	      "secretId": "my-secr"
+	    }
+	  },
+	  "response": {
+	    "stables": "*",
+	    "changes": "*",
+	    "hasDetailedDiff": "*"
+	  }
+	}
+	]`, proj, proj))
 }

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -112,8 +112,8 @@ func TestTopicIamBinding(t *testing.T) {
 }
 
 func TestWrongRegionWarning(t *testing.T) {
-	if !testing.Short() {
-		t.Skip("Only run in short mode, since we want to NOT have credentials.")
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
 	}
 	t.Setenv("GOOGLE_REGION", "westus")
 

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -133,8 +133,8 @@ func TestWrongRegionWarning(t *testing.T) {
 }
 
 func TestNoGlobalProjectWarning(t *testing.T) {
-	if !testing.Short() {
-		t.Skip("Only run in short mode, since we want to NOT have credentials.")
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
 	}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -358,6 +358,7 @@ func logOrPrint(ctx context.Context, host *provider.HostClient, msg string) {
 	}
 }
 
+// gcpClientOpts is used to pass in options during testing.
 func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpClientOpts []option.ClientOption) func(
 	ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig,
 ) error {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	gcpPFProvider "github.com/hashicorp/terraform-provider-google-beta/google-beta/fwprovider"
 	gcpProvider "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
 	tpg_transport "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
@@ -24,6 +25,7 @@ import (
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"google.golang.org/api/compute/v1"
 
 	"github.com/pulumi/pulumi-gcp/provider/v7/pkg/version"
 )
@@ -317,65 +319,101 @@ func nameField(info *tfbridge.SchemaInfo) map[string]*tfbridge.SchemaInfo {
 	}
 }
 
-// We should only run the validation once to avoid duplicating the reported errors.
-var credentialsValidationRun atomic.Bool
-
-func preConfigureCallbackWithLogger(ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig) error {
-	if !credentialsValidationRun.CompareAndSwap(false, true) {
-		return nil
+func getRegionsList(project string) ([]string, error) {
+	computeService, err := compute.NewService(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create compute service: %w", err)
 	}
-	project := tfbridge.ConfigStringValue(vars, "project", []string{
-		"GOOGLE_PROJECT",
-		"GOOGLE_CLOUD_PROJECT",
-		"GCLOUD_PROJECT",
-		"CLOUDSDK_CORE_PROJECT",
-	})
-	if project == "" {
-		msg := "unable to detect a global setting for GCP Project;\n" +
-			"Pulumi will rely on per-resource settings for this operation.\n" +
-			"Set the GCP Project by using:\n" +
-			"\t`pulumi config set gcp:project <project>`"
-		host.Log(ctx, diag.Warning, "", msg) // the URN will default to the root stack name which is exactly what we want
-		//return fmt.Errorf("unable to find required configuration setting: GCP Project\n" +
-		//"Set the GCP Project by using:\n" +
-		//"\t`pulumi config set gcp:project <project>`")
-		//
-		return nil
+	regionsService := compute.NewRegionsService(computeService)
+	regionList, err := regionsService.List(project).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list regions: %w", err)
 	}
+	var regions []string
+	for _, region := range regionList.Items {
+		regions = append(regions, region.Name)
+	}
+	return regions, nil
+}
 
-	config := tpg_transport.Config{
-		AccessToken: tfbridge.ConfigStringValue(vars, "accessToken", []string{"GOOGLE_OAUTH_ACCESS_TOKEN"}),
-		Credentials: tfbridge.ConfigStringValue(vars, "credentials", []string{
-			"GOOGLE_CREDENTIALS",
-			"GOOGLE_CLOUD_KEYFILE_JSON",
-			"GCLOUD_KEYFILE_JSON",
-		}),
-		ImpersonateServiceAccount: tfbridge.ConfigStringValue(vars, "impersonateServiceAccount", []string{"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"}),
-		Project: tfbridge.ConfigStringValue(vars, "project", []string{
+//go:embed errors/no_credentials.txt
+var noCredentialsErr string
+
+//go:embed errors/wrong_region.txt
+var wrongRegionErr string
+
+//go:embed errors/no_project.txt
+var noProjectErr string
+
+func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool) func(
+	ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig,
+) error {
+	return func(ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig) error {
+		if !credentialsValidationRun.CompareAndSwap(false, true) {
+			return nil
+		}
+		project := tfbridge.ConfigStringValue(vars, "project", []string{
 			"GOOGLE_PROJECT",
 			"GOOGLE_CLOUD_PROJECT",
 			"GCLOUD_PROJECT",
 			"CLOUDSDK_CORE_PROJECT",
-		}),
-		Region: tfbridge.ConfigStringValue(vars, "region", []string{
-			"GOOGLE_REGION",
-			"GCLOUD_REGION",
-			"CLOUDSDK_COMPUTE_REGION",
-		}),
-		Zone: tfbridge.ConfigStringValue(vars, "zone", []string{
-			"GOOGLE_ZONE",
-			"GCLOUD_ZONE",
-			"CLOUDSDK_COMPUTE_ZONE",
-		}),
-	}
+		})
+		// host is nil in tests.
+		if project == "" && host != nil {
+			host.Log(ctx, diag.Warning, "", noProjectErr) // the URN will default to the root stack name which is exactly what we want
+		}
 
-	// validate the gcloud config
-	err := config.LoadAndValidate(context.Background())
-	if err != nil {
-		return fmt.Errorf(
-			"failed to load application credentials.\nTo use your default gcloud credentials, run:\n\t`gcloud auth application-default login`\nSee https://www.pulumi.com/registry/packages/gcp/installation-configuration/ for details.\nExpanded error message: %w", err)
+		config := tpg_transport.Config{
+			AccessToken: tfbridge.ConfigStringValue(vars, "accessToken", []string{"GOOGLE_OAUTH_ACCESS_TOKEN"}),
+			Credentials: tfbridge.ConfigStringValue(vars, "credentials", []string{
+				"GOOGLE_CREDENTIALS",
+				"GOOGLE_CLOUD_KEYFILE_JSON",
+				"GCLOUD_KEYFILE_JSON",
+			}),
+			ImpersonateServiceAccount: tfbridge.ConfigStringValue(vars, "impersonateServiceAccount", []string{"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"}),
+			Project: tfbridge.ConfigStringValue(vars, "project", []string{
+				"GOOGLE_PROJECT",
+				"GOOGLE_CLOUD_PROJECT",
+				"GCLOUD_PROJECT",
+				"CLOUDSDK_CORE_PROJECT",
+			}),
+			Region: tfbridge.ConfigStringValue(vars, "region", []string{
+				"GOOGLE_REGION",
+				"GCLOUD_REGION",
+				"CLOUDSDK_COMPUTE_REGION",
+			}),
+			Zone: tfbridge.ConfigStringValue(vars, "zone", []string{
+				"GOOGLE_ZONE",
+				"GCLOUD_ZONE",
+				"CLOUDSDK_COMPUTE_ZONE",
+			}),
+		}
+
+		// validate the gcloud config
+		err := config.LoadAndValidate(context.Background())
+		if err != nil {
+			return fmt.Errorf(noCredentialsErr, err)
+		}
+
+		skipRegionValidation := tfbridge.ConfigBoolValue(
+			vars, "skipRegionValidation", []string{"PULUMI_GCP_SKIP_REGION_VALIDATION"},
+		)
+
+		if !skipRegionValidation && config.Region != "" && config.Project != "" {
+			regionList, err := getRegionsList(config.Project)
+			if err != nil {
+				return fmt.Errorf("failed to get regions list: %w", err)
+			}
+			for _, region := range regionList {
+				if region == config.Region {
+					return nil
+				}
+			}
+			return fmt.Errorf(wrongRegionErr, config.Region, config.Project)
+		}
+
+		return nil
 	}
-	return nil
 }
 
 //go:embed cmd/pulumi-resource-gcp/bridge-metadata.json
@@ -387,6 +425,10 @@ func Provider() tfbridge.ProviderInfo {
 		context.Background(),
 		shimv2.NewProvider(gcpProvider.Provider(), shimv2.WithDiffStrategy(shimv2.PlanState)),
 		gcpPFProvider.New(version.Version)) // this probably should be TF version but it does not seem to matter
+
+	// We should only run the validation once to avoid duplicating the reported errors.
+	var credentialsValidationRun atomic.Bool
+
 	prov := tfbridge.ProviderInfo{
 		P:                           p,
 		Name:                        "google-beta",
@@ -432,13 +474,27 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 		},
+		ExtraConfig: map[string]*tfbridge.ConfigInfo{
+			"skipRegionValidation": {
+				Schema: shimv2.NewSchema(&schema.Schema{
+					Type:     schema.TypeBool,
+					Optional: true,
+				}),
+				Info: &tfbridge.SchemaInfo{
+					Default: &tfbridge.DefaultInfo{
+						Value:   false,
+						EnvVars: []string{"PULUMI_GCP_SKIP_REGION_VALIDATION"},
+					},
+				},
+			},
+		},
 		IgnoreMappings: []string{
 			// There is a resource and data source, identically named. The outputs of the data source share identical
 			// types with the resource.
 			// See: https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/data_source_dataproc_metastore_service
 			"google_dataproc_metastore_service",
 		},
-		PreConfigureCallbackWithLogger: preConfigureCallbackWithLogger,
+		PreConfigureCallbackWithLogger: preConfigureCallbackWithLogger(&credentialsValidationRun),
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// Access Context Manager
 			"google_access_context_manager_access_level": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -360,9 +360,9 @@ func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpCl
 			"GCLOUD_PROJECT",
 			"CLOUDSDK_CORE_PROJECT",
 		})
-		// host is nil in tests.
-		if project == "" && host != nil {
+		if project == "" {
 			host.Log(ctx, diag.Warning, "", noProjectErr) // the URN will default to the root stack name which is exactly what we want
+			return nil
 		}
 
 		config := tpg_transport.Config{
@@ -404,10 +404,7 @@ func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpCl
 		if !skipRegionValidation && config.Region != "" && config.Project != "" {
 			regionList, err := getRegionsList(ctx, config.Project, gcpClientOpts)
 			if err != nil {
-				// host is nil in tests.
-				if host != nil {
-					_ = host.Log(ctx, diag.Warning, "", fmt.Sprintf("failed to get regions list: %v", err))
-				}
+				_ = host.Log(ctx, diag.Warning, "", fmt.Sprintf("failed to get regions list: %v", err))
 				return nil
 			}
 			for _, region := range regionList {
@@ -415,7 +412,7 @@ func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpCl
 					return nil
 				}
 			}
-			return fmt.Errorf(wrongRegionErr, config.Region, config.Project)
+			_ = host.Log(ctx, diag.Warning, "",fmt.Sprintf(wrongRegionErr, config.Region, config.Project))
 		}
 
 		return nil

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -4,29 +4,30 @@ package gcp
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"path"
 	"strings"
 	"sync/atomic"
 	"unicode"
 
-	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	_ "embed"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	gcpPFProvider "github.com/hashicorp/terraform-provider-google-beta/google-beta/fwprovider"
 	gcpProvider "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
 	tpg_transport "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+
 	pf "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	tks "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/option"
 
 	"github.com/pulumi/pulumi-gcp/provider/v7/pkg/version"
 )

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -346,19 +346,9 @@ var wrongRegionErr string
 //go:embed errors/no_project.txt
 var noProjectErr string
 
-type preConfigureCallbackOpts struct {
-	gcpClientOpts []option.ClientOption
-}
-
-type preConfigureCallbackOption func (options *preConfigureCallbackOpts)
-
-func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, opts ...preConfigureCallbackOption) func(
+func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpClientOpts []option.ClientOption) func(
 	ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig,
 ) error {
-	options := preConfigureCallbackOpts{}
-	for _, opt := range opts {
-		opt(&options)
-	}
 	return func(ctx context.Context, host *provider.HostClient, vars resource.PropertyMap, c shim.ResourceConfig) error {
 		if !credentialsValidationRun.CompareAndSwap(false, true) {
 			return nil
@@ -411,7 +401,7 @@ func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, opts 
 		)
 
 		if !skipRegionValidation && config.Region != "" && config.Project != "" {
-			regionList, err := getRegionsList(ctx, config.Project, options.gcpClientOpts)
+			regionList, err := getRegionsList(ctx, config.Project, gcpClientOpts)
 			if err != nil {
 				// host is nil in tests.
 				if host != nil {
@@ -509,7 +499,7 @@ func Provider() tfbridge.ProviderInfo {
 			// See: https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/data_source_dataproc_metastore_service
 			"google_dataproc_metastore_service",
 		},
-		PreConfigureCallbackWithLogger: preConfigureCallbackWithLogger(&credentialsValidationRun),
+		PreConfigureCallbackWithLogger: preConfigureCallbackWithLogger(&credentialsValidationRun, nil),
 		Resources: map[string]*tfbridge.ResourceInfo{
 			// Access Context Manager
 			"google_access_context_manager_access_level": {

--- a/provider/test-programs/project-bucket/Pulumi.yaml
+++ b/provider/test-programs/project-bucket/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: simple-bucket
+runtime: yaml
+description: A minimal Google Cloud Pulumi YAML program
+config:
+  gcpProj: string
+resources:
+  # Create a GCP resource (Storage Bucket)
+  my-bucket:
+    properties:
+      location: US
+      project: ${gcpProj}
+    type: gcp:storage:Bucket

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -1026,6 +1026,13 @@ namespace Pulumi.Gcp
             set => _serviceUsageCustomEndpoint.Set(value);
         }
 
+        private static readonly __Value<bool?> _skipRegionValidation = new __Value<bool?>(() => __config.GetBoolean("skipRegionValidation") ?? Utilities.GetEnvBoolean("PULUMI_GCP_SKIP_REGION_VALIDATION") ?? false);
+        public static bool? SkipRegionValidation
+        {
+            get => _skipRegionValidation.Get();
+            set => _skipRegionValidation.Set(value);
+        }
+
         private static readonly __Value<string?> _sourceRepoCustomEndpoint = new __Value<string?>(() => __config.Get("sourceRepoCustomEndpoint"));
         public static string? SourceRepoCustomEndpoint
         {

--- a/sdk/go/gcp/config/config.go
+++ b/sdk/go/gcp/config/config.go
@@ -453,6 +453,17 @@ func GetServiceNetworkingCustomEndpoint(ctx *pulumi.Context) string {
 func GetServiceUsageCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:serviceUsageCustomEndpoint")
 }
+func GetSkipRegionValidation(ctx *pulumi.Context) bool {
+	v, err := config.TryBool(ctx, "gcp:skipRegionValidation")
+	if err == nil {
+		return v
+	}
+	var value bool
+	if d := internal.GetEnvOrDefault(false, internal.ParseEnvBool, "PULUMI_GCP_SKIP_REGION_VALIDATION"); d != nil {
+		value = d.(bool)
+	}
+	return value
+}
 func GetSourceRepoCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:sourceRepoCustomEndpoint")
 }

--- a/sdk/java/src/main/java/com/pulumi/gcp/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/Config.java
@@ -441,6 +441,9 @@ public final class Config {
     public Optional<String> serviceUsageCustomEndpoint() {
         return Codegen.stringProp("serviceUsageCustomEndpoint").config(config).get();
     }
+    public Optional<Boolean> skipRegionValidation() {
+        return Codegen.booleanProp("skipRegionValidation").config(config).env("PULUMI_GCP_SKIP_REGION_VALIDATION").def(false).get();
+    }
     public Optional<String> sourceRepoCustomEndpoint() {
         return Codegen.stringProp("sourceRepoCustomEndpoint").config(config).get();
     }

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -1145,6 +1145,14 @@ Object.defineProperty(exports, "serviceUsageCustomEndpoint", {
     enumerable: true,
 });
 
+export declare const skipRegionValidation: boolean;
+Object.defineProperty(exports, "skipRegionValidation", {
+    get() {
+        return __config.getObject<boolean>("skipRegionValidation") ?? (utilities.getEnvBoolean("PULUMI_GCP_SKIP_REGION_VALIDATION") || false);
+    },
+    enumerable: true,
+});
+
 export declare const sourceRepoCustomEndpoint: string | undefined;
 Object.defineProperty(exports, "sourceRepoCustomEndpoint", {
     get() {

--- a/sdk/python/pulumi_gcp/config/__init__.pyi
+++ b/sdk/python/pulumi_gcp/config/__init__.pyi
@@ -294,6 +294,8 @@ serviceNetworkingCustomEndpoint: Optional[str]
 
 serviceUsageCustomEndpoint: Optional[str]
 
+skipRegionValidation: bool
+
 sourceRepoCustomEndpoint: Optional[str]
 
 spannerCustomEndpoint: Optional[str]

--- a/sdk/python/pulumi_gcp/config/vars.py
+++ b/sdk/python/pulumi_gcp/config/vars.py
@@ -585,6 +585,10 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get('serviceUsageCustomEndpoint')
 
     @property
+    def skip_region_validation(self) -> bool:
+        return __config__.get_bool('skipRegionValidation') or (_utilities.get_env_bool('PULUMI_GCP_SKIP_REGION_VALIDATION') or False)
+
+    @property
     def source_repo_custom_endpoint(self) -> Optional[str]:
         return __config__.get('sourceRepoCustomEndpoint')
 


### PR DESCRIPTION
Should fix https://github.com/pulumi/pulumi-gcp/issues/129 by reintroducing https://github.com/pulumi/pulumi-gcp/pull/1554 reverted in https://github.com/pulumi/pulumi-gcp/pull/1650

I've also added a mechanism to pass in options to the GCP client via `preConfigureCallback` as well as tests for that around the region list behaviour.

I haven't tested with OIDC auth since it seems quite involved. The new tests should ensure that we have not introduced any failures there, LMK if you don't think this is sufficient.