### PR TITLE
Support env vars for `accessToken` and `credentials`

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -488,6 +488,20 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
+			"access_token": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"GOOGLE_OAUTH_ACCESS_TOKEN"},
+				},
+			},
+			"credentials": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{
+						"GOOGLE_CREDENTIALS",
+						"GOOGLE_CLOUD_KEYFILE_JSON",
+						"GCLOUD_KEYFILE_JSON",
+					},
+				},
+			},
 		},
 		ExtraConfig: map[string]*tfbridge.ConfigInfo{
 			"skipRegionValidation": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -404,7 +404,7 @@ func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpCl
 		}
 
 		// validate the gcloud config
-		err := config.LoadAndValidate(context.Background())
+		err := config.LoadAndValidate(ctx)
 		if err != nil {
 			return fmt.Errorf(noCredentialsErr, err)
 		}

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Gcp
             set => _accessContextManagerCustomEndpoint.Set(value);
         }
 
-        private static readonly __Value<string?> _accessToken = new __Value<string?>(() => __config.Get("accessToken"));
+        private static readonly __Value<string?> _accessToken = new __Value<string?>(() => __config.Get("accessToken") ?? Utilities.GetEnv("GOOGLE_OAUTH_ACCESS_TOKEN"));
         public static string? AccessToken
         {
             get => _accessToken.Get();
@@ -396,7 +396,7 @@ namespace Pulumi.Gcp
             set => _coreBillingCustomEndpoint.Set(value);
         }
 
-        private static readonly __Value<string?> _credentials = new __Value<string?>(() => __config.Get("credentials"));
+        private static readonly __Value<string?> _credentials = new __Value<string?>(() => __config.Get("credentials") ?? Utilities.GetEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"));
         public static string? Credentials
         {
             get => _credentials.Get();

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -1026,6 +1026,8 @@ namespace Pulumi.Gcp
 
         public ProviderArgs()
         {
+            AccessToken = Utilities.GetEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
+            Credentials = Utilities.GetEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
             Project = Utilities.GetEnv("GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT");
             Region = Utilities.GetEnv("GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION");
             Zone = Utilities.GetEnv("GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE");

--- a/sdk/go/gcp/config/config.go
+++ b/sdk/go/gcp/config/config.go
@@ -18,7 +18,15 @@ func GetAccessContextManagerCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:accessContextManagerCustomEndpoint")
 }
 func GetAccessToken(ctx *pulumi.Context) string {
-	return config.Get(ctx, "gcp:accessToken")
+	v, err := config.Try(ctx, "gcp:accessToken")
+	if err == nil {
+		return v
+	}
+	var value string
+	if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_OAUTH_ACCESS_TOKEN"); d != nil {
+		value = d.(string)
+	}
+	return value
 }
 func GetActiveDirectoryCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:activeDirectoryCustomEndpoint")
@@ -168,7 +176,15 @@ func GetCoreBillingCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:coreBillingCustomEndpoint")
 }
 func GetCredentials(ctx *pulumi.Context) string {
-	return config.Get(ctx, "gcp:credentials")
+	v, err := config.Try(ctx, "gcp:credentials")
+	if err == nil {
+		return v
+	}
+	var value string
+	if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"); d != nil {
+		value = d.(string)
+	}
+	return value
 }
 func GetDataCatalogCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:dataCatalogCustomEndpoint")

--- a/sdk/go/gcp/provider.go
+++ b/sdk/go/gcp/provider.go
@@ -184,6 +184,16 @@ func NewProvider(ctx *pulumi.Context,
 		args = &ProviderArgs{}
 	}
 
+	if args.AccessToken == nil {
+		if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_OAUTH_ACCESS_TOKEN"); d != nil {
+			args.AccessToken = pulumi.StringPtr(d.(string))
+		}
+	}
+	if args.Credentials == nil {
+		if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"); d != nil {
+			args.Credentials = pulumi.StringPtr(d.(string))
+		}
+	}
 	if args.Project == nil {
 		if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"); d != nil {
 			args.Project = pulumi.StringPtr(d.(string))

--- a/sdk/java/src/main/java/com/pulumi/gcp/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/Config.java
@@ -22,7 +22,7 @@ public final class Config {
         return Codegen.stringProp("accessContextManagerCustomEndpoint").config(config).get();
     }
     public Optional<String> accessToken() {
-        return Codegen.stringProp("accessToken").config(config).get();
+        return Codegen.stringProp("accessToken").config(config).env("GOOGLE_OAUTH_ACCESS_TOKEN").get();
     }
     public Optional<String> activeDirectoryCustomEndpoint() {
         return Codegen.stringProp("activeDirectoryCustomEndpoint").config(config).get();
@@ -172,7 +172,7 @@ public final class Config {
         return Codegen.stringProp("coreBillingCustomEndpoint").config(config).get();
     }
     public Optional<String> credentials() {
-        return Codegen.stringProp("credentials").config(config).get();
+        return Codegen.stringProp("credentials").config(config).env("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON").get();
     }
     public Optional<String> dataCatalogCustomEndpoint() {
         return Codegen.stringProp("dataCatalogCustomEndpoint").config(config).get();

--- a/sdk/java/src/main/java/com/pulumi/gcp/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/ProviderArgs.java
@@ -2840,6 +2840,8 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ProviderArgs build() {
+            $.accessToken = Codegen.stringProp("accessToken").output().arg($.accessToken).env("GOOGLE_OAUTH_ACCESS_TOKEN").getNullable();
+            $.credentials = Codegen.stringProp("credentials").output().arg($.credentials).env("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON").getNullable();
             $.project = Codegen.stringProp("project").output().arg($.project).env("GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT").getNullable();
             $.region = Codegen.stringProp("region").output().arg($.region).env("GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION").getNullable();
             $.zone = Codegen.stringProp("zone").output().arg($.zone).env("GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE").getNullable();

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -28,7 +28,7 @@ Object.defineProperty(exports, "accessContextManagerCustomEndpoint", {
 export declare const accessToken: string | undefined;
 Object.defineProperty(exports, "accessToken", {
     get() {
-        return __config.get("accessToken");
+        return __config.get("accessToken") ?? utilities.getEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
     },
     enumerable: true,
 });
@@ -428,7 +428,7 @@ Object.defineProperty(exports, "coreBillingCustomEndpoint", {
 export declare const credentials: string | undefined;
 Object.defineProperty(exports, "credentials", {
     get() {
-        return __config.get("credentials");
+        return __config.get("credentials") ?? utilities.getEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
     },
     enumerable: true,
 });

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -198,7 +198,7 @@ export class Provider extends pulumi.ProviderResource {
         {
             resourceInputs["accessApprovalCustomEndpoint"] = args ? args.accessApprovalCustomEndpoint : undefined;
             resourceInputs["accessContextManagerCustomEndpoint"] = args ? args.accessContextManagerCustomEndpoint : undefined;
-            resourceInputs["accessToken"] = args ? args.accessToken : undefined;
+            resourceInputs["accessToken"] = (args ? args.accessToken : undefined) ?? utilities.getEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
             resourceInputs["activeDirectoryCustomEndpoint"] = args ? args.activeDirectoryCustomEndpoint : undefined;
             resourceInputs["addTerraformAttributionLabel"] = pulumi.output(args ? args.addTerraformAttributionLabel : undefined).apply(JSON.stringify);
             resourceInputs["alloydbCustomEndpoint"] = args ? args.alloydbCustomEndpoint : undefined;
@@ -248,7 +248,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["containerAzureCustomEndpoint"] = args ? args.containerAzureCustomEndpoint : undefined;
             resourceInputs["containerCustomEndpoint"] = args ? args.containerCustomEndpoint : undefined;
             resourceInputs["coreBillingCustomEndpoint"] = args ? args.coreBillingCustomEndpoint : undefined;
-            resourceInputs["credentials"] = args ? args.credentials : undefined;
+            resourceInputs["credentials"] = (args ? args.credentials : undefined) ?? utilities.getEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
             resourceInputs["dataCatalogCustomEndpoint"] = args ? args.dataCatalogCustomEndpoint : undefined;
             resourceInputs["dataFusionCustomEndpoint"] = args ? args.dataFusionCustomEndpoint : undefined;
             resourceInputs["dataLossPreventionCustomEndpoint"] = args ? args.dataLossPreventionCustomEndpoint : undefined;

--- a/sdk/python/pulumi_gcp/config/vars.py
+++ b/sdk/python/pulumi_gcp/config/vars.py
@@ -26,7 +26,7 @@ class _ExportableConfig(types.ModuleType):
 
     @property
     def access_token(self) -> Optional[str]:
-        return __config__.get('accessToken')
+        return __config__.get('accessToken') or _utilities.get_env('GOOGLE_OAUTH_ACCESS_TOKEN')
 
     @property
     def active_directory_custom_endpoint(self) -> Optional[str]:
@@ -226,7 +226,7 @@ class _ExportableConfig(types.ModuleType):
 
     @property
     def credentials(self) -> Optional[str]:
-        return __config__.get('credentials')
+        return __config__.get('credentials') or _utilities.get_env('GOOGLE_CREDENTIALS', 'GOOGLE_CLOUD_KEYFILE_JSON', 'GCLOUD_KEYFILE_JSON')
 
     @property
     def data_catalog_custom_endpoint(self) -> Optional[str]:

--- a/sdk/python/pulumi_gcp/provider.py
+++ b/sdk/python/pulumi_gcp/provider.py
@@ -186,6 +186,8 @@ class ProviderArgs:
             pulumi.set(__self__, "access_approval_custom_endpoint", access_approval_custom_endpoint)
         if access_context_manager_custom_endpoint is not None:
             pulumi.set(__self__, "access_context_manager_custom_endpoint", access_context_manager_custom_endpoint)
+        if access_token is None:
+            access_token = _utilities.get_env('GOOGLE_OAUTH_ACCESS_TOKEN')
         if access_token is not None:
             pulumi.set(__self__, "access_token", access_token)
         if active_directory_custom_endpoint is not None:
@@ -286,6 +288,8 @@ class ProviderArgs:
             pulumi.set(__self__, "container_custom_endpoint", container_custom_endpoint)
         if core_billing_custom_endpoint is not None:
             pulumi.set(__self__, "core_billing_custom_endpoint", core_billing_custom_endpoint)
+        if credentials is None:
+            credentials = _utilities.get_env('GOOGLE_CREDENTIALS', 'GOOGLE_CLOUD_KEYFILE_JSON', 'GCLOUD_KEYFILE_JSON')
         if credentials is not None:
             pulumi.set(__self__, "credentials", credentials)
         if data_catalog_custom_endpoint is not None:
@@ -2375,6 +2379,8 @@ class Provider(pulumi.ProviderResource):
 
             __props__.__dict__["access_approval_custom_endpoint"] = access_approval_custom_endpoint
             __props__.__dict__["access_context_manager_custom_endpoint"] = access_context_manager_custom_endpoint
+            if access_token is None:
+                access_token = _utilities.get_env('GOOGLE_OAUTH_ACCESS_TOKEN')
             __props__.__dict__["access_token"] = access_token
             __props__.__dict__["active_directory_custom_endpoint"] = active_directory_custom_endpoint
             __props__.__dict__["add_terraform_attribution_label"] = pulumi.Output.from_input(add_terraform_attribution_label).apply(pulumi.runtime.to_json) if add_terraform_attribution_label is not None else None
@@ -2425,6 +2431,8 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["container_azure_custom_endpoint"] = container_azure_custom_endpoint
             __props__.__dict__["container_custom_endpoint"] = container_custom_endpoint
             __props__.__dict__["core_billing_custom_endpoint"] = core_billing_custom_endpoint
+            if credentials is None:
+                credentials = _utilities.get_env('GOOGLE_CREDENTIALS', 'GOOGLE_CLOUD_KEYFILE_JSON', 'GCLOUD_KEYFILE_JSON')
             __props__.__dict__["credentials"] = credentials
             __props__.__dict__["data_catalog_custom_endpoint"] = data_catalog_custom_endpoint
             __props__.__dict__["data_fusion_custom_endpoint"] = data_fusion_custom_endpoint


### PR DESCRIPTION
This should allow `accessToken` and `credentials` to be fully replaced by env vars.

Fixes https://github.com/pulumi/pulumi-gcp/issues/1693