### PR TITLE
Remove gcp creds from state

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -583,7 +583,11 @@ func TestEnvTokenNotInState(t *testing.T) {
 	test := pulumitest.NewPulumiTest(t, filepath.Join("test-programs", "storage-bucket"),
 		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
 	)
-	test.SetConfig("gcp:config:project", testProject)
+	googleProj := os.Getenv("GOOGLE_PROJECT")
+	if googleProj == "" {
+        googleProj = testProject
+    }
+	test.SetConfig("gcp:config:project", googleProj)
 
 	test.Up()
 	stack := test.ExportStack()

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -19,7 +19,6 @@ package gcp
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -578,7 +577,6 @@ func TestEnvTokenNotInState(t *testing.T) {
 		errMsg := err.(*exec.ExitError).Stderr
 		t.Fatal(string(errMsg))
 	}
-	log.Printf("GOOGLE_OAUTH_ACCESS_TOKEN: %s\n", outputStr)
 	t.Setenv("GOOGLE_OAUTH_ACCESS_TOKEN", outputStr)
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -585,8 +585,8 @@ func TestEnvTokenNotInState(t *testing.T) {
 	)
 	googleProj := os.Getenv("GOOGLE_PROJECT")
 	if googleProj == "" {
-        googleProj = testProject
-    }
+		googleProj = testProject
+	}
 	test.SetConfig("gcp:config:project", googleProj)
 
 	test.Up()

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -500,7 +500,6 @@ func Provider() tfbridge.ProviderInfo {
 				Default: &tfbridge.DefaultInfo{
 					EnvVars: []string{"GOOGLE_OAUTH_ACCESS_TOKEN"},
 				},
-				Secret: tfbridge.True(),
 			},
 			"credentials": {
 				Default: &tfbridge.DefaultInfo{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -410,7 +410,7 @@ func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpCl
 		}
 
 		// validate the gcloud config
-		err := config.LoadAndValidate(context.Background())
+		err := config.LoadAndValidate(ctx)
 		if err != nil {
 			return fmt.Errorf(noCredentialsErr, err)
 		}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -410,7 +410,7 @@ func preConfigureCallbackWithLogger(credentialsValidationRun *atomic.Bool, gcpCl
 		}
 
 		// validate the gcloud config
-		err := config.LoadAndValidate(ctx)
+		err := config.LoadAndValidate(context.Background())
 		if err != nil {
 			return fmt.Errorf(noCredentialsErr, err)
 		}
@@ -493,20 +493,6 @@ func Provider() tfbridge.ProviderInfo {
 						"GOOGLE_ZONE",
 						"GCLOUD_ZONE",
 						"CLOUDSDK_COMPUTE_ZONE",
-					},
-				},
-			},
-			"access_token": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"GOOGLE_OAUTH_ACCESS_TOKEN"},
-				},
-			},
-			"credentials": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{
-						"GOOGLE_CREDENTIALS",
-						"GOOGLE_CLOUD_KEYFILE_JSON",
-						"GCLOUD_KEYFILE_JSON",
 					},
 				},
 			},

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -46,7 +46,7 @@ namespace Pulumi.Gcp
             set => _accessContextManagerCustomEndpoint.Set(value);
         }
 
-        private static readonly __Value<string?> _accessToken = new __Value<string?>(() => __config.Get("accessToken") ?? Utilities.GetEnv("GOOGLE_OAUTH_ACCESS_TOKEN"));
+        private static readonly __Value<string?> _accessToken = new __Value<string?>(() => __config.Get("accessToken"));
         public static string? AccessToken
         {
             get => _accessToken.Get();
@@ -396,7 +396,7 @@ namespace Pulumi.Gcp
             set => _coreBillingCustomEndpoint.Set(value);
         }
 
-        private static readonly __Value<string?> _credentials = new __Value<string?>(() => __config.Get("credentials") ?? Utilities.GetEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"));
+        private static readonly __Value<string?> _credentials = new __Value<string?>(() => __config.Get("credentials"));
         public static string? Credentials
         {
             get => _credentials.Get();

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -1026,8 +1026,6 @@ namespace Pulumi.Gcp
 
         public ProviderArgs()
         {
-            AccessToken = Utilities.GetEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
-            Credentials = Utilities.GetEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
             Project = Utilities.GetEnv("GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT");
             Region = Utilities.GetEnv("GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION");
             Zone = Utilities.GetEnv("GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE");

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -507,10 +507,6 @@ namespace Pulumi.Gcp
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
-                AdditionalSecretOutputs =
-                {
-                    "accessToken",
-                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
@@ -528,16 +524,7 @@ namespace Pulumi.Gcp
         public Input<string>? AccessContextManagerCustomEndpoint { get; set; }
 
         [Input("accessToken")]
-        private Input<string>? _accessToken;
-        public Input<string>? AccessToken
-        {
-            get => _accessToken;
-            set
-            {
-                var emptySecret = Output.CreateSecret(0);
-                _accessToken = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
-            }
-        }
+        public Input<string>? AccessToken { get; set; }
 
         [Input("activeDirectoryCustomEndpoint")]
         public Input<string>? ActiveDirectoryCustomEndpoint { get; set; }

--- a/sdk/go/gcp/config/config.go
+++ b/sdk/go/gcp/config/config.go
@@ -18,15 +18,7 @@ func GetAccessContextManagerCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:accessContextManagerCustomEndpoint")
 }
 func GetAccessToken(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "gcp:accessToken")
-	if err == nil {
-		return v
-	}
-	var value string
-	if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_OAUTH_ACCESS_TOKEN"); d != nil {
-		value = d.(string)
-	}
-	return value
+	return config.Get(ctx, "gcp:accessToken")
 }
 func GetActiveDirectoryCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:activeDirectoryCustomEndpoint")
@@ -176,15 +168,7 @@ func GetCoreBillingCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:coreBillingCustomEndpoint")
 }
 func GetCredentials(ctx *pulumi.Context) string {
-	v, err := config.Try(ctx, "gcp:credentials")
-	if err == nil {
-		return v
-	}
-	var value string
-	if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"); d != nil {
-		value = d.(string)
-	}
-	return value
+	return config.Get(ctx, "gcp:credentials")
 }
 func GetDataCatalogCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:dataCatalogCustomEndpoint")

--- a/sdk/go/gcp/provider.go
+++ b/sdk/go/gcp/provider.go
@@ -184,16 +184,6 @@ func NewProvider(ctx *pulumi.Context,
 		args = &ProviderArgs{}
 	}
 
-	if args.AccessToken == nil {
-		if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_OAUTH_ACCESS_TOKEN"); d != nil {
-			args.AccessToken = pulumi.StringPtr(d.(string))
-		}
-	}
-	if args.Credentials == nil {
-		if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"); d != nil {
-			args.Credentials = pulumi.StringPtr(d.(string))
-		}
-	}
 	if args.Project == nil {
 		if d := internal.GetEnvOrDefault(nil, nil, "GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"); d != nil {
 			args.Project = pulumi.StringPtr(d.(string))

--- a/sdk/go/gcp/provider.go
+++ b/sdk/go/gcp/provider.go
@@ -209,13 +209,6 @@ func NewProvider(ctx *pulumi.Context,
 			args.Zone = pulumi.StringPtr(d.(string))
 		}
 	}
-	if args.AccessToken != nil {
-		args.AccessToken = pulumi.ToSecret(args.AccessToken).(pulumi.StringPtrInput)
-	}
-	secrets := pulumi.AdditionalSecretOutputs([]string{
-		"accessToken",
-	})
-	opts = append(opts, secrets)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Provider
 	err := ctx.RegisterResource("pulumi:providers:gcp", name, args, &resource, opts...)

--- a/sdk/java/src/main/java/com/pulumi/gcp/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/Config.java
@@ -22,7 +22,7 @@ public final class Config {
         return Codegen.stringProp("accessContextManagerCustomEndpoint").config(config).get();
     }
     public Optional<String> accessToken() {
-        return Codegen.stringProp("accessToken").config(config).env("GOOGLE_OAUTH_ACCESS_TOKEN").get();
+        return Codegen.stringProp("accessToken").config(config).get();
     }
     public Optional<String> activeDirectoryCustomEndpoint() {
         return Codegen.stringProp("activeDirectoryCustomEndpoint").config(config).get();
@@ -172,7 +172,7 @@ public final class Config {
         return Codegen.stringProp("coreBillingCustomEndpoint").config(config).get();
     }
     public Optional<String> credentials() {
-        return Codegen.stringProp("credentials").config(config).env("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON").get();
+        return Codegen.stringProp("credentials").config(config).get();
     }
     public Optional<String> dataCatalogCustomEndpoint() {
         return Codegen.stringProp("dataCatalogCustomEndpoint").config(config).get();

--- a/sdk/java/src/main/java/com/pulumi/gcp/Provider.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/Provider.java
@@ -10,7 +10,6 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.gcp.ProviderArgs;
 import com.pulumi.gcp.Utilities;
 import java.lang.String;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -994,9 +993,6 @@ public class Provider extends com.pulumi.resources.ProviderResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
-            .additionalSecretOutputs(List.of(
-                "accessToken"
-            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/com/pulumi/gcp/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/ProviderArgs.java
@@ -2840,7 +2840,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ProviderArgs build() {
-            $.accessToken = Codegen.stringProp("accessToken").secret().arg($.accessToken).env("GOOGLE_OAUTH_ACCESS_TOKEN").getNullable();
+            $.accessToken = Codegen.stringProp("accessToken").output().arg($.accessToken).env("GOOGLE_OAUTH_ACCESS_TOKEN").getNullable();
             $.credentials = Codegen.stringProp("credentials").output().arg($.credentials).env("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON").getNullable();
             $.project = Codegen.stringProp("project").output().arg($.project).env("GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT").getNullable();
             $.region = Codegen.stringProp("region").output().arg($.region).env("GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION").getNullable();

--- a/sdk/java/src/main/java/com/pulumi/gcp/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/ProviderArgs.java
@@ -2840,8 +2840,6 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ProviderArgs build() {
-            $.accessToken = Codegen.stringProp("accessToken").output().arg($.accessToken).env("GOOGLE_OAUTH_ACCESS_TOKEN").getNullable();
-            $.credentials = Codegen.stringProp("credentials").output().arg($.credentials).env("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON").getNullable();
             $.project = Codegen.stringProp("project").output().arg($.project).env("GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT").getNullable();
             $.region = Codegen.stringProp("region").output().arg($.region).env("GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION").getNullable();
             $.zone = Codegen.stringProp("zone").output().arg($.zone).env("GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE").getNullable();

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -28,7 +28,7 @@ Object.defineProperty(exports, "accessContextManagerCustomEndpoint", {
 export declare const accessToken: string | undefined;
 Object.defineProperty(exports, "accessToken", {
     get() {
-        return __config.get("accessToken") ?? utilities.getEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
+        return __config.get("accessToken");
     },
     enumerable: true,
 });
@@ -428,7 +428,7 @@ Object.defineProperty(exports, "coreBillingCustomEndpoint", {
 export declare const credentials: string | undefined;
 Object.defineProperty(exports, "credentials", {
     get() {
-        return __config.get("credentials") ?? utilities.getEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
+        return __config.get("credentials");
     },
     enumerable: true,
 });

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -198,7 +198,7 @@ export class Provider extends pulumi.ProviderResource {
         {
             resourceInputs["accessApprovalCustomEndpoint"] = args ? args.accessApprovalCustomEndpoint : undefined;
             resourceInputs["accessContextManagerCustomEndpoint"] = args ? args.accessContextManagerCustomEndpoint : undefined;
-            resourceInputs["accessToken"] = (args?.accessToken ? pulumi.secret(args.accessToken) : undefined) ?? utilities.getEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
+            resourceInputs["accessToken"] = (args ? args.accessToken : undefined) ?? utilities.getEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
             resourceInputs["activeDirectoryCustomEndpoint"] = args ? args.activeDirectoryCustomEndpoint : undefined;
             resourceInputs["addTerraformAttributionLabel"] = pulumi.output(args ? args.addTerraformAttributionLabel : undefined).apply(JSON.stringify);
             resourceInputs["alloydbCustomEndpoint"] = args ? args.alloydbCustomEndpoint : undefined;
@@ -362,8 +362,6 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["zone"] = (args ? args.zone : undefined) ?? utilities.getEnv("GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE");
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const secretOpts = { additionalSecretOutputs: ["accessToken"] };
-        opts = pulumi.mergeOptions(opts, secretOpts);
         super(Provider.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -198,7 +198,7 @@ export class Provider extends pulumi.ProviderResource {
         {
             resourceInputs["accessApprovalCustomEndpoint"] = args ? args.accessApprovalCustomEndpoint : undefined;
             resourceInputs["accessContextManagerCustomEndpoint"] = args ? args.accessContextManagerCustomEndpoint : undefined;
-            resourceInputs["accessToken"] = (args ? args.accessToken : undefined) ?? utilities.getEnv("GOOGLE_OAUTH_ACCESS_TOKEN");
+            resourceInputs["accessToken"] = args ? args.accessToken : undefined;
             resourceInputs["activeDirectoryCustomEndpoint"] = args ? args.activeDirectoryCustomEndpoint : undefined;
             resourceInputs["addTerraformAttributionLabel"] = pulumi.output(args ? args.addTerraformAttributionLabel : undefined).apply(JSON.stringify);
             resourceInputs["alloydbCustomEndpoint"] = args ? args.alloydbCustomEndpoint : undefined;
@@ -248,7 +248,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["containerAzureCustomEndpoint"] = args ? args.containerAzureCustomEndpoint : undefined;
             resourceInputs["containerCustomEndpoint"] = args ? args.containerCustomEndpoint : undefined;
             resourceInputs["coreBillingCustomEndpoint"] = args ? args.coreBillingCustomEndpoint : undefined;
-            resourceInputs["credentials"] = (args ? args.credentials : undefined) ?? utilities.getEnv("GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON");
+            resourceInputs["credentials"] = args ? args.credentials : undefined;
             resourceInputs["dataCatalogCustomEndpoint"] = args ? args.dataCatalogCustomEndpoint : undefined;
             resourceInputs["dataFusionCustomEndpoint"] = args ? args.dataFusionCustomEndpoint : undefined;
             resourceInputs["dataLossPreventionCustomEndpoint"] = args ? args.dataLossPreventionCustomEndpoint : undefined;

--- a/sdk/python/pulumi_gcp/config/vars.py
+++ b/sdk/python/pulumi_gcp/config/vars.py
@@ -26,7 +26,7 @@ class _ExportableConfig(types.ModuleType):
 
     @property
     def access_token(self) -> Optional[str]:
-        return __config__.get('accessToken') or _utilities.get_env('GOOGLE_OAUTH_ACCESS_TOKEN')
+        return __config__.get('accessToken')
 
     @property
     def active_directory_custom_endpoint(self) -> Optional[str]:
@@ -226,7 +226,7 @@ class _ExportableConfig(types.ModuleType):
 
     @property
     def credentials(self) -> Optional[str]:
-        return __config__.get('credentials') or _utilities.get_env('GOOGLE_CREDENTIALS', 'GOOGLE_CLOUD_KEYFILE_JSON', 'GCLOUD_KEYFILE_JSON')
+        return __config__.get('credentials')
 
     @property
     def data_catalog_custom_endpoint(self) -> Optional[str]:

--- a/sdk/python/pulumi_gcp/provider.py
+++ b/sdk/python/pulumi_gcp/provider.py
@@ -2381,7 +2381,7 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["access_context_manager_custom_endpoint"] = access_context_manager_custom_endpoint
             if access_token is None:
                 access_token = _utilities.get_env('GOOGLE_OAUTH_ACCESS_TOKEN')
-            __props__.__dict__["access_token"] = None if access_token is None else pulumi.Output.secret(access_token)
+            __props__.__dict__["access_token"] = access_token
             __props__.__dict__["active_directory_custom_endpoint"] = active_directory_custom_endpoint
             __props__.__dict__["add_terraform_attribution_label"] = pulumi.Output.from_input(add_terraform_attribution_label).apply(pulumi.runtime.to_json) if add_terraform_attribution_label is not None else None
             __props__.__dict__["alloydb_custom_endpoint"] = alloydb_custom_endpoint
@@ -2551,8 +2551,6 @@ class Provider(pulumi.ProviderResource):
             if zone is None:
                 zone = _utilities.get_env('GOOGLE_ZONE', 'GCLOUD_ZONE', 'CLOUDSDK_COMPUTE_ZONE')
             __props__.__dict__["zone"] = zone
-        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["accessToken"])
-        opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(Provider, __self__).__init__(
             'gcp',
             resource_name,

--- a/sdk/python/pulumi_gcp/provider.py
+++ b/sdk/python/pulumi_gcp/provider.py
@@ -186,8 +186,6 @@ class ProviderArgs:
             pulumi.set(__self__, "access_approval_custom_endpoint", access_approval_custom_endpoint)
         if access_context_manager_custom_endpoint is not None:
             pulumi.set(__self__, "access_context_manager_custom_endpoint", access_context_manager_custom_endpoint)
-        if access_token is None:
-            access_token = _utilities.get_env('GOOGLE_OAUTH_ACCESS_TOKEN')
         if access_token is not None:
             pulumi.set(__self__, "access_token", access_token)
         if active_directory_custom_endpoint is not None:
@@ -288,8 +286,6 @@ class ProviderArgs:
             pulumi.set(__self__, "container_custom_endpoint", container_custom_endpoint)
         if core_billing_custom_endpoint is not None:
             pulumi.set(__self__, "core_billing_custom_endpoint", core_billing_custom_endpoint)
-        if credentials is None:
-            credentials = _utilities.get_env('GOOGLE_CREDENTIALS', 'GOOGLE_CLOUD_KEYFILE_JSON', 'GCLOUD_KEYFILE_JSON')
         if credentials is not None:
             pulumi.set(__self__, "credentials", credentials)
         if data_catalog_custom_endpoint is not None:
@@ -2379,8 +2375,6 @@ class Provider(pulumi.ProviderResource):
 
             __props__.__dict__["access_approval_custom_endpoint"] = access_approval_custom_endpoint
             __props__.__dict__["access_context_manager_custom_endpoint"] = access_context_manager_custom_endpoint
-            if access_token is None:
-                access_token = _utilities.get_env('GOOGLE_OAUTH_ACCESS_TOKEN')
             __props__.__dict__["access_token"] = access_token
             __props__.__dict__["active_directory_custom_endpoint"] = active_directory_custom_endpoint
             __props__.__dict__["add_terraform_attribution_label"] = pulumi.Output.from_input(add_terraform_attribution_label).apply(pulumi.runtime.to_json) if add_terraform_attribution_label is not None else None
@@ -2431,8 +2425,6 @@ class Provider(pulumi.ProviderResource):
             __props__.__dict__["container_azure_custom_endpoint"] = container_azure_custom_endpoint
             __props__.__dict__["container_custom_endpoint"] = container_custom_endpoint
             __props__.__dict__["core_billing_custom_endpoint"] = core_billing_custom_endpoint
-            if credentials is None:
-                credentials = _utilities.get_env('GOOGLE_CREDENTIALS', 'GOOGLE_CLOUD_KEYFILE_JSON', 'GCLOUD_KEYFILE_JSON')
             __props__.__dict__["credentials"] = credentials
             __props__.__dict__["data_catalog_custom_endpoint"] = data_catalog_custom_endpoint
             __props__.__dict__["data_fusion_custom_endpoint"] = data_fusion_custom_endpoint


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-gcp/issues/1759

Reverts https://github.com/pulumi/pulumi-gcp/pull/1715 and https://github.com/pulumi/pulumi-gcp/pull/1691.

The TF providers was already picking up credentials from the env var before https://github.com/pulumi/pulumi-gcp/pull/1691. We have no reason to store these in the state.

Note that this might break users who depend on the the stored credentials for authentication. I think this is intended and they can set up an env var or explicitly configure the provider to store the credentials.