### PR TITLE
Refactor GCP upgrade test interface

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -72,7 +72,10 @@ func testProviderUpgrade(t *testing.T, dir string, opts ...func(*UpgradeTestOpts
 	testProviderUpgradeWithConfig(t, dir, options.baselineVersion, options.config, options.assertFunc)
 }
 
-func testProviderUpgradeWithConfig(t *testing.T, dir, baselineVersion string, config map[string]string, assertFunction func(*testing.T, auto.PreviewResult)) {
+func testProviderUpgradeWithConfig(
+	t *testing.T, dir, baselineVersion string, config map[string]string,
+	assertFunction func(*testing.T, auto.PreviewResult),
+) {
 	if testing.Short() {
 		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
 	}
@@ -94,7 +97,7 @@ func testProviderUpgradeWithConfig(t *testing.T, dir, baselineVersion string, co
 	result := providertest.PreviewProviderUpgrade(test, providerName, baselineVersion, optproviderupgrade.DisableAttach())
 	if assertFunction != nil {
 		assertFunction(t, result)
-    } else {
+	} else {
 		assertpreview.HasNoReplacements(t, result)
 	}
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-gcp/provider/v7/pkg/version"
@@ -39,11 +40,39 @@ func TestUpgradeCoverage(t *testing.T) {
 	providertest.ReportUpgradeCoverage(t)
 }
 
-func testProviderUpgrade(t *testing.T, dir, baselineVersion string) {
-	testProviderUpgradeWithConfig(t, dir, baselineVersion, nil)
+type UpgradeTestOpts struct {
+	baselineVersion string
+	assertFunc      func(*testing.T, auto.PreviewResult)
+	config          map[string]string
 }
 
-func testProviderUpgradeWithConfig(t *testing.T, dir, baselineVersion string, config map[string]string) {
+func WithBaselineVersion(baselineVersion string) func(opts *UpgradeTestOpts) {
+	return func(opts *UpgradeTestOpts) {
+		opts.baselineVersion = baselineVersion
+	}
+}
+
+func WithAssertFunc(assertFunc func(*testing.T, auto.PreviewResult)) func(opts *UpgradeTestOpts) {
+	return func(opts *UpgradeTestOpts) {
+		opts.assertFunc = assertFunc
+	}
+}
+
+func WithConfig(config map[string]string) func(opts *UpgradeTestOpts) {
+	return func(opts *UpgradeTestOpts) {
+		opts.config = config
+	}
+}
+
+func testProviderUpgrade(t *testing.T, dir string, opts ...func(*UpgradeTestOpts)) {
+	options := &UpgradeTestOpts{}
+	for _, o := range opts {
+		o(options)
+	}
+	testProviderUpgradeWithConfig(t, dir, options.baselineVersion, options.config, options.assertFunc)
+}
+
+func testProviderUpgradeWithConfig(t *testing.T, dir, baselineVersion string, config map[string]string, assertFunction func(*testing.T, auto.PreviewResult)) {
 	if testing.Short() {
 		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
 	}
@@ -63,7 +92,11 @@ func testProviderUpgradeWithConfig(t *testing.T, dir, baselineVersion string, co
 	// The SetConfig above does not seem to be working here.
 	t.Setenv("PULUMI_GCP_SKIP_REGION_VALIDATION", "true")
 	result := providertest.PreviewProviderUpgrade(test, providerName, baselineVersion, optproviderupgrade.DisableAttach())
-	assertpreview.HasNoReplacements(t, result)
+	if assertFunction != nil {
+		assertFunction(t, result)
+    } else {
+		assertpreview.HasNoReplacements(t, result)
+	}
 }
 
 func providerServer(t *testing.T) pulumirpc.ResourceProviderServer {

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -33,55 +33,55 @@ import (
 )
 
 func TestDNSRecordSetUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/dns-recordset", "")
+	testProviderUpgrade(t, "test-programs/dns-recordset")
 }
 
 func TestPubSubSubscriptionUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/pubsub-subscription", "")
+	testProviderUpgrade(t, "test-programs/pubsub-subscription")
 }
 
 func TestPubSubTopicUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/pubsub-topic", "")
+	testProviderUpgrade(t, "test-programs/pubsub-topic")
 }
 
 func TestStorageBucketUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/storage-bucket", "")
+	testProviderUpgrade(t, "test-programs/storage-bucket")
 }
 
 func TestStorageBucketObjectUpgrade(t *testing.T) {
 	t.Skipf("TODO[pulumi/pulumi-gcp#1607] temporarily skipping failing test")
-	testProviderUpgrade(t, "test-programs/storage-bucketobject", "")
+	testProviderUpgrade(t, "test-programs/storage-bucketobject")
 }
 
 func TestSecretManagerSecretUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/secretmanager-secret", "")
+	testProviderUpgrade(t, "test-programs/secretmanager-secret")
 }
 
 func TestSqlUserUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/sql-user", "")
+	testProviderUpgrade(t, "test-programs/sql-user")
 }
 
 func TestBigQueryTableUpgrade(t *testing.T) {
-	testProviderUpgradeWithConfig(t, "test-programs/bigquery-table", "", map[string]string{
+	testProviderUpgrade(t, "test-programs/bigquery-table", WithConfig(map[string]string{
 		"datasetID": "dspitrunnerbigqueryt4b22ee25",
-	})
+	}))
 }
 
 func TestComputeFirewallUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/compute-firewall", "")
+	testProviderUpgrade(t, "test-programs/compute-firewall")
 }
 
 func TestCloudFunctionUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/cloudfunctions-function", "")
+	testProviderUpgrade(t, "test-programs/cloudfunctions-function")
 }
 
 func TestNetworkUpgrade(t *testing.T) {
 	t.Skipf("Flakey: see https://github.com/pulumi/pulumi-gcp/issues/1655 for details")
-	testProviderUpgrade(t, "test-programs/network", "")
+	testProviderUpgrade(t, "test-programs/network")
 }
 
 func TestClusterUpgrade(t *testing.T) {
-	testProviderUpgrade(t, "test-programs/cluster", "7.2.1" /* test upgrading from this version */)
+	testProviderUpgrade(t, "test-programs/cluster", WithBaselineVersion("7.2.1"))
 }
 
 func skipIfNotCI(t *testing.T) {
@@ -93,25 +93,25 @@ func skipIfNotCI(t *testing.T) {
 func TestIamBinding(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testProviderUpgrade(t, "test-programs/iam-binding", "7.0.0")
+	testProviderUpgrade(t, "test-programs/iam-binding", WithBaselineVersion("7.0.0"))
 }
 
 func TestIamMember(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testProviderUpgrade(t, "test-programs/iam-member", "7.0.0")
+	testProviderUpgrade(t, "test-programs/iam-member", WithBaselineVersion("7.0.0"))
 }
 
 func TestLogSink(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testProviderUpgrade(t, "test-programs/logsink", "7.0.0")
+	testProviderUpgrade(t, "test-programs/logsink", WithBaselineVersion("7.0.0"))
 }
 
 func TestTopicIamBinding(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testProviderUpgrade(t, "test-programs/topic-iam-binding", "7.0.0")
+	testProviderUpgrade(t, "test-programs/topic-iam-binding", WithBaselineVersion("7.0.0"))
 }
 
 func TestWrongRegionWarning(t *testing.T) {
@@ -178,7 +178,7 @@ func TestAutoExtractedProgramsUpgrade(t *testing.T) {
 		tc := tc
 		t.Run(tc.program, func(t *testing.T) {
 			d := filepath.Join("test-programs", tc.program)
-			testProviderUpgrade(t, d, "")
+			testProviderUpgrade(t, d)
 		})
 	}
 }


### PR DESCRIPTION
Pure refactor, the options were growing and this'll make it nicer to use.