### PR TITLE
Pin to bridge at a1a46e5bc072a6fc2c7cae23e44ed0d6019f1548

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/hashicorp/terraform-provider-google-beta v0.0.0
 	github.com/pulumi/providertest v0.0.11
-	github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240425153425-3770ed5a7ac4
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240425153425-3770ed5a7ac4
+	github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240508212925-a1a46e5bc072
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508212925-a1a46e5bc072
 	github.com/pulumi/pulumi/pkg/v3 v3.113.0
 	github.com/pulumi/pulumi/sdk/v3 v3.113.0
 	github.com/stretchr/testify v1.8.4

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2847,10 +2847,10 @@ github.com/pulumi/providertest v0.0.11 h1:mg8MQ7Cq7+9XlHIkBD+aCqQO4mwAJEISngZgVd
 github.com/pulumi/providertest v0.0.11/go.mod h1:HsxjVsytcMIuNj19w1lT2W0QXY0oReXl1+h6eD2JXP8=
 github.com/pulumi/pulumi-java/pkg v0.10.0 h1:D1i5MiiNrxYr2uJ1szcj1aQwF9DYv7TTsPmajB9dKSw=
 github.com/pulumi/pulumi-java/pkg v0.10.0/go.mod h1:xu6UgYtQm+xXOo1/DZNa2CWVPytu+RMkZVTtI7w7ffY=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240425153425-3770ed5a7ac4 h1:jFcJcDKvw74VuC7xTsdo+WGQxOpLN/RkBjdJqfMPqHw=
-github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240425153425-3770ed5a7ac4/go.mod h1:GsE570mIdTHkCK93qD4viTlKY3GgiW+dLakILu+skMY=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240425153425-3770ed5a7ac4 h1:fIg0veKH97O7GtVT7knx/LR1XVHdArLozx6PZQL9ElE=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240425153425-3770ed5a7ac4/go.mod h1:B8/cgXxqjfBcOx+yntCG8suxaq2h+mhe2+1LbPQ7ajI=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240508212925-a1a46e5bc072 h1:z45qwIdXe//BCGK2oGHljwSMGwXzMjrNU49SA+Rnh3Q=
+github.com/pulumi/pulumi-terraform-bridge/pf v0.33.1-0.20240508212925-a1a46e5bc072/go.mod h1:GsE570mIdTHkCK93qD4viTlKY3GgiW+dLakILu+skMY=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508212925-a1a46e5bc072 h1:OD7j/OMes102r/m0sPwr1DTK4+6xcTDxbd1qvIN2gpY=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.81.1-0.20240508212925-a1a46e5bc072/go.mod h1:B8/cgXxqjfBcOx+yntCG8suxaq2h+mhe2+1LbPQ7ajI=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.9-0.20240227144008-2da15b3d6f6e h1:yON1jwN6gg4cjnOQF607I3fTiFyIDr9WSsQNXHD6wbM=
 github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.9-0.20240227144008-2da15b3d6f6e/go.mod h1:AvlZujvfRiEu+60frCGEhaLeGttjHwM/g+47+IdPZXw=
 github.com/pulumi/pulumi-yaml v1.6.0 h1:mb/QkebWXTa1fR+P3ZkCCHGXOYC6iTN8X8By9eNz8xM=


### PR DESCRIPTION
This is a quick fix to address customer issues outlined in pulumi/pulumi-terraform-bridge#1940.
The [bridge version used](https://github.com/pulumi/pulumi-terraform-bridge/tree/revert-1896-for-gcp) is based off of the last pinned bridge commit, with pulumi/pulumi-terraform-bridge#1896
 reverted.

While we develop a more complete fix for the above issue, this will unblock customers and enable them to upgrade.
