### PR TITLE
Re-enable skipped bucket test

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -57,6 +57,7 @@ func TestAccTopic(t *testing.T) {
 }
 
 func TestAccBucket(t *testing.T) {
+	t.Skip("Skipping due to high failure rates. See pulumi/pulumi-gcp#1277")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "bucket"),

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -57,7 +57,6 @@ func TestAccTopic(t *testing.T) {
 }
 
 func TestAccBucket(t *testing.T) {
-	t.Skip("Skipping due to high failure rates. See pulumi/pulumi-gcp#1267")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "bucket"),

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -57,7 +57,6 @@ func TestAccTopic(t *testing.T) {
 }
 
 func TestAccBucket(t *testing.T) {
-	t.Skip("Skipping due to high failure rates. See pulumi/pulumi-gcp#1277")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "bucket"),


### PR DESCRIPTION
I believe we meant to re-enable it in https://github.com/pulumi/pulumi-gcp/pull/1276/files as the referenced issue is closed by it: https://github.com/pulumi/pulumi-gcp/issues/1267
