### PR TITLE
Fix overfitting label tests

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -233,6 +233,28 @@ func TestLabelsCombinationsGo(t *testing.T) {
 			},
 		},
 		{
+			"make label empty",
+			labelsState{
+				DefaultLabels: map[string]string{},
+				Labels:        map[string]string{"x": "s"},
+			},
+			labelsState{
+				DefaultLabels: map[string]string{},
+				Labels:        map[string]string{"x": ""},
+			},
+		},
+		{
+			"make default label empty",
+			labelsState{
+				DefaultLabels: map[string]string{"x": "s"},
+				Labels:        map[string]string{},
+			},
+			labelsState{
+				DefaultLabels: map[string]string{"x": ""},
+				Labels:        map[string]string{},
+			},
+		},
+		{
 			"convoluted test case found by random-sampling",
 			labelsState{
 				DefaultLabels: map[string]string{"x": "", "y": "s"},


### PR DESCRIPTION
During PlanResourceChange these tests was discovered to fail. Looks like this is actually an upstream bug - the provider takes empty string for a label to mean "keep previous value". This was reproed in TF.

I've adjusted the tests to take this into account - they should now work for both PRC and non-PRC. We can remove the non-PRC bit after enabling PRC by default.

fixes https://github.com/pulumi/pulumi-gcp/issues/2078