### PR TITLE
Skip refresh for labels test

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -387,6 +387,7 @@ func (st labelsState) validateTransitionTo(t *testing.T, st2 labelsState) {
 			"state2": st2.serialize(t),
 		},
 		Quick:            true,
+		SkipRefresh: 	  true,
 		DestroyOnCleanup: true,
 	})
 


### PR DESCRIPTION
Under PRC we match the TF behaviour for labels, which combined with the new refresh behaviour fails TestLabelsCombinationsGo.

The reason for that is that in TF, empty strings for a label is taken to mean "maintain old value": https://github.com/pulumi/pulumi-gcp/issues/2083

This produces a permadiff if one of the labels is an empty string, as that is unknown at preview time. This is the correct behaviour here as there could be a change in that label, depending on the value in the cloud.

This PR adds a skip to these tests for the refresh step.