### PR TITLE
Fix firestore backup schedule permadiff

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/providertest/replay"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 )
 
 func TestDNSRecordSetUpgrade(t *testing.T) {
@@ -949,4 +950,10 @@ func TestImport(t *testing.T) {
 			assertpreview.HasNoChanges(t, prevResult)
 		})
 	}
+}
+
+func TestFirestoreBackupScheduleNoPermadiff(t *testing.T) {
+	pt := pulumiTest(t, "test-programs/firestore-backup-schedule")
+	pt.Up()
+	pt.Preview(optpreview.ExpectNoChanges())
 }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -462,7 +462,8 @@ func Provider() tfbridge.ProviderInfo {
 			shimv2.WithDiffStrategy(shimv2.PlanState),
 			shimv2.WithPlanResourceChange(func(s string) bool {
 				switch s {
-				case "google_datastream_connection_profile":
+				case "google_datastream_connection_profile",
+					"google_firestore_backup_schedule":
 					return true
 				default:
 					return false

--- a/provider/test-programs/firestore-backup-schedule/Pulumi.yaml
+++ b/provider/test-programs/firestore-backup-schedule/Pulumi.yaml
@@ -1,0 +1,15 @@
+name: firestore-backup-schedule
+runtime: yaml
+resources:
+  firestoredb:
+    type: gcp:firestore:Database
+    properties:
+      locationId: us-central1
+      type: FIRESTORE_NATIVE
+
+  firestoreBackupsSchedule:
+    type: gcp:firestore:BackupSchedule
+    properties:
+      database: ${firestoredb.name}
+      retention: 8467200s
+      dailyRecurrence: {}


### PR DESCRIPTION
Enables PRC for firestore backup schedule in order to fix a permadiff with the resource.

Adds a regression test.

fixes https://github.com/pulumi/pulumi-gcp/issues/2066