### PR TITLE
Fix PAM entitlement permadiff by enabling PRC

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -957,3 +957,12 @@ func TestFirestoreBackupScheduleNoPermadiff(t *testing.T) {
 	pt.Up()
 	pt.Preview(optpreview.ExpectNoChanges())
 }
+
+func TestPAMEntitlementPermadiffRegress2167(t *testing.T) {
+	pt := pulumiTest(t, "test-programs/pam-entitlement", opttest.DownloadProviderVersion("random", "4.16.3"))
+
+	proj := getProject()
+	pt.SetConfig("gcpProj", proj)
+	pt.Up()
+	pt.Preview(optpreview.ExpectNoChanges())
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -465,7 +465,8 @@ func Provider() tfbridge.ProviderInfo {
 				case "google_datastream_connection_profile",
 					"google_firestore_backup_schedule",
 					"google_cloud_run_service",
-					"google_cloud_run_domain_mapping":
+					"google_cloud_run_domain_mapping",
+					"google_privileged_access_manager_entitlement":
 					return true
 				default:
 					return false

--- a/provider/test-programs/pam-entitlement/.gitignore
+++ b/provider/test-programs/pam-entitlement/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/provider/test-programs/pam-entitlement/Pulumi.yaml
+++ b/provider/test-programs/pam-entitlement/Pulumi.yaml
@@ -1,0 +1,31 @@
+name: gcp_2167
+runtime:
+  name: yaml
+config:
+  gcpProj: string
+resources:
+  entitlementId:
+    type: random:index/randomString:RandomString
+    properties:
+      length: 10
+      special: false
+      upper: false
+      number: true
+
+  entitlement:
+    type: gcp:privilegedaccessmanager:entitlement
+    properties:
+      parent: "projects/${gcpProj}"
+      entitlementId: "${entitlementId.result}"
+      location: "global"
+      eligibleUsers:
+        - principals: ["domain:pulumi.com"]
+      maxRequestDuration: "7200s"
+      requesterJustificationConfig:
+        unstructured: {}
+      privilegedAccess:
+        gcpIamAccess:
+          resource: "//cloudresourcemanager.googleapis.com/projects/${gcpProj}"
+          resourceType: "cloudresourcemanager.googleapis.com/Project"
+          roleBindings:
+            - role: "roles/storage.admin"


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-gcp/issues/2167

Enabled PRC for PAM entitlement to fix a permadiff with an empty object parameter.