### PR TITLE
Fix firestore field permadiff by enabling PRC

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -966,3 +966,12 @@ func TestPAMEntitlementPermadiffRegress2167(t *testing.T) {
 	pt.Up()
 	pt.Preview(optpreview.ExpectNoChanges())
 }
+
+func TestFirestoreFieldPermadiffRegress2166(t *testing.T) {
+	pt := pulumiTest(t, "test-programs/firestore-field")
+
+	proj := getProject()
+	pt.SetConfig("gcpProj", proj)
+	pt.Up()
+	pt.Preview(optpreview.ExpectNoChanges())
+}

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -466,7 +466,8 @@ func Provider() tfbridge.ProviderInfo {
 					"google_firestore_backup_schedule",
 					"google_cloud_run_service",
 					"google_cloud_run_domain_mapping",
-					"google_privileged_access_manager_entitlement":
+					"google_privileged_access_manager_entitlement",
+					"google_firestore_field":
 					return true
 				default:
 					return false

--- a/provider/test-programs/firestore-field/Pulumi.yaml
+++ b/provider/test-programs/firestore-field/Pulumi.yaml
@@ -3,11 +3,17 @@ runtime: yaml
 config:
   gcpProj: string
 resources:
+  db:
+    type: gcp:firestore:Database
+    properties:
+      type: "FIRESTORE_NATIVE"
+      project: ${gcpProj}
+      locationId: "us-central1"
   noidx:
     type: gcp:firestore:Field
     properties:
       project: ${gcpProj}
       collection: my-collection
-      database: (default)
+      database: ${db.name}
       field: field
       indexConfig: {}

--- a/provider/test-programs/firestore-field/Pulumi.yaml
+++ b/provider/test-programs/firestore-field/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: firestore-field
+runtime: yaml
+config:
+  gcpProj: string
+resources:
+  noidx:
+    type: gcp:firestore:Field
+    properties:
+      project: ${gcpProj}
+      collection: my-collection
+      database: (default)
+      field: field
+      indexConfig: {}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-gcp/issues/2166

Enabled PRC for firestore field which prevents a permadiff in the `indexConfig` parameter.