### PR TITLE
Fix firestore database resource leak

### DIFF
--- a/provider/test-programs/firestore-backup-schedule/Pulumi.yaml
+++ b/provider/test-programs/firestore-backup-schedule/Pulumi.yaml
@@ -6,6 +6,7 @@ resources:
     properties:
       locationId: us-central1
       type: FIRESTORE_NATIVE
+      deletionPolicy: DELETE
 
   firestoreBackupsSchedule:
     type: gcp:firestore:BackupSchedule


### PR DESCRIPTION
It needs a special parameter for resources to actually be deleted.

We hit the quota for firestore dbs.

The default behaviour is ABANDON.