### PR TITLE
Fix resource leak

### DIFF
--- a/provider/test-programs/firestore-field/Pulumi.yaml
+++ b/provider/test-programs/firestore-field/Pulumi.yaml
@@ -9,6 +9,7 @@ resources:
       type: "FIRESTORE_NATIVE"
       project: ${gcpProj}
       locationId: "us-central1"
+      deletionPolicy: DELETE
   noidx:
     type: gcp:firestore:Field
     properties:


### PR DESCRIPTION
Fixes a resource leak from the firestore field test.

Firestore databases need the parameter specified in order to get deleted.

Related to https://github.com/pulumi/pulumi-gcp/issues/2273

I've also manually deleted all the firestore databases in the CI account:

```bash
for db in $(gcloud firestore databases list --project pulumi-ci-gcp-provider --format='value(name.split("/").slice(-1))'); do gcloud alpha firestore databases delete $db --project pulumi-ci-gcp-provider --quiet; done
```