### PR TITLE
Enable zero default schema version in GCP

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2700,6 +2700,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			Namespaces: namespaceMap,
 		},
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	prov.RenameResourceWithAlias("google_compute_managed_ssl_certificate", gcpResource(gcpCompute,


### PR DESCRIPTION
Roll out https://github.com/pulumi/pulumi-terraform-bridge/pull/2081 to GCP.

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133