### PR TITLE
Cleanup deprecated goreleaser flag

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -31,7 +31,6 @@ plugins:
     version: "1.0.17"
     kind: converter
 goBuildParallelism: 2
-skipGoReleaserHooks: true
 actions:
   preTest:
     - name: make upstream


### PR DESCRIPTION
Remove the flag `skipGoReleaserHooks` from `.ci-mgmt.yml` because support for this was removed a while ago, with the last bits removed in https://github.com/pulumi/ci-mgmt/pull/1074

Change applied based on this section which was removed from https://github.com/pulumi/ci-mgmt/blob/master/provider-ci/internal/pkg/templates/bridged-provider.config.yaml:

```
# Go releaser: skip the post cleaning steps
# Only used for gcp: https://github.com/search?q=org%3Apulumi+path%3A.ci-mgmt.yaml+%22skipGoReleaserHooks%3A%22&type=code
#skipGoReleaserHooks: false
```