### PR TITLE
Fix empty labels permadiff

### DIFF
--- a/patches/0012-Trial-empty-labels-fix.patch
+++ b/patches/0012-Trial-empty-labels-fix.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ian Wahbe <me@iwahbe.com>
+Date: Thu, 12 Sep 2024 15:41:19 +0200
+Subject: [PATCH] Trial empty labels fix
+
+
+diff --git a/google-beta/services/kms/resource_kms_crypto_key.go b/google-beta/services/kms/resource_kms_crypto_key.go
+index df9fb749f..2a64a2c19 100644
+--- a/google-beta/services/kms/resource_kms_crypto_key.go
++++ b/google-beta/services/kms/resource_kms_crypto_key.go
+@@ -788,7 +788,11 @@ func expandKMSCryptoKeyEffectiveLabels(v interface{}, d tpgresource.TerraformRes
+ 	}
+ 	m := make(map[string]string)
+ 	for k, val := range v.(map[string]interface{}) {
+-		m[k] = val.(string)
++		l := val.(string)
++		if l == tpgresource.EmptyLabelProxy {
++			l = ""
++		}
++		m[k] = l
+ 	}
+ 	return m, nil
+ }
+diff --git a/google-beta/tpgresource/labels.go b/google-beta/tpgresource/labels.go
+index cf3ba739d..938cc9903 100644
+--- a/google-beta/tpgresource/labels.go
++++ b/google-beta/tpgresource/labels.go
+@@ -81,6 +81,8 @@ func SetDataSourceLabels(d *schema.ResourceData) error {
+ 	return nil
+ }
+ 
++const EmptyLabelProxy = "pulumi-empty-label-proxy:entropy=87456874167148"
++
+ func SetLabelsDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+ 	raw := d.Get("labels")
+ 	if raw == nil {
+@@ -141,7 +143,11 @@ func SetLabelsDiff(_ context.Context, d *schema.ResourceDiff, meta interface{})
+ 	effectiveLabels := d.Get("effective_labels").(map[string]interface{})
+ 
+ 	for k, v := range n.(map[string]interface{}) {
+-		effectiveLabels[k] = v.(string)
++		l := v.(string)
++		if l == "" {
++			l = EmptyLabelProxy
++		}
++		effectiveLabels[k] = l
+ 	}
+ 
+ 	for k := range o.(map[string]interface{}) {

--- a/patches/0013-Apply-fix-to-terraform_labels-also.patch
+++ b/patches/0013-Apply-fix-to-terraform_labels-also.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ian Wahbe <me@iwahbe.com>
+Date: Thu, 12 Sep 2024 16:09:58 +0200
+Subject: [PATCH] Apply fix to terraform_labels also
+
+
+diff --git a/google-beta/services/kms/resource_kms_crypto_key.go b/google-beta/services/kms/resource_kms_crypto_key.go
+index 2a64a2c19..2064cfb2e 100644
+--- a/google-beta/services/kms/resource_kms_crypto_key.go
++++ b/google-beta/services/kms/resource_kms_crypto_key.go
+@@ -694,7 +694,11 @@ func flattenKMSCryptoKeyTerraformLabels(v interface{}, d *schema.ResourceData, c
+ 	transformed := make(map[string]interface{})
+ 	if l, ok := d.GetOkExists("terraform_labels"); ok {
+ 		for k := range l.(map[string]interface{}) {
+-			transformed[k] = v.(map[string]interface{})[k]
++			v := v.(map[string]interface{})[k].(string)
++			if v == "" {
++				v = tpgresource.EmptyLabelProxy
++			}
++			transformed[k] = v
+ 		}
+ 	}
+ 
+diff --git a/google-beta/tpgresource/labels.go b/google-beta/tpgresource/labels.go
+index 938cc9903..bdc376324 100644
+--- a/google-beta/tpgresource/labels.go
++++ b/google-beta/tpgresource/labels.go
+@@ -132,7 +132,11 @@ func SetLabelsDiff(_ context.Context, d *schema.ResourceDiff, meta interface{})
+ 
+ 	labels := raw.(map[string]interface{})
+ 	for k, v := range labels {
+-		terraformLabels[k] = v.(string)
++		l := v.(string)
++		if l == "" {
++			l = EmptyLabelProxy
++		}
++		terraformLabels[k] = l
+ 	}
+ 
+ 	if err := d.SetNew("terraform_labels", terraformLabels); err != nil {


### PR DESCRIPTION
This PR prototypes a solution to #2372.

My theory is that TF SDKv2 cannot reliably distinguish between `""` and missing in much the post-diff customizer segment of the machinery. That makes #2372 and thus https://github.com/hashicorp/terraform-provider-google/issues/16750 systemic and unfixable in SDKv2 based providers. It makes it unlikely that the bug will be fixed upstream.

The solution:

Transform empty strings into a proxy value (`"pulumi-empty-label-proxy:entropy=87456874167148"`) before they are seen by the provider, and after they come back from the provider with `PreCheckCallback`, `TransformOutputs` and `TransformFromState`. Then path each resources `expand{resource-name}EffectiveLabels` and `flatten{resource-name}TerraformLabels` to hide `""` from the rest of GCP & SDKv2's machinery.

Fixes #2372

---

To merge:
- [ ] Finish implementation - move `SetLabelsDiff` into `PreCheckCallback` to minimize the patch size.
- [ ] Write a script to manually generate the necessary patch... for each resource.
- [ ] Write up tests to ensure that:
  - [ ] Pulumi users (and state) never see the label proxy.
  - [ ] The GCP console never sees the label proxy.
- [ ] Write a more detailed guide to this patch, how and why it works. The guide needs to detail how pulumi-gcp maintainers will keep pulumi-gcp's patch set up to date with new resources.
  - [ ] Ideally, this will be automatic, since regular manual changes will make maintenance painful, perhaps prohibitively so.