### PR TITLE
Fix empty labels handling in Cluster resource

### DIFF
--- a/provider/labels.go
+++ b/provider/labels.go
@@ -4,7 +4,6 @@ package gcp
 
 import (
 	"context"
-	"q"
 
 	"github.com/hashicorp/go-cty/cty"
 
@@ -26,7 +25,6 @@ func fixEmptyLabels(_ context.Context, req shimv2.PlanStateEditRequest) (cty.Val
 	programLabels := property.Map{}
 
 	labelsPropertyName := "labels"
-	q.Q(req.TfToken, req.NewInputs, req.PlanState, req.ProviderConfig)
 	if req.TfToken == "google_container_cluster" {
 		labelsPropertyName = "resourceLabels"
 	}

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -1133,27 +1133,9 @@ func TestFirestoreDatabaseAutoname(t *testing.T) {
 func TestEmptyLabels(t *testing.T) {
 	tests := []struct {
 		program       string
-		previewStdout autogold.Value
 		upOutputs     autogold.Value
 	}{
-		{"empty-label", autogold.Expect(`Previewing update (test):
-
- +  pulumi:pulumi:Stack empty-label-test create
- +  gcp:kms:KeyRing ring create
- +  gcp:kms:CryptoKey key create
- +  pulumi:pulumi:Stack empty-label-test create
-Outputs:
-    effectiveLabels: [secret]
-    labels         : {
-        empty : ""
-        static: "value"
-    }
-    pulumiLabels   : [secret]
-
-Resources:
-    + 3 to create
-
-`), autogold.Expect(auto.OutputMap{
+		{"empty-label", autogold.Expect(auto.OutputMap{
 			"effectiveLabels": auto.OutputValue{
 				Value: map[string]interface{}{
 					"empty":                   "",
@@ -1175,23 +1157,7 @@ Resources:
 				Secret: true,
 			},
 		})},
-		{"empty-alone-label", autogold.Expect(`Previewing update (test):
-
- +  pulumi:pulumi:Stack empty-alone-label-test create
- +  gcp:kms:KeyRing ring create
- +  gcp:kms:CryptoKey key create
- +  pulumi:pulumi:Stack empty-alone-label-test create
-Outputs:
-    effectiveLabels: [secret]
-    labels         : {
-        empty: ""
-    }
-    pulumiLabels   : [secret]
-
-Resources:
-    + 3 to create
-
-`), autogold.Expect(auto.OutputMap{
+		{"empty-alone-label", autogold.Expect(auto.OutputMap{
 			"effectiveLabels": auto.OutputValue{
 				Value: map[string]interface{}{
 					"empty":                   "",
@@ -1208,23 +1174,7 @@ Resources:
 				Secret: true,
 			},
 		})},
-		{"empty-default-label", autogold.Expect(`Previewing update (test):
-
- +  pulumi:pulumi:Stack empty-default-label-test create
- +  gcp:kms:KeyRing ring create
- +  gcp:kms:CryptoKey key create
- +  pulumi:pulumi:Stack empty-default-label-test create
-Outputs:
-    effectiveLabels: [secret]
-    labels         : {
-        static: "value"
-    }
-    pulumiLabels   : [secret]
-
-Resources:
-    + 3 to create
-
-`), autogold.Expect(auto.OutputMap{
+		{"empty-default-label", autogold.Expect(auto.OutputMap{
 			"effectiveLabels": auto.OutputValue{
 				Value: map[string]interface{}{
 					"empty-default":           "",
@@ -1246,25 +1196,6 @@ Resources:
 		{
 			// Cluster overloads the labels field and instead uses resourceLabels for GCP labels.
 			"empty-label-cluster",
-			autogold.Expect(`Previewing update (test):
-
- +  pulumi:pulumi:Stack empty-label-cluster-test create
- +  random:index:RandomString random-account-id create
- +  gcp:container:Cluster primary create
- +  gcp:serviceaccount:Account serviceAccount create
- +  pulumi:pulumi:Stack empty-label-cluster-test create
-Outputs:
-    effectiveLabels: [secret]
-    labels         : {
-        environment: "dev"
-        test       : ""
-    }
-    pulumiLabels   : [secret]
-
-Resources:
-    + 4 to create
-
-`),
 			autogold.Expect(auto.OutputMap{
 				"effectiveLabels": auto.OutputValue{
 					Value: map[string]interface{}{
@@ -1297,9 +1228,6 @@ Resources:
 			pt := pulumiTest(t, "test-programs/"+tt.program)
 			proj := getProject()
 			pt.SetConfig("gcpProj", proj)
-
-			previewResult := pt.Preview(optpreview.SuppressProgress())
-			tt.previewStdout.Equal(t, previewResult.StdOut)
 
 			upResult := pt.Up(optup.SuppressProgress())
 			tt.upOutputs.Equal(t, upResult.Outputs)

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -384,7 +384,7 @@ func writeStackExport(path string, snapshot *apitype.UntypedDeployment, overwrit
 		return fmt.Errorf("stack export must not be nil")
 	}
 	dir := filepath.Dir(path)
-	err := os.MkdirAll(dir, 0o755)
+	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err
 	}
@@ -399,9 +399,8 @@ func writeStackExport(path string, snapshot *apitype.UntypedDeployment, overwrit
 	if pathExists && !overwrite {
 		return fmt.Errorf("stack export already exists at %s", path)
 	}
-	return os.WriteFile(path, stackBytes, 0o600)
+	return os.WriteFile(path, stackBytes, 0600)
 }
-
 func exists(filePath string) (bool, error) {
 	_, err := os.Stat(filePath)
 	switch {

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -1132,8 +1132,8 @@ func TestFirestoreDatabaseAutoname(t *testing.T) {
 
 func TestEmptyLabels(t *testing.T) {
 	tests := []struct {
-		program       string
-		upOutputs     autogold.Value
+		program   string
+		upOutputs autogold.Value
 	}{
 		{"empty-label", autogold.Expect(auto.OutputMap{
 			"effectiveLabels": auto.OutputValue{

--- a/provider/test-programs/empty-label-cluster/Pulumi.yaml
+++ b/provider/test-programs/empty-label-cluster/Pulumi.yaml
@@ -1,0 +1,31 @@
+name: empty-label-cluster
+runtime: yaml
+resources:
+  random-account-id:
+    type: random:RandomString
+    properties:
+      length: 10
+      special: false
+      upper: false
+      number: false
+  serviceAccount:
+    type: gcp:serviceaccount:Account
+    properties:
+      accountId: ${random-account-id.result}
+  primary:
+    type: gcp:container:Cluster
+    properties:
+      location: us-central1
+      # We can't create a cluster with no node pool defined, but we want to only use
+      # separately managed node pools. So we create the smallest possible default
+      # node pool and immediately delete it.
+      removeDefaultNodePool: true
+      initialNodeCount: 1
+      deletionProtection: false
+      resourceLabels:
+        environment: "dev"
+        test: ""
+outputs:
+  labels: ${primary.resourceLabels}
+  effectiveLabels: ${primary.effectiveLabels}
+  pulumiLabels: ${primary.pulumiLabels}


### PR DESCRIPTION
This fixes the empty label handling in the GCP Cluster resource.

In the fix for https://github.com/pulumi/pulumi-gcp/issues/2372 (https://github.com/pulumi/pulumi-gcp/pull/2386 and https://github.com/pulumi/pulumi-terraform-bridge/pull/2417) we did not know that the labels property in GCP is sometimes overloaded, ex GCP Custer.

For the Cluster resource, the GCP labels are under `resource_labels`, not `labels`

This PR adds the logic to the empty labels fix and adds a regression test.

fixes https://github.com/pulumi/pulumi-gcp/issues/2395