### PR TITLE
Revert "Refactor gcp tests to use pulumitest directly"

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -23,8 +23,6 @@ replace (
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240520223432-0c0bf0d65f10
 	github.com/hashicorp/terraform-provider-google-beta => ../upstream
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
-	// Until we propagate this from the bridge, replace this here to fix a panic [pulumi/pulumi-terraform-bridge#2088]
-	github.com/pulumi/pulumi-terraform-bridge/x/muxer => github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.10
 )
 
 require (
@@ -214,7 +212,7 @@ require (
 	github.com/pulumi/inflector v0.1.1 // indirect
 	github.com/pulumi/pulumi-java/pkg v0.16.1 // indirect
 	github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.9-0.20240227144008-2da15b3d6f6e // indirect
-	github.com/pulumi/pulumi-yaml v1.10.3 // indirect
+	github.com/pulumi/pulumi-yaml v1.10.0 // indirect
 	github.com/pulumi/schema-tools v0.1.2 // indirect
 	github.com/pulumi/terraform-diff-reader v0.0.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1987,10 +1987,10 @@ github.com/pulumi/pulumi-terraform-bridge/pf v0.44.1 h1:39UPLBqbnvylm2heU/Rxa1+G
 github.com/pulumi/pulumi-terraform-bridge/pf v0.44.1/go.mod h1:Zj4XBf+TuV3um7y82X3xk2yQiP+pnQ7YxMc4fq/rVVw=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.91.1 h1:Twh0IKS1pGHP6LHDq1oR0vbHlV52asoUCC7spEJl3Ao=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.91.1/go.mod h1:DvueDDtOIbf7W1Or4oH0o7F990ozp/ROmlm/vgLoe+g=
-github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.10 h1:VAXmHuldKd760ZlMe6khXeJY0ccY3TJF1g1FnWGccaM=
-github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.10/go.mod h1:+AQS/2h775Chx1a4vxb7cDdyiOsdEw2Q6gD7K5QCIwI=
-github.com/pulumi/pulumi-yaml v1.10.3 h1:j5cjPiE32ILmjrWnC1cfZ0MWdqCZ8fg9wlaWk7HOtM4=
-github.com/pulumi/pulumi-yaml v1.10.3/go.mod h1:MFMQXkaUP5YQUKVJ6Z/aagZDl2f8hdU9oGaJfTcMf1Y=
+github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.9-0.20240227144008-2da15b3d6f6e h1:yON1jwN6gg4cjnOQF607I3fTiFyIDr9WSsQNXHD6wbM=
+github.com/pulumi/pulumi-terraform-bridge/x/muxer v0.0.9-0.20240227144008-2da15b3d6f6e/go.mod h1:AvlZujvfRiEu+60frCGEhaLeGttjHwM/g+47+IdPZXw=
+github.com/pulumi/pulumi-yaml v1.10.0 h1:djbgMJCxJBmYMr4kOpAXH5iauxGohYjEuTLfxD3NUUI=
+github.com/pulumi/pulumi-yaml v1.10.0/go.mod h1://lTvwHpgJ+WBKeMGiLrd/jinc4dl3eWV5LZ3G8iCfE=
 github.com/pulumi/pulumi/pkg/v3 v3.133.0 h1:j1rd7ToLZIQc5H0427ISOXSbOIIemZ6B0MXtRhQ38Yg=
 github.com/pulumi/pulumi/pkg/v3 v3.133.0/go.mod h1:JtMAnrsFIccO138WcMfPdhO0PioDukKihnZC0xTRLwo=
 github.com/pulumi/pulumi/sdk/v3 v3.133.0 h1:o+7dbJZY9BVgAjOF5GYIWgjp/zpKAgWZwD4pPjUMXKQ=

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -8,13 +8,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	_ "embed"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/providertest"
 	"github.com/pulumi/providertest/optproviderupgrade"
-	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
 	"github.com/pulumi/providertest/pulumitest/opttest"
@@ -43,18 +40,96 @@ func TestUpgradeCoverage(t *testing.T) {
 	providertest.ReportUpgradeCoverage(t)
 }
 
-//go:embed cmd/pulumi-resource-gcp/schema.json
-var schemaBytes []byte
+type UpgradeTestOpts struct {
+	baselineVersion     string
+	assertFunc          func(*testing.T, auto.PreviewResult)
+	config              map[string]string
+	additionalProviders map[string]string
+}
 
-func providerFactory[T any](T) (pulumirpc.ResourceProviderServer, error) {
-	ctx := context.Background()
-	version.Version = "0.0.1"
-	info := Provider()
-	return pfbridge.MakeMuxedServer(ctx, info.Name, info, schemaBytes)(nil)
+func WithBaselineVersion(baselineVersion string) func(opts *UpgradeTestOpts) {
+	return func(opts *UpgradeTestOpts) {
+		opts.baselineVersion = baselineVersion
+	}
+}
+
+func WithAssertFunc(assertFunc func(*testing.T, auto.PreviewResult)) func(opts *UpgradeTestOpts) {
+	return func(opts *UpgradeTestOpts) {
+		opts.assertFunc = assertFunc
+	}
+}
+
+func WithConfig(config map[string]string) func(opts *UpgradeTestOpts) {
+	return func(opts *UpgradeTestOpts) {
+		opts.config = config
+	}
+}
+
+func WithAdditionalProvider(provider, version string) func(opts *UpgradeTestOpts) {
+	return func(opts *UpgradeTestOpts) {
+		if opts.additionalProviders == nil {
+			opts.additionalProviders = map[string]string{}
+		}
+		opts.additionalProviders[provider] = version
+	}
+}
+
+func testProviderUpgrade(t *testing.T, dir string, opts ...func(*UpgradeTestOpts)) {
+	options := &UpgradeTestOpts{}
+	for _, o := range opts {
+		o(options)
+	}
+	testProviderUpgradeWithConfig(t, dir, options.baselineVersion, options.config, options.assertFunc,
+		options.additionalProviders)
+}
+
+func testProviderUpgradeWithConfig(
+	t *testing.T, dir, baselineVersion string, config map[string]string,
+	assertFunction func(*testing.T, auto.PreviewResult), additionalProviders map[string]string,
+) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	if baselineVersion == "" {
+		baselineVersion = defaultBaselineVersion
+	}
+	opts := []opttest.Option{
+		opttest.DownloadProviderVersion(providerName, baselineVersion),
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+	}
+	for prov, version := range additionalProviders {
+		opts = append(opts, opttest.DownloadProviderVersion(prov, version))
+	}
+	test := pulumitest.NewPulumiTest(t, dir, opts...)
+	test.SetConfig(t, "gcp:config:project", testProject)
+	for k, v := range config {
+		test.SetConfig(t, k, v)
+	}
+	// The SetConfig above does not seem to be working here.
+	t.Setenv("PULUMI_GCP_SKIP_REGION_VALIDATION", "true")
+	result := providertest.PreviewProviderUpgrade(t, test, providerName, baselineVersion,
+		optproviderupgrade.DisableAttach())
+	if assertFunction != nil {
+		assertFunction(t, result)
+	} else {
+		assertpreview.HasNoReplacements(t, result)
+	}
 }
 
 func providerServer(t *testing.T) pulumirpc.ResourceProviderServer {
-	p, err := providerFactory(t)
+	ctx := context.Background()
+	version.Version = "0.0.1"
+	info := Provider()
+	p, err := pfbridge.MakeMuxedServer(ctx, info.Name, info,
+		/*
+		 * We leave the schema blank. This will result in incorrect calls to
+		 * GetSchema, but otherwise does not effect the provider. It reduces the
+		 * time to test start by minutes.
+		 */
+		[]byte("{}"),
+	)(nil)
 	require.NoError(t, err)
 	return p
 }
@@ -77,29 +152,4 @@ func pulumiTest(t *testing.T, dir string, opts ...opttest.Option) *pulumitest.Pu
 	googleProj := getProject()
 	test.SetConfig(t, "gcp:config:project", googleProj)
 	return test
-}
-
-func testUpgrade(t *testing.T, dir string, opts ...optproviderupgrade.PreviewProviderUpgradeOpt) auto.PreviewResult {
-	t.Helper()
-	if testing.Short() {
-		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without cloud credentials")
-		return auto.PreviewResult{}
-	}
-
-	// Provider factory allows the tests to run against an in-process provider.
-	rpFactory := providers.ResourceProviderFactory(providerFactory)
-	pt := pulumitest.NewPulumiTest(t, dir,
-		opttest.AttachProvider(providerName, rpFactory))
-	googleProj := getProject()
-	pt.SetConfig(t, "gcp:config:project", googleProj)
-
-	upgradeOpts := []optproviderupgrade.PreviewProviderUpgradeOpt{
-		optproviderupgrade.DisableAttach(),
-	}
-	upgradeOpts = append(upgradeOpts, opts...)
-	previewResult := providertest.PreviewProviderUpgrade(t, pt, providerName, defaultBaselineVersion, upgradeOpts...)
-
-	assertpreview.HasNoReplacements(t, previewResult)
-	assertpreview.HasNoDeletes(t, previewResult)
-	return previewResult
 }

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -29,68 +29,71 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/providertest/optproviderupgrade"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
+	"github.com/pulumi/providertest/pulumitest/optnewstack"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/providertest/replay"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 func TestDNSRecordSetUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/dns-recordset")
+	testProviderUpgrade(t, "test-programs/dns-recordset")
 }
 
 func TestPubSubSubscriptionUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/pubsub-subscription")
+	testProviderUpgrade(t, "test-programs/pubsub-subscription")
 }
 
 func TestPubSubTopicUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/pubsub-topic")
+	testProviderUpgrade(t, "test-programs/pubsub-topic")
 }
 
 func TestStorageBucketUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/storage-bucket")
+	testProviderUpgrade(t, "test-programs/storage-bucket")
 }
 
 func TestStorageBucketObjectUpgrade(t *testing.T) {
 	t.Skipf("TODO[pulumi/pulumi-gcp#1607] temporarily skipping failing test")
-	testUpgrade(t, "test-programs/storage-bucketobject")
+	testProviderUpgrade(t, "test-programs/storage-bucketobject")
 }
 
 func TestSecretManagerSecretUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/secretmanager-secret")
+	testProviderUpgrade(t, "test-programs/secretmanager-secret")
 }
 
 func TestSqlUserUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/sql-user")
+	testProviderUpgrade(t, "test-programs/sql-user")
 }
 
 func TestBigQueryTableUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/bigquery-table")
+	testProviderUpgrade(t, "test-programs/bigquery-table", WithConfig(map[string]string{
+		"datasetID": "dspitrunnerbigqueryt4b22ee25",
+	}))
 }
 
 func TestComputeFirewallUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/compute-firewall")
+	testProviderUpgrade(t, "test-programs/compute-firewall")
 }
 
 func TestCloudFunctionUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/cloudfunctions-function")
+	testProviderUpgrade(t, "test-programs/cloudfunctions-function")
 }
 
 func TestNetworkUpgrade(t *testing.T) {
 	t.Skipf("Flakey: see https://github.com/pulumi/pulumi-gcp/issues/1655 for details")
-	testUpgrade(t, "test-programs/network")
+	testProviderUpgrade(t, "test-programs/network")
 }
 
 func TestClusterUpgrade(t *testing.T) {
-	testUpgrade(t, "test-programs/cluster",
-		optproviderupgrade.BaselineOpts(opttest.DownloadProviderVersion(providerName, "7.2.1")))
+	testProviderUpgrade(t, "test-programs/cluster", WithBaselineVersion("7.2.1"))
 }
 
 func skipIfNotCI(t *testing.T) {
@@ -102,49 +105,46 @@ func skipIfNotCI(t *testing.T) {
 func TestIamBinding(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testUpgrade(t, "test-programs/iam-binding",
-		optproviderupgrade.BaselineOpts(opttest.DownloadProviderVersion(providerName, "7.0.0")))
+	testProviderUpgrade(t, "test-programs/iam-binding", WithBaselineVersion("7.0.0"))
 }
 
 func TestIamMember(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testUpgrade(t, "test-programs/iam-member",
-		optproviderupgrade.BaselineOpts(opttest.DownloadProviderVersion(providerName, "7.0.0")))
+	testProviderUpgrade(t, "test-programs/iam-member", WithBaselineVersion("7.0.0"))
 }
 
 func TestLogSink(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testUpgrade(t, "test-programs/logsink",
-		optproviderupgrade.BaselineOpts(opttest.DownloadProviderVersion(providerName, "7.0.0")))
+	testProviderUpgrade(t, "test-programs/logsink", WithBaselineVersion("7.0.0"))
 }
 
 func TestTopicIamBinding(t *testing.T) {
 	skipIfNotCI(t)
 	// ServiceAccount requires 7.0
-	testUpgrade(t, "test-programs/topic-iam-binding",
-		optproviderupgrade.BaselineOpts(opttest.DownloadProviderVersion(providerName, "7.0.0")))
+	testProviderUpgrade(t, "test-programs/topic-iam-binding", WithBaselineVersion("7.0.0"))
 }
 
 func TestConnectionProfileUpgrade(t *testing.T) {
-	res := testUpgrade(t, "test-programs/connection-profile",
-		optproviderupgrade.BaselineOpts(opttest.DownloadProviderVersion("random", "4.16.0")))
-	assertpreview.HasNoChanges(t, res)
+	testProviderUpgrade(t, "test-programs/connection-profile", WithAssertFunc(assertpreview.HasNoChanges),
+		WithAdditionalProvider("random", "4.16.0"))
 }
 
 func TestConnectionProfileUpgradev7(t *testing.T) {
-	res := testUpgrade(t, "test-programs/connection-profile",
-		optproviderupgrade.BaselineOpts(
-			opttest.DownloadProviderVersion("random", "4.16.0"),
-			opttest.DownloadProviderVersion(providerName, "7.17.0")),
-	)
-	assertpreview.HasNoChanges(t, res)
+	testProviderUpgrade(t, "test-programs/connection-profile", WithAssertFunc(assertpreview.HasNoChanges),
+		WithBaselineVersion("7.17.0"), WithAdditionalProvider("random", "4.16.0"))
 }
 
 // Regression test for https://github.com/pulumi/pulumi-gcp/issues/1874
 func TestRegress1874(t *testing.T) {
-	test := pulumiTest(t, "test-programs/connection-profile",
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	test := pulumitest.NewPulumiTest(t, "test-programs/connection-profile",
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
 		opttest.DownloadProviderVersion("random", "4.16.0"),
 	)
 
@@ -219,7 +219,7 @@ func TestAutoExtractedProgramsUpgrade(t *testing.T) {
 		tc := tc
 		t.Run(tc.program, func(t *testing.T) {
 			d := filepath.Join("test-programs", tc.program)
-			testUpgrade(t, d)
+			testProviderUpgrade(t, d)
 		})
 	}
 }
@@ -254,7 +254,16 @@ resources:
                       name: empty-dir-volume
         type: gcp:cloudrunv2:Service
 runtime:
-    name: yaml`
+    name: yaml
+
+`
+
+	var (
+		providerName    = "gcp"
+		baselineVersion = "7.28.0"
+	)
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
 
 	// Apply the relevant changes expected to upgrade successfully v7 -> v8:
 	// `ports` is now an Object, not a maxItemsOne list
@@ -268,16 +277,140 @@ runtime:
 		"\n            deletionProtection: false",
 		"ports:\n                        containerPort: 8080"),
 	)
+	// Test that we can upgrade from v7 to v8 with the changes applied to the program.
+	t.Run("upgrade-to-v8-shows-no-diffs-for-ports", func(t *testing.T) {
+		pulumiTest := testProviderCodeChanges(t, &testProviderCodeChangesOptions{
+			firstProgram: firstProgram,
+			firstProgramOptions: []opttest.Option{
+				opttest.DownloadProviderVersion(providerName, baselineVersion),
+			},
+			secondProgram: secondProgram,
+			secondProgramOptions: []opttest.Option{
+				opttest.LocalProviderPath("gcp", filepath.Join(cwd, "..", "bin")),
+			},
+		})
 
-	testDir := t.TempDir()
-	err := os.WriteFile(filepath.Join(testDir, "Pulumi.yaml"), firstProgram, 0o600)
+		res := pulumiTest.Preview(t)
+		t.Logf("stdout: %s \n", res.StdOut)
+		t.Logf("stderr: %s \n", res.StdErr)
+		assertpreview.HasNoChanges(t, res)
+
+		upResult := pulumiTest.Up(t)
+		t.Logf("stdout: %s \n", upResult.StdOut)
+		t.Logf("stderr: %s \n", upResult.StdErr)
+	})
+}
+
+type testProviderCodeChangesOptions struct {
+	firstProgram         []byte
+	secondProgram        []byte
+	firstProgramOptions  []opttest.Option
+	secondProgramOptions []opttest.Option
+}
+
+// testProviderCodeChanges tests two different runs of a pulumi program. This allows you to run
+// pulumi up with an initial program, change the code of the program and then run another pulumi command
+func testProviderCodeChanges(t *testing.T, opts *testProviderCodeChangesOptions) *pulumitest.PulumiTest {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without credentials")
+	}
+	t.Parallel()
+	t.Helper()
+
+	workdir := t.TempDir()
+	stackExportFile := filepath.Join(workdir, "stack.json")
+
+	err := os.WriteFile(filepath.Join(workdir, "Pulumi.yaml"), opts.firstProgram, 0o600)
 	require.NoError(t, err)
 
-	secondTestDir := t.TempDir()
-	err = os.WriteFile(filepath.Join(secondTestDir, "Pulumi.yaml"), secondProgram, 0o600)
-	require.NoError(t, err)
+	options := []opttest.Option{
+		opttest.SkipInstall(),
+		opttest.NewStackOptions(optnewstack.DisableAutoDestroy()),
+	}
+	options = append(options, opts.firstProgramOptions...)
 
-	testUpgrade(t, testDir, optproviderupgrade.NewSourcePath(secondTestDir))
+	firstTest := pulumitest.NewPulumiTest(t, workdir, options...)
+	googleProj := getProject()
+	firstTest.SetConfig(t, "gcp:config:project", googleProj)
+
+	var export *apitype.UntypedDeployment
+	export, err = tryReadStackExport(stackExportFile)
+	if err != nil {
+		firstTest.Up(t)
+		grptLog := firstTest.GrpcLog(t)
+		grpcLogPath := filepath.Join(workdir, "grpc.json")
+		t.Logf("writing grpc log to %s", grpcLogPath)
+		err = grptLog.WriteTo(grpcLogPath)
+		assert.NoError(t, err)
+		e := firstTest.ExportStack(t)
+		export = &e
+		err = writeStackExport(stackExportFile, export, true)
+		assert.NoError(t, err)
+	}
+
+	secondOptions := []opttest.Option{
+		opttest.SkipInstall(),
+		opttest.NewStackOptions(optnewstack.EnableAutoDestroy()),
+	}
+	secondOptions = append(secondOptions, opts.secondProgramOptions...)
+
+	err = os.WriteFile(filepath.Join(workdir, "Pulumi.yaml"), opts.secondProgram, 0o600)
+	require.NoError(t, err)
+	secondTest := pulumitest.NewPulumiTest(t, workdir, secondOptions...)
+	secondTest.ImportStack(t, *export)
+	secondTest.SetConfig(t, "gcp:config:project", googleProj)
+
+	return secondTest
+}
+
+// tryReadStackExport reads a stack export from the given file path.
+// If the file does not exist, returns nil, nil.
+func tryReadStackExport(path string) (*apitype.UntypedDeployment, error) {
+	stackBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stack export at %s: %v", path, err)
+	}
+	var stackExport apitype.UntypedDeployment
+	err = json.Unmarshal(stackBytes, &stackExport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal stack export at %s: %v", path, err)
+	}
+	return &stackExport, nil
+}
+
+// writeStackExport writes the stack export to the given path creating any directories needed.
+func writeStackExport(path string, snapshot *apitype.UntypedDeployment, overwrite bool) error {
+	if snapshot == nil {
+		return fmt.Errorf("stack export must not be nil")
+	}
+	dir := filepath.Dir(path)
+	err := os.MkdirAll(dir, 0o755)
+	if err != nil {
+		return err
+	}
+	stackBytes, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	pathExists, err := exists(path)
+	if err != nil {
+		return err
+	}
+	if pathExists && !overwrite {
+		return fmt.Errorf("stack export already exists at %s", path)
+	}
+	return os.WriteFile(path, stackBytes, 0o600)
+}
+
+func exists(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	switch {
+	case err == nil:
+		return true, nil
+	case !os.IsNotExist(err):
+		return false, err
+	}
+	return false, nil
 }
 
 // This used to panic in the Diff on unexpected bool label (expecting string), see
@@ -619,7 +752,13 @@ func TestEnvTokenNotInState(t *testing.T) {
 		t.Fatal(string(errMsg))
 	}
 	t.Setenv("GOOGLE_OAUTH_ACCESS_TOKEN", outputStr)
-	test := pulumiTest(t, filepath.Join("test-programs", "storage-bucket"))
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	test := pulumitest.NewPulumiTest(t, filepath.Join("test-programs", "storage-bucket"),
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+	)
+	googleProj := getProject()
+	test.SetConfig(t, "gcp:config:project", googleProj)
 
 	test.Up(t)
 	stack := test.ExportStack(t)

--- a/provider/test-programs/bigquery-table/Pulumi.yaml
+++ b/provider/test-programs/bigquery-table/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: test
 runtime:
     name: yaml
+config:
+  datasetID:
+    type: string
 resources:
     provider:
         type: pulumi:providers:gcp
@@ -32,7 +35,7 @@ resources:
         options:
             provider: ${provider}
         properties:
-            datasetId: dspitrunnerbigqueryt4b22ee25
+            datasetId: ${datasetID}
             defaultTableExpirationMs: 3.6e+06
             description: This is a test description
             friendlyName: test


### PR DESCRIPTION
Reverts pulumi/pulumi-gcp#2508

It looks like this change has broken CI. 