### PR TITLE
Cloudrun service fix 409 conflict due to not refreshing by default

### DIFF
--- a/provider/provider_nodejs_test.go
+++ b/provider/provider_nodejs_test.go
@@ -4,8 +4,11 @@
 package gcp
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,6 +46,45 @@ func TestCloudrunServicePanicRegress2155(t *testing.T) {
 	)
 
 	test.Up(t)
+	test.Up(t)
+}
+
+func TestCloudrunServicePanicRegress2622(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	region := "us-central1"
+	t.Setenv("GOOGLE_REGION", region)
+
+	test := pulumitest.NewPulumiTest(t, filepath.Join("test-programs", "cloudrun-service"),
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+	)
+
+	proj := getProject()
+	test.SetConfig(t, "gcp:project", proj)
+	up := test.Up(t)
+
+	outputID := up.Outputs["id"].Value.(string)
+	parts := strings.Split(outputID, "/")
+	id := parts[len(parts)-1]
+
+	cmdDepErr := exec.Command(
+		"gcloud", "run", "deploy", id, "--image=us-docker.pkg.dev/cloudrun/container/hello", "--cpu=2",
+		"--no-cpu-boost", fmt.Sprintf(`--region=%s`, region), fmt.Sprintf(`--project=%s`, proj)).Run()
+	if cmdDepErr != nil {
+		t.Fatal(cmdDepErr.Error())
+	}
+
+	cmdErr := exec.Command("gcloud", "run", "services", "update-traffic", id, "--to-latest",
+		fmt.Sprintf(`--region=%s`, region), fmt.Sprintf(`--project=%s`, proj)).Run()
+	if cmdErr != nil {
+		t.Fatal(cmdErr.Error())
+	}
+	test.SetConfig(t, "cpu", "2")
 	test.Up(t)
 }
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1776,7 +1776,25 @@ func Provider() tfbridge.ProviderInfo {
 
 			// CloudRun Resources
 			"google_cloud_run_domain_mapping": {Tok: gcpResource(gcpCloudRun, "DomainMapping")},
-			"google_cloud_run_service":        {Tok: gcpResource(gcpCloudRun, "Service"), Fields: nameField(lowercaseAutoName())},
+			"google_cloud_run_service": {
+				Tok: gcpResource(gcpCloudRun, "Service"),
+				// PreCheckCallback: func(
+				// 	ctx context.Context, config resource.PropertyMap, meta resource.PropertyMap,
+				// ) (resource.PropertyMap, error) {
+				// 	panic("I am your provider")
+				// },
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": tfbridge.AutoNameWithCustomOptions("name",
+						// Name is auto-named without any suffix.
+						tfbridge.AutoNameOptions{Randlen: 0}),
+					"autogenerate_revision_name": {
+						Default: &tfbridge.DefaultInfo{
+							Value: true,
+						},
+					},
+				},
+				// Fields: nameField(lowercaseAutoName())
+			},
 			"google_cloud_run_service_iam_binding": {
 				Tok:  gcpResource(gcpCloudRun, "IamBinding"),
 				Docs: &tfbridge.DocInfo{Source: "cloud_run_service_iam.html.markdown"},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1783,7 +1783,7 @@ func Provider() tfbridge.ProviderInfo {
 				// program, and since pulumi does not refresh by default. See the following urls for more information:
 				// https://cloud.google.com/run/docs/reference/rpc/google.cloud.run.meta.v1#google.cloud.run.meta.v1.ObjectMeta
 				// https://github.com/pulumi/pulumi-gcp/issues/350
-				TransformFromState: func(ctx context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+				TransformFromState: func(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
 					if _, md := state["metadata"]; md {
 						if state["metadata"].IsObject() {
 							metadata := state["metadata"].ObjectValue()

--- a/provider/test-programs/cloudrun-service/index.ts
+++ b/provider/test-programs/cloudrun-service/index.ts
@@ -1,12 +1,23 @@
+import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
 
-new gcp.cloudrun.Service("my-service", {
+const pulumiConfig = new pulumi.Config()
+const cpu = pulumiConfig.get("cpu") || "1"
+
+const cloudRunService = new gcp.cloudrun.Service("my-service", {
     location: "us-central1",
     template: {
         spec: {
             containers: [{
                 image: "us-docker.pkg.dev/cloudrun/container/hello",
+                resources: {
+                    limits: {
+                        cpu: cpu,
+                    },
+                },
             }],
         },
     },
 });
+
+export const id = cloudRunService.id


### PR DESCRIPTION
This change fixes an issue with the `cloud_run_service` resource which causes a 409 conflict with the service whenever there is a change outside of pulumi. The conflict is caused by the `resourceVersion` property in the `metadata` blob, which is used for optimistic locking.

This change adds a `TransformFromState` hook to the resource which deletes the `resourceVersion` from the state. This disables the optimistic locking behaviour and prevents the 409 conflicts caused by changes to the resource.

fixes https://github.com/pulumi/pulumi-gcp/issues/350