### PR TITLE
Adding in disableGlobalProjectWarning, fixes #1168

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -20,9 +20,9 @@ To provision resources with the Pulumi Google Cloud Provider, you need to have G
 
 Pulumi can authenticate to Google Cloud via several methods:
 
-- Google Cloud CLI
-- OpenID Connect (OIDC)
-- Service account
+* Google Cloud CLI
+* OpenID Connect (OIDC)
+* Service account
 
 ## Configuration
 
@@ -95,3 +95,4 @@ Use `pulumi config set gcp:<option>` or pass options to the [constructor of `new
 | `accessToken` | Optional | A temporary OAuth 2.0 access token obtained from the Google Authorization server, i.e. the `Authorization: Bearer` token used to authenticate HTTP requests to GCP APIs. Alternative to `credentials`. Ignores the `scopes` field. |
 | `scopes` | Optional | List of OAuth 2.0 [scopes](https://developers.google.com/identity/protocols/oauth2/scopes) requested when generating an access token using the service account key specified in `credentials`. Defaults: `https://www.googleapis.com/auth/cloud-platform` and `https://www.googleapis.com/auth/userinfo.email` |
 | `impersonateServiceAccount` | Optional | Setting to impersonate a [Google service account](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct) If you authenticate as a service account, Google Cloud derives your quota project and permissions from that service account rather than your primary authentication method. A valid primary authentication mechanism must be provided for the impersonation call, and your primary identity must have the `roles/iam.serviceAccountTokenCreator` role on the service account you are impersonating. This can also be specified by setting the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment variable. |
+| `disableGlobalProjectWarning` | Optional | Boolean setting to disable the warning when the Google global `project` is not set |

--- a/provider/errors/no_project.txt
+++ b/provider/errors/no_project.txt
@@ -2,3 +2,5 @@ unable to detect a global setting for GCP Project.
 Pulumi will rely on per-resource settings for this operation.
 Set the GCP Project by using:
     `pulumi config set gcp:project <project>`
+If you would like to disable this warning use:
+    `pulumi config set gcp:disableGlobalProjectWarning true`

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -214,6 +214,22 @@ func TestNoGlobalProjectWarning(t *testing.T) {
 	)
 }
 
+func TestGlobalProjectNoProjectWarning(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	proj := getProject()
+	test := pulumitest.NewPulumiTest(t, "test-programs/project-bucket",
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")))
+
+	test.SetConfig(t, "gcp:disableGlobalProjectWarning", "true")
+	test.SetConfig(t, "gcpProj", proj)
+	res := test.Up(t)
+	require.NotContains(t, res.StdOut, "If you would like to disable this warning use")
+}
+
 // Test programs that were automatically extracted from examples without autocorrection.
 func TestAutoExtractedProgramsUpgrade(t *testing.T) {
 	type testCase struct {

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -536,6 +536,13 @@ namespace Pulumi.Gcp
             set => _dialogflowCxCustomEndpoint.Set(value);
         }
 
+        private static readonly __Value<bool?> _disableGlobalProjectWarning = new __Value<bool?>(() => __config.GetBoolean("disableGlobalProjectWarning") ?? Utilities.GetEnvBoolean("PULUMI_GCP_DISABLE_GLOBAL_PROJECT_WARNING") ?? false);
+        public static bool? DisableGlobalProjectWarning
+        {
+            get => _disableGlobalProjectWarning.Get();
+            set => _disableGlobalProjectWarning.Set(value);
+        }
+
         private static readonly __Value<bool?> _disableGooglePartnerName = new __Value<bool?>(() => __config.GetBoolean("disableGooglePartnerName"));
         public static bool? DisableGooglePartnerName
         {

--- a/sdk/go/gcp/config/config.go
+++ b/sdk/go/gcp/config/config.go
@@ -227,6 +227,17 @@ func GetDialogflowCustomEndpoint(ctx *pulumi.Context) string {
 func GetDialogflowCxCustomEndpoint(ctx *pulumi.Context) string {
 	return config.Get(ctx, "gcp:dialogflowCxCustomEndpoint")
 }
+func GetDisableGlobalProjectWarning(ctx *pulumi.Context) bool {
+	v, err := config.TryBool(ctx, "gcp:disableGlobalProjectWarning")
+	if err == nil {
+		return v
+	}
+	var value bool
+	if d := internal.GetEnvOrDefault(false, internal.ParseEnvBool, "PULUMI_GCP_DISABLE_GLOBAL_PROJECT_WARNING"); d != nil {
+		value = d.(bool)
+	}
+	return value
+}
 func GetDisableGooglePartnerName(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "gcp:disableGooglePartnerName")
 }

--- a/sdk/java/src/main/java/com/pulumi/gcp/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/Config.java
@@ -231,6 +231,9 @@ public final class Config {
     public Optional<String> dialogflowCxCustomEndpoint() {
         return Codegen.stringProp("dialogflowCxCustomEndpoint").config(config).get();
     }
+    public Optional<Boolean> disableGlobalProjectWarning() {
+        return Codegen.booleanProp("disableGlobalProjectWarning").config(config).env("PULUMI_GCP_DISABLE_GLOBAL_PROJECT_WARNING").def(false).get();
+    }
     public Optional<Boolean> disableGooglePartnerName() {
         return Codegen.booleanProp("disableGooglePartnerName").config(config).get();
     }

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -585,6 +585,14 @@ Object.defineProperty(exports, "dialogflowCxCustomEndpoint", {
     enumerable: true,
 });
 
+export declare const disableGlobalProjectWarning: boolean;
+Object.defineProperty(exports, "disableGlobalProjectWarning", {
+    get() {
+        return __config.getObject<boolean>("disableGlobalProjectWarning") ?? (utilities.getEnvBoolean("PULUMI_GCP_DISABLE_GLOBAL_PROJECT_WARNING") || false);
+    },
+    enumerable: true,
+});
+
 export declare const disableGooglePartnerName: boolean | undefined;
 Object.defineProperty(exports, "disableGooglePartnerName", {
     get() {

--- a/sdk/python/pulumi_gcp/config/__init__.pyi
+++ b/sdk/python/pulumi_gcp/config/__init__.pyi
@@ -159,6 +159,8 @@ dialogflowCustomEndpoint: Optional[str]
 
 dialogflowCxCustomEndpoint: Optional[str]
 
+disableGlobalProjectWarning: bool
+
 disableGooglePartnerName: Optional[bool]
 
 discoveryEngineCustomEndpoint: Optional[str]

--- a/sdk/python/pulumi_gcp/config/vars.py
+++ b/sdk/python/pulumi_gcp/config/vars.py
@@ -310,6 +310,10 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get('dialogflowCxCustomEndpoint')
 
     @property
+    def disable_global_project_warning(self) -> bool:
+        return __config__.get_bool('disableGlobalProjectWarning') or (_utilities.get_env_bool('PULUMI_GCP_DISABLE_GLOBAL_PROJECT_WARNING') or False)
+
+    @property
     def disable_google_partner_name(self) -> Optional[bool]:
         return __config__.get_bool('disableGooglePartnerName')
 


### PR DESCRIPTION
Adds `disableGlobalProjectWarning` to the ExtraConfig for the provider, allowing users to disable the initial default project. This fixes #1168 