### PR TITLE
Anonymous subtests

### DIFF
--- a/provider/doc_edits_test.go
+++ b/provider/doc_edits_test.go
@@ -63,7 +63,7 @@ Some more text.`,
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.text, func(t *testing.T) {
+		t.Run("", func(t *testing.T) {
 			t.Parallel()
 			actual, err := removeSecretsInPlainTextNote.Edit("doc.md", []byte(tt.text))
 			require.NoError(t, err)


### PR DESCRIPTION
Use the default subtest name in `TestSecretsInPlainTextNote`. The current name causes `gotestfmt` to erroneously decide
`TestSecretsInPlainTextNote/Some_other_text.__~>_**Warning:**_All_a...` has failed:


