### PR TITLE
Set `.DisplayName` in `tfbridge.ProviderInfo`

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -482,6 +482,7 @@ func Provider() tfbridge.ProviderInfo {
 	prov := tfbridge.ProviderInfo{
 		P:                p,
 		Name:             "google-beta",
+		DisplayName:      "Google Cloud Classic",
 		ResourcePrefix:   "google",
 		GitHubOrg:        "hashicorp",
 		Description:      "A Pulumi package for creating and managing Google Cloud Platform resources.",


### PR DESCRIPTION
This PR is part of pulumi/registry#4672. The display name used was taken from `github.com/pulumi/registry/tools/resourcedocsgen/pkg/lookup.go`.