### PR TITLE
Fix PULUMI_GCP_DISABLE_GLOBAL_PROJECT_WARNING/gcp:disableGlobalProjectWarning

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -31,10 +31,6 @@ plugins:
     version: "1.0.17"
     kind: converter
 goBuildParallelism: 2
-actions:
-  preTest:
-    - name: Run provider tests
-      run: |
-        cd provider && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
 # Use `pulumi convert` for translating examples from TF to Pulumi.
 pulumiConvert: 1
+integrationTestProvider: true

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -91,7 +91,7 @@ jobs:
           schema-tools compare -r github://api.github.com/pulumi -p gcp -o "${{ inputs.default_branch }}" -n --local-path=provider/cmd/pulumi-resource-gcp/schema.json;
           echo "$EOF";
         } >> "$GITHUB_ENV"
-    - if: inputs.is_pr && inputs.is_automated == false
+    - if: inputs.is_pr && inputs.is_automated == false && github.actor != 'dependabot[bot]'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,8 +98,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         version: v2.5.0
     - name: Run provider tests
-      run: |
-        cd provider && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
+      if: matrix.testTarget == 'local'
+      working-directory: provider
+      run: go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 .
     - name: Run tests
       if: matrix.testTarget == 'local'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -skip TestPulumiExamples -parallel 4 .

--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -192,7 +192,7 @@ func TestPreConfigureCallbackWarningWhenNoProject(t *testing.T) {
 	expectedLogs := &expectLogs{t, []string{noProjectErr}}
 	defer expectedLogs.assertDone()
 
-	t.Setenv("PULUMI_GCP_DISABLE_GLOBAL_PROJECT_WARNING", "")
+	t.Setenv("GOOGLE_PROJECT", "")
 
 	ctx := testutil.InitLogging(t, context.Background(), expectedLogs)
 	callback := preConfigureCallbackWithLogger(new(atomic.Bool), nil)


### PR DESCRIPTION
The current "disableGlobalProjectWarning" check happens after the global project warning has already been displayed, and instead serves to skip the gcloud config validation. This PR moves the check to the correct place, and puts in tests on the logged output.

Fixes #2829