### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -415,12 +415,13 @@ func TestBucketBooleanLabel(t *testing.T) {
 	      "stables": "*",
 	      "hasDetailedDiff": true,
 	      "detailedDiff": {
-		"labels.bad-bool": {
+		"labels[\"bad-bool\"]": {
 		  "kind": "UPDATE"
 		},
-                "pulumiLabels": {
+		"effectiveLabels[\"bad-bool\"]": {
 		  "kind": "UPDATE"
-                }
+                },
+		  "pulumiLabels[\"bad-bool\"]": {}
 	      }
 	    }
 	  }
@@ -640,7 +641,9 @@ func TestRegress1488(t *testing.T) {
 	  "response": {
 	    "stables": "*",
 	    "changes": "*",
-	    "hasDetailedDiff": "*"
+	    "hasDetailedDiff": "*",
+	    "detailedDiff": "*",
+		"diffs": "*"
 	  }
 	}
 	]`, proj, proj))

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2804,6 +2804,7 @@ func Provider() tfbridge.ProviderInfo {
 			Namespaces:           namespaceMap,
 		},
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	prov.RenameResourceWithAlias("google_compute_managed_ssl_certificate", gcpResource(gcpCompute,


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the provider.

part of pulumi/pulumi-terraform-bridge#2598