### PR TITLE
Fix final misconfiguration in Workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -214,6 +214,7 @@ jobs:
     name: verify_release
     needs: publish_sdk
     permissions:
+      contents: write
       id-token: write
     uses: ./.github/workflows/verify-release.yml
     secrets: inherit


### PR DESCRIPTION
This hopefully addresses https://github.com/pulumi/pulumi-gcp/issues/2906.

I've run the `master` Workflow from this branch and they run, so they are (finally) valid: https://github.com/pulumi/pulumi-gcp/actions/runs/13060398100