### PR TITLE
Dont auto-merge upstream upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -39,3 +39,4 @@ releaseVerification:
   python: examples/bucket-py
   dotnet: examples/serverless-cs
   go: examples/bucket-go
+AutoMergeProviderUpgrades: false


### PR DESCRIPTION
Sets the `AutoMergeProviderUpgrades` ci-mgmt config to false to avoid auto-merging upstream upgrades.

Part of https://github.com/pulumi/ci-mgmt/issues/1344