### PR TITLE
Disallow missing resource docs on upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -34,6 +34,7 @@ goBuildParallelism: 2
 # Use `pulumi convert` for translating examples from TF to Pulumi.
 pulumiConvert: 1
 integrationTestProvider: true
+allowMissingDocs: false
 releaseVerification:
   nodejs: examples/bucket
   python: examples/bucket-py


### PR DESCRIPTION
Sets the `allowMissingDocs` ci-mgmt config to false to error on missing resource docs. This maintains the current behaviour.

Part of https://github.com/pulumi/upgrade-provider/issues/303