### PR TITLE
Fix metastoreservice delete before replace V2

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1255,7 +1255,17 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			"google_dataproc_autoscaling_policy":   {Tok: gcpResource(gcpDataProc, "AutoscalingPolicy")},
-			"google_dataproc_metastore_service":    {Tok: gcpResource(gcpDataProc, "MetastoreService")},
+			"google_dataproc_metastore_service":    {
+				Tok: gcpResource(gcpDataProc, "MetastoreService"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					// https://cloud.google.com/dataproc-metastore/docs/reference/rpc/google.cloud.metastore.v1#createservicerequest
+					// This value must be between 2 and 63 characters long
+					// inclusive, begin with a letter, end with a letter or
+					// number, and consist of alpha-numeric ASCII characters or
+					// hyphens.
+					"service_id": tfbridge.AutoName("", 63, "-"),
+				},
+			},
 			"google_dataproc_metastore_federation": {Tok: gcpResource(gcpDataProc, "MetastoreFederation")},
 			"google_dataproc_workflow_template":    {Tok: gcpResource(gcpDataProc, "WorkflowTemplate")},
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1254,8 +1254,8 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "dataproc_job_iam.html.markdown",
 				},
 			},
-			"google_dataproc_autoscaling_policy":   {Tok: gcpResource(gcpDataProc, "AutoscalingPolicy")},
-			"google_dataproc_metastore_service":    {
+			"google_dataproc_autoscaling_policy": {Tok: gcpResource(gcpDataProc, "AutoscalingPolicy")},
+			"google_dataproc_metastore_service": {
 				Tok: gcpResource(gcpDataProc, "MetastoreService"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					// https://cloud.google.com/dataproc-metastore/docs/reference/rpc/google.cloud.metastore.v1#createservicerequest

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1255,10 +1255,7 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			"google_dataproc_autoscaling_policy":   {Tok: gcpResource(gcpDataProc, "AutoscalingPolicy")},
-			"google_dataproc_metastore_service":    {
-				Tok: gcpResource(gcpDataProc, "MetastoreService"),
-				DeleteBeforeReplace: true,
-			},
+			"google_dataproc_metastore_service":    {Tok: gcpResource(gcpDataProc, "MetastoreService")},
 			"google_dataproc_metastore_federation": {Tok: gcpResource(gcpDataProc, "MetastoreFederation")},
 			"google_dataproc_workflow_template":    {Tok: gcpResource(gcpDataProc, "WorkflowTemplate")},
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1255,7 +1255,10 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			"google_dataproc_autoscaling_policy":   {Tok: gcpResource(gcpDataProc, "AutoscalingPolicy")},
-			"google_dataproc_metastore_service":    {Tok: gcpResource(gcpDataProc, "MetastoreService")},
+			"google_dataproc_metastore_service":    {
+				Tok: gcpResource(gcpDataProc, "MetastoreService"),
+				DeleteBeforeReplace: true,
+			},
 			"google_dataproc_metastore_federation": {Tok: gcpResource(gcpDataProc, "MetastoreFederation")},
 			"google_dataproc_workflow_template":    {Tok: gcpResource(gcpDataProc, "WorkflowTemplate")},
 

--- a/sdk/dotnet/Dataproc/MetastoreService.cs
+++ b/sdk/dotnet/Dataproc/MetastoreService.cs
@@ -674,7 +674,7 @@ namespace Pulumi.Gcp.Dataproc
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public MetastoreService(string name, MetastoreServiceArgs args, CustomResourceOptions? options = null)
+        public MetastoreService(string name, MetastoreServiceArgs? args = null, CustomResourceOptions? options = null)
             : base("gcp:dataproc/metastoreService:MetastoreService", name, args ?? new MetastoreServiceArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -840,8 +840,8 @@ namespace Pulumi.Gcp.Dataproc
         /// 
         /// - - -
         /// </summary>
-        [Input("serviceId", required: true)]
-        public Input<string> ServiceId { get; set; } = null!;
+        [Input("serviceId")]
+        public Input<string>? ServiceId { get; set; }
 
         /// <summary>
         /// The configuration specifying telemetry settings for the Dataproc Metastore service. If unspecified defaults to JSON.

--- a/sdk/go/gcp/dataproc/metastoreService.go
+++ b/sdk/go/gcp/dataproc/metastoreService.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -640,12 +639,9 @@ type MetastoreService struct {
 func NewMetastoreService(ctx *pulumi.Context,
 	name string, args *MetastoreServiceArgs, opts ...pulumi.ResourceOption) (*MetastoreService, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &MetastoreServiceArgs{}
 	}
 
-	if args.ServiceId == nil {
-		return nil, errors.New("invalid value for required argument 'ServiceId'")
-	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"effectiveLabels",
 		"pulumiLabels",
@@ -894,7 +890,7 @@ type metastoreServiceArgs struct {
 	// 3 and 63 characters.
 	//
 	// ***
-	ServiceId string `pulumi:"serviceId"`
+	ServiceId *string `pulumi:"serviceId"`
 	// The configuration specifying telemetry settings for the Dataproc Metastore service. If unspecified defaults to JSON.
 	// Structure is documented below.
 	TelemetryConfig *MetastoreServiceTelemetryConfig `pulumi:"telemetryConfig"`
@@ -959,7 +955,7 @@ type MetastoreServiceArgs struct {
 	// 3 and 63 characters.
 	//
 	// ***
-	ServiceId pulumi.StringInput
+	ServiceId pulumi.StringPtrInput
 	// The configuration specifying telemetry settings for the Dataproc Metastore service. If unspecified defaults to JSON.
 	// Structure is documented below.
 	TelemetryConfig MetastoreServiceTelemetryConfigPtrInput

--- a/sdk/java/src/main/java/com/pulumi/gcp/dataproc/MetastoreService.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/dataproc/MetastoreService.java
@@ -1123,7 +1123,7 @@ public class MetastoreService extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public MetastoreService(java.lang.String name, MetastoreServiceArgs args) {
+    public MetastoreService(java.lang.String name, @Nullable MetastoreServiceArgs args) {
         this(name, args, null);
     }
     /**
@@ -1132,7 +1132,7 @@ public class MetastoreService extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public MetastoreService(java.lang.String name, MetastoreServiceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public MetastoreService(java.lang.String name, @Nullable MetastoreServiceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("gcp:dataproc/metastoreService:MetastoreService", name, makeArgs(args, options), makeResourceOptions(options, Codegen.empty()), false);
     }
 
@@ -1140,7 +1140,7 @@ public class MetastoreService extends com.pulumi.resources.CustomResource {
         super("gcp:dataproc/metastoreService:MetastoreService", name, state, makeResourceOptions(options, id), false);
     }
 
-    private static MetastoreServiceArgs makeArgs(MetastoreServiceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    private static MetastoreServiceArgs makeArgs(@Nullable MetastoreServiceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;
         }

--- a/sdk/java/src/main/java/com/pulumi/gcp/dataproc/MetastoreServiceArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/dataproc/MetastoreServiceArgs.java
@@ -5,7 +5,6 @@ package com.pulumi.gcp.dataproc;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import com.pulumi.exceptions.MissingRequiredPropertyException;
 import com.pulumi.gcp.dataproc.inputs.MetastoreServiceEncryptionConfigArgs;
 import com.pulumi.gcp.dataproc.inputs.MetastoreServiceHiveMetastoreConfigArgs;
 import com.pulumi.gcp.dataproc.inputs.MetastoreServiceMaintenanceWindowArgs;
@@ -298,8 +297,8 @@ public final class MetastoreServiceArgs extends com.pulumi.resources.ResourceArg
      * ***
      * 
      */
-    @Import(name="serviceId", required=true)
-    private Output<String> serviceId;
+    @Import(name="serviceId")
+    private @Nullable Output<String> serviceId;
 
     /**
      * @return The ID of the metastore service. The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
@@ -309,8 +308,8 @@ public final class MetastoreServiceArgs extends com.pulumi.resources.ResourceArg
      * ***
      * 
      */
-    public Output<String> serviceId() {
-        return this.serviceId;
+    public Optional<Output<String>> serviceId() {
+        return Optional.ofNullable(this.serviceId);
     }
 
     /**
@@ -751,7 +750,7 @@ public final class MetastoreServiceArgs extends com.pulumi.resources.ResourceArg
          * @return builder
          * 
          */
-        public Builder serviceId(Output<String> serviceId) {
+        public Builder serviceId(@Nullable Output<String> serviceId) {
             $.serviceId = serviceId;
             return this;
         }
@@ -817,9 +816,6 @@ public final class MetastoreServiceArgs extends com.pulumi.resources.ResourceArg
         }
 
         public MetastoreServiceArgs build() {
-            if ($.serviceId == null) {
-                throw new MissingRequiredPropertyException("MetastoreServiceArgs", "serviceId");
-            }
             return $;
         }
     }

--- a/sdk/nodejs/dataproc/metastoreService.ts
+++ b/sdk/nodejs/dataproc/metastoreService.ts
@@ -503,7 +503,7 @@ export class MetastoreService extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: MetastoreServiceArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args?: MetastoreServiceArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: MetastoreServiceArgs | MetastoreServiceState, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
@@ -537,9 +537,6 @@ export class MetastoreService extends pulumi.CustomResource {
             resourceInputs["uid"] = state ? state.uid : undefined;
         } else {
             const args = argsOrState as MetastoreServiceArgs | undefined;
-            if ((!args || args.serviceId === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'serviceId'");
-            }
             resourceInputs["databaseType"] = args ? args.databaseType : undefined;
             resourceInputs["deletionProtection"] = args ? args.deletionProtection : undefined;
             resourceInputs["encryptionConfig"] = args ? args.encryptionConfig : undefined;
@@ -802,7 +799,7 @@ export interface MetastoreServiceArgs {
      *
      * - - -
      */
-    serviceId: pulumi.Input<string>;
+    serviceId?: pulumi.Input<string>;
     /**
      * The configuration specifying telemetry settings for the Dataproc Metastore service. If unspecified defaults to JSON.
      * Structure is documented below.

--- a/sdk/python/pulumi_gcp/dataproc/metastore_service.py
+++ b/sdk/python/pulumi_gcp/dataproc/metastore_service.py
@@ -21,7 +21,6 @@ __all__ = ['MetastoreServiceArgs', 'MetastoreService']
 @pulumi.input_type
 class MetastoreServiceArgs:
     def __init__(__self__, *,
-                 service_id: pulumi.Input[str],
                  database_type: Optional[pulumi.Input[str]] = None,
                  deletion_protection: Optional[pulumi.Input[bool]] = None,
                  encryption_config: Optional[pulumi.Input['MetastoreServiceEncryptionConfigArgs']] = None,
@@ -37,16 +36,11 @@ class MetastoreServiceArgs:
                  release_channel: Optional[pulumi.Input[str]] = None,
                  scaling_config: Optional[pulumi.Input['MetastoreServiceScalingConfigArgs']] = None,
                  scheduled_backup: Optional[pulumi.Input['MetastoreServiceScheduledBackupArgs']] = None,
+                 service_id: Optional[pulumi.Input[str]] = None,
                  telemetry_config: Optional[pulumi.Input['MetastoreServiceTelemetryConfigArgs']] = None,
                  tier: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a MetastoreService resource.
-        :param pulumi.Input[str] service_id: The ID of the metastore service. The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
-               and hyphens (-). Cannot begin or end with underscore or hyphen. Must consist of between
-               3 and 63 characters.
-               
-               
-               - - -
         :param pulumi.Input[str] database_type: The database type that the Metastore service stores its data.
                Default value is `MYSQL`.
                Possible values are: `MYSQL`, `SPANNER`.
@@ -81,12 +75,17 @@ class MetastoreServiceArgs:
                Structure is documented below.
         :param pulumi.Input['MetastoreServiceScheduledBackupArgs'] scheduled_backup: The configuration of scheduled backup for the metastore service.
                Structure is documented below.
+        :param pulumi.Input[str] service_id: The ID of the metastore service. The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
+               and hyphens (-). Cannot begin or end with underscore or hyphen. Must consist of between
+               3 and 63 characters.
+               
+               
+               - - -
         :param pulumi.Input['MetastoreServiceTelemetryConfigArgs'] telemetry_config: The configuration specifying telemetry settings for the Dataproc Metastore service. If unspecified defaults to JSON.
                Structure is documented below.
         :param pulumi.Input[str] tier: The tier of the service.
                Possible values are: `DEVELOPER`, `ENTERPRISE`.
         """
-        pulumi.set(__self__, "service_id", service_id)
         if database_type is not None:
             pulumi.set(__self__, "database_type", database_type)
         if deletion_protection is not None:
@@ -117,27 +116,12 @@ class MetastoreServiceArgs:
             pulumi.set(__self__, "scaling_config", scaling_config)
         if scheduled_backup is not None:
             pulumi.set(__self__, "scheduled_backup", scheduled_backup)
+        if service_id is not None:
+            pulumi.set(__self__, "service_id", service_id)
         if telemetry_config is not None:
             pulumi.set(__self__, "telemetry_config", telemetry_config)
         if tier is not None:
             pulumi.set(__self__, "tier", tier)
-
-    @property
-    @pulumi.getter(name="serviceId")
-    def service_id(self) -> pulumi.Input[str]:
-        """
-        The ID of the metastore service. The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
-        and hyphens (-). Cannot begin or end with underscore or hyphen. Must consist of between
-        3 and 63 characters.
-
-
-        - - -
-        """
-        return pulumi.get(self, "service_id")
-
-    @service_id.setter
-    def service_id(self, value: pulumi.Input[str]):
-        pulumi.set(self, "service_id", value)
 
     @property
     @pulumi.getter(name="databaseType")
@@ -337,6 +321,23 @@ class MetastoreServiceArgs:
     @scheduled_backup.setter
     def scheduled_backup(self, value: Optional[pulumi.Input['MetastoreServiceScheduledBackupArgs']]):
         pulumi.set(self, "scheduled_backup", value)
+
+    @property
+    @pulumi.getter(name="serviceId")
+    def service_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        The ID of the metastore service. The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
+        and hyphens (-). Cannot begin or end with underscore or hyphen. Must consist of between
+        3 and 63 characters.
+
+
+        - - -
+        """
+        return pulumi.get(self, "service_id")
+
+    @service_id.setter
+    def service_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "service_id", value)
 
     @property
     @pulumi.getter(name="telemetryConfig")
@@ -1229,7 +1230,7 @@ class MetastoreService(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: MetastoreServiceArgs,
+                 args: Optional[MetastoreServiceArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A managed metastore service that serves metadata queries.
@@ -1599,8 +1600,6 @@ class MetastoreService(pulumi.CustomResource):
             __props__.__dict__["release_channel"] = release_channel
             __props__.__dict__["scaling_config"] = scaling_config
             __props__.__dict__["scheduled_backup"] = scheduled_backup
-            if service_id is None and not opts.urn:
-                raise TypeError("Missing required property 'service_id'")
             __props__.__dict__["service_id"] = service_id
             __props__.__dict__["telemetry_config"] = telemetry_config
             __props__.__dict__["tier"] = tier


### PR DESCRIPTION
This PR is a copy of https://github.com/pulumi/pulumi-gcp/pull/2969 by @stooj , to make CI tests run. Original description:

Fixes https://github.com/pulumi/pulumi-gcp/issues/2931

This resource doesn't have it's own name, so when pulumi tries to create a new resource it conflicts with the old one.