### PR TITLE
chore: fix .gitignore to not ignore schema.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ yarn.lock
 **/pulumiManifest.go
 
 ci-scripts
-**/schema.go
 provider/**/schema-embed.json
 **/version.txt
 **/nuget


### PR DESCRIPTION
There are files under sdk that match schema.go they probably should not be ignored.