### PR TITLE
Limit autoname len on cloudrunv2 service

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1843,6 +1843,15 @@ func Provider() tfbridge.ProviderInfo {
 			"google_cloud_run_v2_job": {Tok: gcpResource(gcpCloudRunV2, "Job")},
 			"google_cloud_run_v2_service": {
 				Tok: gcpResource(gcpCloudRunV2, "Service"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": tfbridge.AutoNameWithCustomOptions("",
+						tfbridge.AutoNameOptions{
+							Separator: "-",
+							Maxlen:    50,
+							Randlen:   7,
+							Transform: strings.ToLower,
+						}),
+				},
 
 				TransformFromState: func(_ context.Context, pMap resource.PropertyMap) (resource.PropertyMap, error) {
 					//`port` is an object type in the current version of this provider.


### PR DESCRIPTION
The resource throws errors if configured with a longer name:

```
error: 1 error occurred:
        * Error creating Service: googleapi: Error 400: Violation in CreateServiceRequest.service_id: only lowercase, digits, and hyphens; must begin with letter, and cannot end with hyphen; must be less than 50 characters.
    Details:
    [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "description": "only lowercase, digits, and hyphens; must begin with letter, and cannot end with hyphen; must be less than 50 characters.",
            "field": "Violation in CreateServiceRequest.service_id"
          }
        ]
      }
```

fixes https://github.com/pulumi/pulumi-gcp/issues/3166