### PR TITLE
Fix Secretmanager Autonaming

### DIFF
--- a/provider/secret_manager.go
+++ b/provider/secret_manager.go
@@ -47,5 +47,8 @@ func resourceSecretManagerSecret() *tfbridge.ResourceInfo {
 		) (resource.PropertyMap, error) {
 			return fixReplicationAuto(pm), nil
 		},
+		Fields: map[string]*tfbridge.SchemaInfo{
+			"secret_id": tfbridge.AutoName("secretId", 255, "-"),
+		},
 	}
 }

--- a/sdk/dotnet/SecretManager/Secret.cs
+++ b/sdk/dotnet/SecretManager/Secret.cs
@@ -419,8 +419,8 @@ namespace Pulumi.Gcp.SecretManager
         /// <summary>
         /// This must be unique within the project.
         /// </summary>
-        [Input("secretId", required: true)]
-        public Input<string> SecretId { get; set; } = null!;
+        [Input("secretId")]
+        public Input<string>? SecretId { get; set; }
 
         [Input("topics")]
         private InputList<Inputs.SecretTopicArgs>? _topics;

--- a/sdk/go/gcp/secretmanager/secret.go
+++ b/sdk/go/gcp/secretmanager/secret.go
@@ -276,9 +276,6 @@ func NewSecret(ctx *pulumi.Context,
 	if args.Replication == nil {
 		return nil, errors.New("invalid value for required argument 'Replication'")
 	}
-	if args.SecretId == nil {
-		return nil, errors.New("invalid value for required argument 'SecretId'")
-	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"effectiveLabels",
 		"pulumiLabels",
@@ -464,7 +461,7 @@ type secretArgs struct {
 	// the topics configured on the Secret. 'topics' must be set to configure rotation.
 	Rotation *SecretRotation `pulumi:"rotation"`
 	// This must be unique within the project.
-	SecretId string `pulumi:"secretId"`
+	SecretId *string `pulumi:"secretId"`
 	// A list of up to 10 Pub/Sub topics to which messages are published when control plane operations are called on the secret
 	// or its versions.
 	Topics []SecretTopic `pulumi:"topics"`
@@ -515,7 +512,7 @@ type SecretArgs struct {
 	// the topics configured on the Secret. 'topics' must be set to configure rotation.
 	Rotation SecretRotationPtrInput
 	// This must be unique within the project.
-	SecretId pulumi.StringInput
+	SecretId pulumi.StringPtrInput
 	// A list of up to 10 Pub/Sub topics to which messages are published when control plane operations are called on the secret
 	// or its versions.
 	Topics SecretTopicArrayInput

--- a/sdk/java/src/main/java/com/pulumi/gcp/secretmanager/SecretArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/secretmanager/SecretArgs.java
@@ -145,15 +145,15 @@ public final class SecretArgs extends com.pulumi.resources.ResourceArgs {
      * This must be unique within the project.
      * 
      */
-    @Import(name="secretId", required=true)
-    private Output<String> secretId;
+    @Import(name="secretId")
+    private @Nullable Output<String> secretId;
 
     /**
      * @return This must be unique within the project.
      * 
      */
-    public Output<String> secretId() {
-        return this.secretId;
+    public Optional<Output<String>> secretId() {
+        return Optional.ofNullable(this.secretId);
     }
 
     /**
@@ -422,7 +422,7 @@ public final class SecretArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder secretId(Output<String> secretId) {
+        public Builder secretId(@Nullable Output<String> secretId) {
             $.secretId = secretId;
             return this;
         }
@@ -549,9 +549,6 @@ public final class SecretArgs extends com.pulumi.resources.ResourceArgs {
         public SecretArgs build() {
             if ($.replication == null) {
                 throw new MissingRequiredPropertyException("SecretArgs", "replication");
-            }
-            if ($.secretId == null) {
-                throw new MissingRequiredPropertyException("SecretArgs", "secretId");
             }
             return $;
         }

--- a/sdk/nodejs/secretmanager/secret.ts
+++ b/sdk/nodejs/secretmanager/secret.ts
@@ -278,9 +278,6 @@ export class Secret extends pulumi.CustomResource {
             if ((!args || args.replication === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'replication'");
             }
-            if ((!args || args.secretId === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'secretId'");
-            }
             resourceInputs["annotations"] = args ? args.annotations : undefined;
             resourceInputs["expireTime"] = args ? args.expireTime : undefined;
             resourceInputs["labels"] = args ? args.labels : undefined;
@@ -444,7 +441,7 @@ export interface SecretArgs {
     /**
      * This must be unique within the project.
      */
-    secretId: pulumi.Input<string>;
+    secretId?: pulumi.Input<string>;
     /**
      * A list of up to 10 Pub/Sub topics to which messages are published when control plane operations are called on the secret
      * or its versions.

--- a/sdk/python/pulumi_gcp/secretmanager/secret.py
+++ b/sdk/python/pulumi_gcp/secretmanager/secret.py
@@ -23,12 +23,12 @@ __all__ = ['SecretArgs', 'Secret']
 class SecretArgs:
     def __init__(__self__, *,
                  replication: pulumi.Input['SecretReplicationArgs'],
-                 secret_id: pulumi.Input[builtins.str],
                  annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None,
                  expire_time: Optional[pulumi.Input[builtins.str]] = None,
                  labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None,
                  project: Optional[pulumi.Input[builtins.str]] = None,
                  rotation: Optional[pulumi.Input['SecretRotationArgs']] = None,
+                 secret_id: Optional[pulumi.Input[builtins.str]] = None,
                  topics: Optional[pulumi.Input[Sequence[pulumi.Input['SecretTopicArgs']]]] = None,
                  ttl: Optional[pulumi.Input[builtins.str]] = None,
                  version_aliases: Optional[pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]]] = None,
@@ -38,7 +38,6 @@ class SecretArgs:
         :param pulumi.Input['SecretReplicationArgs'] replication: The replication policy of the secret data attached to the Secret. It cannot be changed
                after the Secret has been created.
                Structure is documented below.
-        :param pulumi.Input[builtins.str] secret_id: This must be unique within the project.
         :param pulumi.Input[Mapping[str, pulumi.Input[builtins.str]]] annotations: Custom metadata about the secret. Annotations are distinct from various forms of labels. Annotations exist to allow
                client tools to store their own state information without requiring a database. Annotation keys must be between 1 and 63
                characters long, have a UTF-8 encoding of maximum 128 bytes, begin and end with an alphanumeric character ([a-z0-9A-Z]),
@@ -60,6 +59,7 @@ class SecretArgs:
                refer to the field 'effective_labels' for all of the labels present on the resource.
         :param pulumi.Input['SecretRotationArgs'] rotation: The rotation time and period for a Secret. At 'next_rotation_time', Secret Manager will send a Pub/Sub notification to
                the topics configured on the Secret. 'topics' must be set to configure rotation.
+        :param pulumi.Input[builtins.str] secret_id: This must be unique within the project.
         :param pulumi.Input[Sequence[pulumi.Input['SecretTopicArgs']]] topics: A list of up to 10 Pub/Sub topics to which messages are published when control plane operations are called on the secret
                or its versions.
         :param pulumi.Input[builtins.str] ttl: The TTL for the Secret. A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
@@ -73,7 +73,6 @@ class SecretArgs:
                a disabled state and the actual destruction happens after this TTL expires.
         """
         pulumi.set(__self__, "replication", replication)
-        pulumi.set(__self__, "secret_id", secret_id)
         if annotations is not None:
             pulumi.set(__self__, "annotations", annotations)
         if expire_time is not None:
@@ -84,6 +83,8 @@ class SecretArgs:
             pulumi.set(__self__, "project", project)
         if rotation is not None:
             pulumi.set(__self__, "rotation", rotation)
+        if secret_id is not None:
+            pulumi.set(__self__, "secret_id", secret_id)
         if topics is not None:
             pulumi.set(__self__, "topics", topics)
         if ttl is not None:
@@ -106,18 +107,6 @@ class SecretArgs:
     @replication.setter
     def replication(self, value: pulumi.Input['SecretReplicationArgs']):
         pulumi.set(self, "replication", value)
-
-    @property
-    @pulumi.getter(name="secretId")
-    def secret_id(self) -> pulumi.Input[builtins.str]:
-        """
-        This must be unique within the project.
-        """
-        return pulumi.get(self, "secret_id")
-
-    @secret_id.setter
-    def secret_id(self, value: pulumi.Input[builtins.str]):
-        pulumi.set(self, "secret_id", value)
 
     @property
     @pulumi.getter
@@ -192,6 +181,18 @@ class SecretArgs:
     @rotation.setter
     def rotation(self, value: Optional[pulumi.Input['SecretRotationArgs']]):
         pulumi.set(self, "rotation", value)
+
+    @property
+    @pulumi.getter(name="secretId")
+    def secret_id(self) -> Optional[pulumi.Input[builtins.str]]:
+        """
+        This must be unique within the project.
+        """
+        return pulumi.get(self, "secret_id")
+
+    @secret_id.setter
+    def secret_id(self, value: Optional[pulumi.Input[builtins.str]]):
+        pulumi.set(self, "secret_id", value)
 
     @property
     @pulumi.getter
@@ -900,8 +901,6 @@ class Secret(pulumi.CustomResource):
                 raise TypeError("Missing required property 'replication'")
             __props__.__dict__["replication"] = replication
             __props__.__dict__["rotation"] = rotation
-            if secret_id is None and not opts.urn:
-                raise TypeError("Missing required property 'secret_id'")
             __props__.__dict__["secret_id"] = secret_id
             __props__.__dict__["topics"] = topics
             __props__.__dict__["ttl"] = ttl


### PR DESCRIPTION
This pull request adds autonaming to the `secretID` field of secretmanager Secret.
Autonaming defaults to a literal `name` filed; this resource uses `secret_id` instead.

Fixes #3180

- **Allow Autonaming on secretId for secretmanager Secret**
- **build schema and sdks**
