### PR TITLE
Enable RawStateDelta

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2864,6 +2864,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		EnableZeroDefaultSchemaVersion: true,
 		EnableAccurateBridgePreview:    true,
+		EnableRawStateDelta:            true,
 	}
 
 	prov.RenameResourceWithAlias("google_compute_managed_ssl_certificate", gcpResource(gcpCompute,


### PR DESCRIPTION
A bridge feature for preserving Terraform raw state is being rolled out to this provider. See also:

- https://github.com/pulumi/pulumi-terraform-bridge/issues/1667
- https://github.com/pulumi/pulumi-terraform-bridge/issues/3003