### PR TITLE
Swapping our read-package-json for @npmcli/package-json

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2801,8 +2801,8 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"read-package-json": "^2.0.13",
-				"@types/express":    "^4.16.0",
+				"@npmcli/package-json": "^6.2.0",
+				"@types/express":       "^4.16.0",
 			},
 			DevDependencies: map[string]string{
 				"@types/node": "^18.0.0", // so we can access strongly typed node definitions.

--- a/provider/test-programs/cloudfunction-callback-packagejson/Pulumi.yaml
+++ b/provider/test-programs/cloudfunction-callback-packagejson/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: cloudfunction-callback-packagejson
+runtime: nodejs
+description: Test CloudFunction with callback to verify package.json processing

--- a/provider/test-programs/cloudfunction-callback-packagejson/index.ts
+++ b/provider/test-programs/cloudfunction-callback-packagejson/index.ts
@@ -1,0 +1,13 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+
+const fn = new gcp.cloudfunctions.CallbackFunction("test-function", {
+    runtime: "nodejs20",
+    callback: (req: any, res: any) => {
+        const _ = require('lodash'); // This should be included in generated package.json
+        res.send(`Hello from Cloud Function! Array: ${_.join(['a', 'b', 'c'], ', ')}`);
+    },
+    triggerHttp: true,
+});
+
+export const functionUrl = fn.function.httpsTriggerUrl;

--- a/provider/test-programs/cloudfunction-callback-packagejson/package.json
+++ b/provider/test-programs/cloudfunction-callback-packagejson/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "cloudfunction-callback-packagejson",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/gcp": "^8.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "lodash": "^4.17.21"
+    }
+}

--- a/provider/test-programs/cloudfunction-callback-packagejson/tsconfig.json
+++ b/provider/test-programs/cloudfunction-callback-packagejson/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,9 +13,9 @@
         "build": "tsc"
     },
     "dependencies": {
+        "@npmcli/package-json": "^6.2.0",
         "@pulumi/pulumi": "^3.142.0",
-        "@types/express": "^4.16.0",
-        "read-package-json": "^2.0.13"
+        "@types/express": "^4.16.0"
     },
     "devDependencies": {
         "@types/node": "^18.0.0",


### PR DESCRIPTION
This pull request introduces changes to improve the handling of `package.json` processing for Google Cloud Functions in the Pulumi GCP provider. The updates include replacing the `read-package-json` library with `@npmcli/package-json`, adding a new test program to validate the changes, and updating dependencies and related test cases.

### Dependency Management Updates:
* Replaced `read-package-json` with `@npmcli/package-json` for better support in `package.json` processing across multiple files, including `schema.json`, `resources.go`, `zMixins.ts`, and `sdk/nodejs/package.json`. [[1]](diffhunk://#diff-dd53246710ef0103fe4fef7f01e09d020522141351d76913664fd5c184824a96L166-R167) [[2]](diffhunk://#diff-34c57e622183cb0d8dd0d3f9eaa0861b3340120e9b2ad811bac7ac7be4cea4b1L2804-R2804) [[3]](diffhunk://#diff-7cd98603d2b41db09c736b15a7f55549bc1c7194d7d437dfe16e1e7e29e766a5L265-R285) [[4]](diffhunk://#diff-0d53ce0d334b84822a2dbdf673d0456efbacb59a76f72aabbfb1b7f8203a58f7R16-R18)

### New Test Program:
* Added a new test program, `cloudfunction-callback-packagejson`, to verify the correctness of `package.json` processing when using the callback syntax in Google Cloud Functions. This includes the following files:
  - [`Pulumi.yaml`](diffhunk://#diff-de7d2701095d501990188ec0efa9524805e05260b18b80f75eb6ef1b9d2af14bR1-R3): Configuration for the test program.
  - [`index.ts`](diffhunk://#diff-807e29c515ae402b2724b851c27a7456b59cab2b57147be1123379bc5f08299cR1-R19): Defines a Cloud Function with callback syntax and a dependency on `lodash`.
  - [`package.json`](diffhunk://#diff-4db320ba6108441f5f1036609d2742c55baca8f796a4ed20b781e9dd00693057R1-R13): Specifies dependencies, including `lodash`, and development dependencies.
  - [`tsconfig.json`](diffhunk://#diff-2f4d404f48b0957a34113be52f2f233df16e50176d0a9a85bbeff4fb2995470cR1-R19): TypeScript configuration for the test program.

### Test Suite Enhancements:
* Added a new test case, `TestCloudfunctionWithCallbackPackageJson`, to validate that the `@npmcli/package-json` replacement works correctly. This ensures that the updated dependency management logic functions as expected.

These changes aim to improve the maintainability and functionality of the Pulumi GCP provider, particularly for use cases involving Google Cloud Functions.
Fixes: #2696 