### PR TITLE
Default NodeJS runtime for callbacks is now 22 since 18 has been decommissioned

### DIFF
--- a/sdk/nodejs/cloudfunctions/zMixins.ts
+++ b/sdk/nodejs/cloudfunctions/zMixins.ts
@@ -169,7 +169,7 @@ export class CallbackFunction extends pulumi.ComponentResource {
 
         this.function = new cloudfunctions.Function(functionName, {
             ...argsCopy,
-            runtime: utils.ifUndefined(args.runtime, "nodejs18"),
+            runtime: utils.ifUndefined(args.runtime, "nodejs22"),
             entryPoint: handlerName,
             sourceArchiveBucket: this.bucket.name,
             sourceArchiveObject: this.bucketObject.name,


### PR DESCRIPTION
https://docs.cloud.google.com/functions/docs/runtime-support

The Node 18 runtime was decommissioned on October 30, meaning new workloads can't be created with it and existing ones can't be updated.

This means our mixin no longer works. To fix it, let's default to the most current GA runtime.

Fixes https://github.com/pulumi/pulumi-gcp/issues/3451