### PR TITLE
Add hypercomputecluster module mapping

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -111,6 +111,7 @@ const (
 	gcpGkeHub                   = "GkeHub"                   // Gke Hub resources
 	gcpGkeOnPrem                = "GkeOnPrem"                // Gke On Prem resources
 	gcpHealthcare               = "Healthcare"               // Healthcare resources
+	gcpHyperComputeCluster      = "HyperComputeCluster"      // HyperComputeCluster resources
 	gcpIAM                      = "Iam"                      // IAM resources
 	gcpIAP                      = "Iap"                      // IAP resources
 	gcpIdentityPlatform         = "IdentityPlatform"         // IdentityPlatform resources
@@ -254,6 +255,7 @@ var moduleMapping = map[string]string{
 	"gke_hub":                    gcpGkeHub,
 	"gkeonprem":                  gcpGkeOnPrem,
 	"healthcare":                 gcpHealthcare,
+	"hypercomputecluster":        gcpHyperComputeCluster,
 	"iam":                        gcpIAM,
 	"iap":                        gcpIAP,
 	"identity_platform":          gcpIdentityPlatform,


### PR DESCRIPTION
Fixes #3608

Adds the missing module mapping for the new `google_hypercomputecluster_cluster` resource.

The upgrade-provider workflow was failing because the Pulumi bridge couldn't find a module mapping for `hypercomputecluster_cluster`. This PR adds:
- `gcpHyperComputeCluster` constant definition
- `"hypercomputecluster": gcpHyperComputeCluster` mapping entry

Generated with [Claude Code](https://claude.ai/code)