### PR TITLE
provider: forward validated credentials to region-list call (fixes #3405)

### DIFF
--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -134,6 +134,79 @@ func TestPreConfigureCallbackNoErrWhenRegionListCallErrors(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestPreConfigureCallbackNoCredentialsWarningWhenAccessTokenSet is a
+// regression test for https://github.com/pulumi/pulumi-gcp/issues/3405.
+//
+// Before the fix, region validation built a brand-new compute client without
+// forwarding the credentials that LoadAndValidate had just resolved. Under
+// WIF / OIDC / explicit-access-token flows there are no ADC, so the fallback
+// failed and pulumi-gcp emitted a noisy "failed to get regions list: ...
+// could not find default credentials" warning on every preview/up — even
+// though every other API call succeeded.
+//
+// With the fix, the validated TokenSource is forwarded to the regions-list
+// client, so the call may still fail (e.g. with a network error if the test
+// host can't reach compute.googleapis.com) but it never fails with a
+// credentials-discovery error. Any warning that does fire must therefore
+// not mention "could not find default credentials".
+//
+// We use a sentinel logger that fails the test if a credentials-not-found
+// warning is observed, while tolerating other warnings (e.g. transport
+// failures from the test environment having no real outbound connectivity).
+func TestPreConfigureCallbackNoCredentialsWarningWhenAccessTokenSet(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
+
+	t.Setenv("GOOGLE_PROJECT", "myproject")
+	t.Setenv("GOOGLE_REGION", "us-central1")
+	// Provide an access token so LoadAndValidate can build a TokenSource
+	// without needing ADC. The token does not need to be valid for the
+	// regression check below — we only assert on the *shape* of any warning.
+	t.Setenv("GOOGLE_OAUTH_ACCESS_TOKEN", "ya29.fake-token-for-regression-test")
+	// Force ADC discovery to fail by pointing every well-known location at
+	// an empty temp dir. Without this, a developer running the test on a
+	// machine that already ran `gcloud auth application-default login` would
+	// silently succeed via ADC and miss the regression. The bug only
+	// reproduces when ADC is absent — which is exactly the case Workload
+	// Identity Federation / OIDC users hit on CI.
+	emptyDir := t.TempDir()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("HOME", emptyDir)
+	t.Setenv("CLOUDSDK_CONFIG", emptyDir)
+	t.Setenv("APPDATA", emptyDir)     // ADC search path on Windows
+	t.Setenv("USERPROFILE", emptyDir) // ADC search path on Windows
+
+	logger := &noCredentialsWarningGuard{t: t}
+	ctx := testutil.InitLogging(t, context.Background(), logger)
+
+	// Production-style nil clientOpts so the new credentials-forwarding
+	// branch is exercised.
+	callback := preConfigureCallbackWithLogger(new(atomic.Bool), nil)
+	err := callback(ctx, nil, nil, nil)
+	require.NoError(t, err)
+}
+
+// noCredentialsWarningGuard is a test sink that asserts no warning matching
+// the bug's signature ever appears.
+type noCredentialsWarningGuard struct {
+	t *testing.T
+}
+
+func (g *noCredentialsWarningGuard) Log(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	if sev == diag.Warning {
+		// This is the exact substring that appeared in #3405's reproducer.
+		assert.NotContainsf(g.t, msg, "could not find default credentials",
+			"regression: warning still references missing ADC even though credentials were supplied (URN=%s)", urn)
+	}
+	return nil
+}
+
+func (g *noCredentialsWarningGuard) LogStatus(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	assert.Failf(g.t, "Unexpected status", "log: %s@%s: %q", sev, urn, msg)
+	return nil
+}
+
 func TestPreConfigureCallbackNoWarningWhenNoProjectEnvSet(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -459,7 +459,20 @@ func preConfigureCallbackWithLogger(
 		}
 
 		if !skipRegionValidation && config.Region != "" && config.Project != "" {
-			regionList, err := getRegionsList(ctx, config.Project, gcpClientOpts)
+			// Forward the credentials that LoadAndValidate just resolved on `config`
+			// so that the regions-list compute client doesn't fall back to ADC
+			// discovery. Under workload-identity / OIDC / explicit access-token
+			// flows, ADC is not populated and the fallback fails with a noisy
+			// "could not find default credentials" warning even though every
+			// other API call in this provider succeeds (#3405). When tests
+			// pre-supply gcpClientOpts (e.g. option.WithoutAuthentication for
+			// httptest), keep using those exclusively to preserve the existing
+			// test contract.
+			regionListOpts := gcpClientOpts
+			if len(regionListOpts) == 0 && config.TokenSource != nil {
+				regionListOpts = []option.ClientOption{option.WithTokenSource(config.TokenSource)}
+			}
+			regionList, err := getRegionsList(ctx, config.Project, regionListOpts)
 			if err != nil {
 				tfbridge.GetLogger(ctx).Warn(fmt.Sprintf("failed to get regions list: %v", err))
 				return nil


### PR DESCRIPTION
## Summary

Forward the validated `TokenSource` from `tpg_transport.Config` to the
compute client used for region validation, so it stops falling back to
ADC discovery and emitting a misleading "could not find default
credentials" warning on every preview/up under Workload Identity
Federation, OIDC, or explicit-access-token flows.

Fixes #3405. Closes #2121 (older duplicate of the same warning under OIDC).

## Context

`preConfigureCallbackWithLogger` calls `config.LoadAndValidate(ctx)`,
which resolves a `TokenSource` on the upstream `transport.Config` from
whatever credential mechanism the user supplied (`GOOGLE_OAUTH_ACCESS_TOKEN`,
`GOOGLE_CREDENTIALS`, WIF/OIDC via `external_account` JSON, etc.).

Right after, region validation calls `getRegionsList(ctx, config.Project, gcpClientOpts)`.
In production `gcpClientOpts` is `nil`, so `compute.NewService(ctx, nil...)`
falls back to ADC discovery. ADC is *not* populated for users who
authenticated through any of the non-ADC mechanisms above, so the call
fails with `credentials: could not find default credentials` and
pulumi-gcp prints

```
warning: failed to get regions list: failed to create compute service: credentials: could not find default credentials.
```

on every operation, even though every other API call in the same run
succeeds because they go through the resolved `TokenSource`. Reporters
described it as "noisy, didn't seem to affect anything" — exactly
because the validation warning is the only thing using that broken code
path.

## Changes

- `provider/resources.go`: when `gcpClientOpts` is empty (production),
  pass `option.WithTokenSource(config.TokenSource)` to `getRegionsList`
  so the regions client uses the same authenticated transport the rest
  of the provider uses. Tests that pre-supply `option.WithoutAuthentication()`
  for `httptest` keep their exclusive set, so the existing test contract
  is preserved. The reasoning is documented inline at the call site for
  reviewers reading the diff cold.
- `provider/gcp_test.go`: new regression test
  `TestPreConfigureCallbackNoCredentialsWarningWhenAccessTokenSet`.
  It sets `GOOGLE_OAUTH_ACCESS_TOKEN`, nullifies every well-known ADC
  search path (`HOME`, `CLOUDSDK_CONFIG`, `APPDATA`, `USERPROFILE`,
  `GOOGLE_APPLICATION_CREDENTIALS`) so the bug actually reproduces on
  developer machines that have `gcloud auth application-default login`
  cached, and uses a sentinel logger that fails the test if any warning
  containing `could not find default credentials` is observed.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone --recurse-submodules https://github.com/pulumi/pulumi-gcp.git /tmp/repro-3405
cd /tmp/repro-3405

# --- BEFORE (origin/master) ---
git checkout origin/master
git fetch https://github.com/jbbqqf/pulumi-gcp.git fix/3405-regions-warning-wif
# Borrow only the regression test (not the fix) so we exercise master code
# against the new test:
git checkout FETCH_HEAD -- provider/gcp_test.go
cd provider && go test -run TestPreConfigureCallbackNoCredentialsWarningWhenAccessTokenSet -v .
# Expected: FAIL with "...should not contain 'could not find default credentials'"
# i.e. master is still emitting the noisy warning under simulated WIF.
cd ..

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
cd provider && go test -run TestPreConfigureCallbackNoCredentialsWarningWhenAccessTokenSet -v .
# Expected: PASS — the validated TokenSource is now forwarded, so no
# "could not find default credentials" warning is emitted.
```

## What I ran locally

- `go test -run TestPreConfigureCallback -v ./provider` → 9/9 passed
  (8 pre-existing + 1 new regression test).
- BEFORE/AFTER demonstrated by reverting only `provider/resources.go`
  while keeping the test: master fails with the exact warning string
  from #3405; this branch passes.

I did not run `make build_sdks` because no schema or cross-language
contract is touched by this change — the diff is provider-go-only and
does not affect generated SDKs.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Existing httptest path with `option.WithoutAuthentication()` | `gcpClientOpts != nil` | unchanged behavior; uses test opts exclusively | `TestPreConfigureCallbackNoErrWhenRegionMatches`, `TestPreConfigureCallbackNoErrWhenRegionDifferent`, `TestPreConfigureCallbackNoErrWhenRegionListCallErrors` (pre-existing, all green) |
| 2 | Production with `GOOGLE_OAUTH_ACCESS_TOKEN` and no ADC | `gcpClientOpts = nil`, `config.TokenSource != nil` | regions client uses `WithTokenSource`; no "could not find default credentials" warning | new `TestPreConfigureCallbackNoCredentialsWarningWhenAccessTokenSet` |
| 3 | `skipRegionValidation = true` | any | region validation never runs; no compute client created | `TestPreConfigureCallbackNoErrWhenRegionCheckSkipped` (pre-existing, green) |
| 4 | `Project == ""` (no global project) | any | region validation never runs; no warning | `TestPreConfigureCallbackWarningWhenNoProject` (pre-existing, green) |
| 5 | `LoadAndValidate` fails (bad credentials shape) | `config.TokenSource == nil` | callback returns the existing `noCredentialsErr` *before* reaching the region-validation branch; new code path is never entered | exercised by the existing `LoadAndValidate` error-return path at line 458 |

## Risk / blast radius

- Additive only on the production path: a new `option.ClientOption`
  threaded through to `compute.NewService`. No public API change.
- Existing tests that supply their own `gcpClientOpts` retain their
  exclusive set (the `len(regionListOpts) == 0` guard). No semantic
  change to test fixtures.
- If the upstream provider ever stops populating `config.TokenSource`
  on success (extremely unlikely — it's the load-bearing field used by
  every other GCP service client downstream), the branch falls back to
  the prior nil-opts behavior, which is the current bug. Net: this
  change is at worst a no-op, at best fixes the warning under WIF/OIDC.

## Release note

```release-note
provider: stop emitting a spurious "failed to get regions list: ... could not find default credentials" warning on every preview/up under Workload Identity Federation, OIDC, or `GOOGLE_OAUTH_ACCESS_TOKEN`-based authentication. The region-validation compute client now reuses the authenticated TokenSource that LoadAndValidate already resolved.
```

---

*PR drafted with assistance from Claude Code. The change was developed
against `pulumi/pulumi-gcp@5333fed` (master) with the upstream
`terraform-provider-google-beta@c48febd` submodule pinned at the same
revision the repo currently tracks. The upstream `transport.Config`
struct definition (`upstream/google-beta/transport/config.go:211-240`)
was used to confirm that `TokenSource` is set on the same `*Config`
receiver during `LoadAndValidate(ctx)` (`config.go:1058-1086`). The
reproducer block above was used during development; it is the same one
a reviewer can paste verbatim.*
