### PR TITLE
Forward validated credentials to region-list call

### DIFF
--- a/provider/gcp_test.go
+++ b/provider/gcp_test.go
@@ -134,6 +134,51 @@ func TestPreConfigureCallbackNoErrWhenRegionListCallErrors(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestPreConfigureCallbackForwardsTokenSourceToRegionList(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")
+	}
+
+	t.Setenv("GOOGLE_PROJECT", "myproject")
+	t.Setenv("GOOGLE_REGION", "us-central1")
+	t.Setenv("GOOGLE_OAUTH_ACCESS_TOKEN", "ya29.fake-token-for-regression-test")
+
+	// Point every well-known ADC location at an empty dir so the regions client
+	// can only authenticate via the access token above. Without this, a
+	// developer with cached `gcloud auth application-default login` credentials
+	// would mask the regression.
+	emptyDir := t.TempDir()
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	t.Setenv("HOME", emptyDir)
+	t.Setenv("CLOUDSDK_CONFIG", emptyDir)
+	t.Setenv("APPDATA", emptyDir)
+	t.Setenv("USERPROFILE", emptyDir)
+
+	logs := &rejectWarning{t: t, banned: "could not find default credentials"}
+	ctx := testutil.InitLogging(t, context.Background(), logs)
+
+	callback := preConfigureCallbackWithLogger(new(atomic.Bool), nil)
+	require.NoError(t, callback(ctx, nil, nil, nil))
+}
+
+// rejectWarning fails the test if any warning contains the banned substring.
+type rejectWarning struct {
+	t      *testing.T
+	banned string
+}
+
+func (r *rejectWarning) Log(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	if sev == diag.Warning {
+		assert.NotContainsf(r.t, msg, r.banned, "unexpected warning for URN %s", urn)
+	}
+	return nil
+}
+
+func (r *rejectWarning) LogStatus(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	assert.Failf(r.t, "Unexpected status", "log: %s@%s: %q", sev, urn, msg)
+	return nil
+}
+
 func TestPreConfigureCallbackNoWarningWhenNoProjectEnvSet(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("Skipping in testing.Short() mode, assuming this is a CI run without GCP creds")

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -459,7 +459,16 @@ func preConfigureCallbackWithLogger(
 		}
 
 		if !skipRegionValidation && config.Region != "" && config.Project != "" {
-			regionList, err := getRegionsList(ctx, config.Project, gcpClientOpts)
+			// Reuse the credentials LoadAndValidate just resolved so the regions
+			// client doesn't fall back to ADC discovery. ADC is absent under
+			// Workload Identity Federation / OIDC / explicit-access-token flows,
+			// and the fallback fails with a spurious "could not find default
+			// credentials" warning even though every other API call succeeds.
+			regionListOpts := gcpClientOpts
+			if len(regionListOpts) == 0 && config.TokenSource != nil {
+				regionListOpts = []option.ClientOption{option.WithTokenSource(config.TokenSource)}
+			}
+			regionList, err := getRegionsList(ctx, config.Project, regionListOpts)
 			if err != nil {
 				tfbridge.GetLogger(ctx).Warn(fmt.Sprintf("failed to get regions list: %v", err))
 				return nil


### PR DESCRIPTION
Region validation builds a fresh compute client to list regions. In production it was created with no client options, so it fell back to Application Default Credentials discovery. Under Workload Identity Federation, OIDC, or `GOOGLE_OAUTH_ACCESS_TOKEN` auth there is no ADC, so the call failed and the provider logged `failed to get regions list: ... could not find default credentials` on every preview/up — even though every other API call succeeded.

We now forward the `TokenSource` that `LoadAndValidate` already resolved to the region-list client, so it uses the same authenticated transport as the rest of the provider. Tests that inject their own client options are unaffected.

Supersedes #3779.

Fixes https://github.com/pulumi/pulumi-gcp/issues/3405. 
Fixes https://github.com/pulumi/pulumi-gcp/issues/2121

## Test plan

- New `TestPreConfigureCallbackForwardsTokenSourceToRegionList` simulates a WIF/OIDC environment (access token set, ADC paths emptied) and fails if a `could not find default credentials` warning is emitted. It fails on `master` and passes with this change.
- Existing `TestPreConfigureCallback*` tests still pass.

```release-note
Stop emitting a spurious "failed to get regions list: ... could not find default credentials" warning on every preview/up under Workload Identity Federation, OIDC, or `GOOGLE_OAUTH_ACCESS_TOKEN`-based authentication.
```
