### PR TITLE
fix: remove broken GKE managed ML diagnostics doc link

### DIFF
--- a/provider/doc_edits_test.go
+++ b/provider/doc_edits_test.go
@@ -43,6 +43,8 @@ func TestReplacementsDotJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Terraform should be untouched here.", string(actual))
 
+	// Upstream currently ships a placeholder TODO URL here. We should not surface
+	// that broken internal marker in generated user-facing docs.
 	actual, err = edit.Edit("container_cluster.html.markdown", []byte(
 		"* `managed_machine_learning_diagnostics_config` - (Optional, [Beta](../guides/provider_versions.html.markdown)) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is [documented below](#nested_managed_ml_diagnostics_config).\n",
 	))

--- a/provider/doc_edits_test.go
+++ b/provider/doc_edits_test.go
@@ -42,6 +42,14 @@ func TestReplacementsDotJSON(t *testing.T) {
 	actual, err = edit.Edit("unrelated.html.markdown", []byte("Terraform should be untouched here."))
 	require.NoError(t, err)
 	assert.Equal(t, "Terraform should be untouched here.", string(actual))
+
+	actual, err = edit.Edit("container_cluster.html.markdown", []byte(
+		"* `managed_machine_learning_diagnostics_config` - (Optional, [Beta](../guides/provider_versions.html.markdown)) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is [documented below](#nested_managed_ml_diagnostics_config).\n",
+	))
+	require.NoError(t, err)
+	assert.Equal(t,
+		"* `managed_machine_learning_diagnostics_config` - (Optional, [Beta](../guides/provider_versions.html.markdown)) Configuration for the GKE Managed ML Diagnostics feature. Structure is [documented below](#nested_managed_ml_diagnostics_config).\n",
+		string(actual))
 }
 
 func TestAggregateIAMExemptedMembersReplacement(t *testing.T) {

--- a/provider/replacements.json
+++ b/provider/replacements.json
@@ -451,6 +451,10 @@
     {
       "old": "    * MODE_UNSPECIFIED: Not Set\n    * GCE_METADATA: Expose all Compute Engine metadata to pods.\n    * GKE_METADATA: Run the GKE Metadata Server on this node. The GKE Metadata Server exposes a metadata API to workloads that is compatible with the V1 Compute Metadata APIs exposed by the Compute Engine and App Engine Metadata Servers. This feature can only be enabled if [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) is enabled at the cluster level.\n",
       "new": "  * UNSPECIFIED: Not Set\n  * GCE_METADATA: Expose all Compute Engine metadata to pods.\n  * GKE_METADATA: Run the GKE Metadata Server on this node. The GKE Metadata Server exposes a metadata API to workloads that is compatible with the V1 Compute Metadata APIs exposed by the Compute Engine and App Engine Metadata Servers. This feature can only be enabled if [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) is enabled at the cluster level.\n"
+    },
+    {
+      "old": "* `managed_machine_learning_diagnostics_config` - (Optional, [Beta](../guides/provider_versions.html.markdown)) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is [documented below](#nested_managed_ml_diagnostics_config).\n",
+      "new": "* `managed_machine_learning_diagnostics_config` - (Optional, [Beta](../guides/provider_versions.html.markdown)) Configuration for the GKE Managed ML Diagnostics feature. Structure is [documented below](#nested_managed_ml_diagnostics_config).\n"
     }
   ],
   "container_engine_versions.html.markdown": [

--- a/sdk/dotnet/Container/Cluster.cs
+++ b/sdk/dotnet/Container/Cluster.cs
@@ -525,7 +525,7 @@ namespace Pulumi.Gcp.Container
         public Output<Outputs.ClusterMaintenancePolicy?> MaintenancePolicy { get; private set; } = null!;
 
         /// <summary>
-        /// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        /// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         /// </summary>
         [Output("managedMachineLearningDiagnosticsConfig")]
         public Output<Outputs.ClusterManagedMachineLearningDiagnosticsConfig> ManagedMachineLearningDiagnosticsConfig { get; private set; } = null!;
@@ -1296,7 +1296,7 @@ namespace Pulumi.Gcp.Container
         public Input<Inputs.ClusterMaintenancePolicyArgs>? MaintenancePolicy { get; set; }
 
         /// <summary>
-        /// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        /// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         /// </summary>
         [Input("managedMachineLearningDiagnosticsConfig")]
         public Input<Inputs.ClusterManagedMachineLearningDiagnosticsConfigArgs>? ManagedMachineLearningDiagnosticsConfig { get; set; }
@@ -2030,7 +2030,7 @@ namespace Pulumi.Gcp.Container
         public Input<Inputs.ClusterMaintenancePolicyGetArgs>? MaintenancePolicy { get; set; }
 
         /// <summary>
-        /// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        /// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         /// </summary>
         [Input("managedMachineLearningDiagnosticsConfig")]
         public Input<Inputs.ClusterManagedMachineLearningDiagnosticsConfigGetArgs>? ManagedMachineLearningDiagnosticsConfig { get; set; }

--- a/sdk/go/gcp/container/cluster.go
+++ b/sdk/go/gcp/container/cluster.go
@@ -359,7 +359,7 @@ type Cluster struct {
 	// The maintenance policy to use for the cluster. Structure is
 	// documented below.
 	MaintenancePolicy ClusterMaintenancePolicyPtrOutput `pulumi:"maintenancePolicy"`
-	// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+	// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
 	ManagedMachineLearningDiagnosticsConfig ClusterManagedMachineLearningDiagnosticsConfigOutput `pulumi:"managedMachineLearningDiagnosticsConfig"`
 	// ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
 	ManagedOpentelemetryConfig ClusterManagedOpentelemetryConfigOutput `pulumi:"managedOpentelemetryConfig"`
@@ -752,7 +752,7 @@ type clusterState struct {
 	// The maintenance policy to use for the cluster. Structure is
 	// documented below.
 	MaintenancePolicy *ClusterMaintenancePolicy `pulumi:"maintenancePolicy"`
-	// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+	// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
 	ManagedMachineLearningDiagnosticsConfig *ClusterManagedMachineLearningDiagnosticsConfig `pulumi:"managedMachineLearningDiagnosticsConfig"`
 	// ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
 	ManagedOpentelemetryConfig *ClusterManagedOpentelemetryConfig `pulumi:"managedOpentelemetryConfig"`
@@ -1111,7 +1111,7 @@ type ClusterState struct {
 	// The maintenance policy to use for the cluster. Structure is
 	// documented below.
 	MaintenancePolicy ClusterMaintenancePolicyPtrInput
-	// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+	// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
 	ManagedMachineLearningDiagnosticsConfig ClusterManagedMachineLearningDiagnosticsConfigPtrInput
 	// ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
 	ManagedOpentelemetryConfig ClusterManagedOpentelemetryConfigPtrInput
@@ -1468,7 +1468,7 @@ type clusterArgs struct {
 	// The maintenance policy to use for the cluster. Structure is
 	// documented below.
 	MaintenancePolicy *ClusterMaintenancePolicy `pulumi:"maintenancePolicy"`
-	// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+	// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
 	ManagedMachineLearningDiagnosticsConfig *ClusterManagedMachineLearningDiagnosticsConfig `pulumi:"managedMachineLearningDiagnosticsConfig"`
 	// ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
 	ManagedOpentelemetryConfig *ClusterManagedOpentelemetryConfig `pulumi:"managedOpentelemetryConfig"`
@@ -1804,7 +1804,7 @@ type ClusterArgs struct {
 	// The maintenance policy to use for the cluster. Structure is
 	// documented below.
 	MaintenancePolicy ClusterMaintenancePolicyPtrInput
-	// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+	// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
 	ManagedMachineLearningDiagnosticsConfig ClusterManagedMachineLearningDiagnosticsConfigPtrInput
 	// ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
 	ManagedOpentelemetryConfig ClusterManagedOpentelemetryConfigPtrInput
@@ -2375,7 +2375,7 @@ func (o ClusterOutput) MaintenancePolicy() ClusterMaintenancePolicyPtrOutput {
 	return o.ApplyT(func(v *Cluster) ClusterMaintenancePolicyPtrOutput { return v.MaintenancePolicy }).(ClusterMaintenancePolicyPtrOutput)
 }
 
-// ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+// Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
 func (o ClusterOutput) ManagedMachineLearningDiagnosticsConfig() ClusterManagedMachineLearningDiagnosticsConfigOutput {
 	return o.ApplyT(func(v *Cluster) ClusterManagedMachineLearningDiagnosticsConfigOutput {
 		return v.ManagedMachineLearningDiagnosticsConfig

--- a/sdk/java/src/main/java/com/pulumi/gcp/container/Cluster.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/container/Cluster.java
@@ -1074,14 +1074,14 @@ public class Cluster extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.maintenancePolicy);
     }
     /**
-     * ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      * 
      */
     @Export(name="managedMachineLearningDiagnosticsConfig", refs={ClusterManagedMachineLearningDiagnosticsConfig.class}, tree="[0]")
     private Output<ClusterManagedMachineLearningDiagnosticsConfig> managedMachineLearningDiagnosticsConfig;
 
     /**
-     * @return ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * @return Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      * 
      */
     public Output<ClusterManagedMachineLearningDiagnosticsConfig> managedMachineLearningDiagnosticsConfig() {

--- a/sdk/java/src/main/java/com/pulumi/gcp/container/ClusterArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/container/ClusterArgs.java
@@ -880,14 +880,14 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      * 
      */
     @Import(name="managedMachineLearningDiagnosticsConfig")
     private @Nullable Output<ClusterManagedMachineLearningDiagnosticsConfigArgs> managedMachineLearningDiagnosticsConfig;
 
     /**
-     * @return ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * @return Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      * 
      */
     public Optional<Output<ClusterManagedMachineLearningDiagnosticsConfigArgs>> managedMachineLearningDiagnosticsConfig() {
@@ -2888,7 +2888,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param managedMachineLearningDiagnosticsConfig ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+         * @param managedMachineLearningDiagnosticsConfig Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
          * 
          * @return builder
          * 
@@ -2899,7 +2899,7 @@ public final class ClusterArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param managedMachineLearningDiagnosticsConfig ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+         * @param managedMachineLearningDiagnosticsConfig Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/gcp/container/inputs/ClusterState.java
+++ b/sdk/java/src/main/java/com/pulumi/gcp/container/inputs/ClusterState.java
@@ -925,14 +925,14 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      * 
      */
     @Import(name="managedMachineLearningDiagnosticsConfig")
     private @Nullable Output<ClusterManagedMachineLearningDiagnosticsConfigArgs> managedMachineLearningDiagnosticsConfig;
 
     /**
-     * @return ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * @return Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      * 
      */
     public Optional<Output<ClusterManagedMachineLearningDiagnosticsConfigArgs>> managedMachineLearningDiagnosticsConfig() {
@@ -3101,7 +3101,7 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param managedMachineLearningDiagnosticsConfig ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+         * @param managedMachineLearningDiagnosticsConfig Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
          * 
          * @return builder
          * 
@@ -3112,7 +3112,7 @@ public final class ClusterState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param managedMachineLearningDiagnosticsConfig ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+         * @param managedMachineLearningDiagnosticsConfig Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/container/cluster.ts
+++ b/sdk/nodejs/container/cluster.ts
@@ -414,7 +414,7 @@ export class Cluster extends pulumi.CustomResource {
      */
     declare public readonly maintenancePolicy: pulumi.Output<outputs.container.ClusterMaintenancePolicy | undefined>;
     /**
-     * ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      */
     declare public readonly managedMachineLearningDiagnosticsConfig: pulumi.Output<outputs.container.ClusterManagedMachineLearningDiagnosticsConfig>;
     /**
@@ -1176,7 +1176,7 @@ export interface ClusterState {
      */
     maintenancePolicy?: pulumi.Input<inputs.container.ClusterMaintenancePolicy | undefined>;
     /**
-     * ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      */
     managedMachineLearningDiagnosticsConfig?: pulumi.Input<inputs.container.ClusterManagedMachineLearningDiagnosticsConfig | undefined>;
     /**
@@ -1714,7 +1714,7 @@ export interface ClusterArgs {
      */
     maintenancePolicy?: pulumi.Input<inputs.container.ClusterMaintenancePolicy | undefined>;
     /**
-     * ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+     * Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
      */
     managedMachineLearningDiagnosticsConfig?: pulumi.Input<inputs.container.ClusterManagedMachineLearningDiagnosticsConfig | undefined>;
     /**

--- a/sdk/python/pulumi_gcp/container/cluster.py
+++ b/sdk/python/pulumi_gcp/container/cluster.py
@@ -218,7 +218,7 @@ class ClusterArgs:
                `logging.googleapis.com/kubernetes`(Stackdriver Kubernetes Engine Logging), and `none`. Defaults to `logging.googleapis.com/kubernetes`
         :param pulumi.Input['ClusterMaintenancePolicyArgs'] maintenance_policy: The maintenance policy to use for the cluster. Structure is
                documented below.
-        :param pulumi.Input['ClusterManagedMachineLearningDiagnosticsConfigArgs'] managed_machine_learning_diagnostics_config: ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        :param pulumi.Input['ClusterManagedMachineLearningDiagnosticsConfigArgs'] managed_machine_learning_diagnostics_config: Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         :param pulumi.Input['ClusterManagedOpentelemetryConfigArgs'] managed_opentelemetry_config: ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
         :param pulumi.Input['ClusterMasterAuthArgs'] master_auth: The authentication information for accessing the
                Kubernetes master. Some values in this block are only returned by the API if
@@ -1139,7 +1139,7 @@ class ClusterArgs:
     @pulumi.getter(name="managedMachineLearningDiagnosticsConfig")
     def managed_machine_learning_diagnostics_config(self) -> pulumi.Input[Optional['ClusterManagedMachineLearningDiagnosticsConfigArgs']]:
         """
-        ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         """
         return pulumi.get(self, "managed_machine_learning_diagnostics_config")
 
@@ -1935,7 +1935,7 @@ class _ClusterState:
                `logging.googleapis.com/kubernetes`(Stackdriver Kubernetes Engine Logging), and `none`. Defaults to `logging.googleapis.com/kubernetes`
         :param pulumi.Input['ClusterMaintenancePolicyArgs'] maintenance_policy: The maintenance policy to use for the cluster. Structure is
                documented below.
-        :param pulumi.Input['ClusterManagedMachineLearningDiagnosticsConfigArgs'] managed_machine_learning_diagnostics_config: ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        :param pulumi.Input['ClusterManagedMachineLearningDiagnosticsConfigArgs'] managed_machine_learning_diagnostics_config: Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         :param pulumi.Input['ClusterManagedOpentelemetryConfigArgs'] managed_opentelemetry_config: ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
         :param pulumi.Input['ClusterMasterAuthArgs'] master_auth: The authentication information for accessing the
                Kubernetes master. Some values in this block are only returned by the API if
@@ -2922,7 +2922,7 @@ class _ClusterState:
     @pulumi.getter(name="managedMachineLearningDiagnosticsConfig")
     def managed_machine_learning_diagnostics_config(self) -> pulumi.Input[Optional['ClusterManagedMachineLearningDiagnosticsConfigArgs']]:
         """
-        ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         """
         return pulumi.get(self, "managed_machine_learning_diagnostics_config")
 
@@ -3901,7 +3901,7 @@ class Cluster(pulumi.CustomResource):
                `logging.googleapis.com/kubernetes`(Stackdriver Kubernetes Engine Logging), and `none`. Defaults to `logging.googleapis.com/kubernetes`
         :param pulumi.Input[Union['ClusterMaintenancePolicyArgs', 'ClusterMaintenancePolicyArgsDict']] maintenance_policy: The maintenance policy to use for the cluster. Structure is
                documented below.
-        :param pulumi.Input[Union['ClusterManagedMachineLearningDiagnosticsConfigArgs', 'ClusterManagedMachineLearningDiagnosticsConfigArgsDict']] managed_machine_learning_diagnostics_config: ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        :param pulumi.Input[Union['ClusterManagedMachineLearningDiagnosticsConfigArgs', 'ClusterManagedMachineLearningDiagnosticsConfigArgsDict']] managed_machine_learning_diagnostics_config: Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         :param pulumi.Input[Union['ClusterManagedOpentelemetryConfigArgs', 'ClusterManagedOpentelemetryConfigArgsDict']] managed_opentelemetry_config: ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
         :param pulumi.Input[Union['ClusterMasterAuthArgs', 'ClusterMasterAuthArgsDict']] master_auth: The authentication information for accessing the
                Kubernetes master. Some values in this block are only returned by the API if
@@ -4590,7 +4590,7 @@ class Cluster(pulumi.CustomResource):
                `logging.googleapis.com/kubernetes`(Stackdriver Kubernetes Engine Logging), and `none`. Defaults to `logging.googleapis.com/kubernetes`
         :param pulumi.Input[Union['ClusterMaintenancePolicyArgs', 'ClusterMaintenancePolicyArgsDict']] maintenance_policy: The maintenance policy to use for the cluster. Structure is
                documented below.
-        :param pulumi.Input[Union['ClusterManagedMachineLearningDiagnosticsConfigArgs', 'ClusterManagedMachineLearningDiagnosticsConfigArgsDict']] managed_machine_learning_diagnostics_config: ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        :param pulumi.Input[Union['ClusterManagedMachineLearningDiagnosticsConfigArgs', 'ClusterManagedMachineLearningDiagnosticsConfigArgsDict']] managed_machine_learning_diagnostics_config: Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         :param pulumi.Input[Union['ClusterManagedOpentelemetryConfigArgs', 'ClusterManagedOpentelemetryConfigArgsDict']] managed_opentelemetry_config: ) Configuration for the [GKE Managed OpenTelemetry](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/managed-otel-gke) feature. Structure is documented below.
         :param pulumi.Input[Union['ClusterMasterAuthArgs', 'ClusterMasterAuthArgsDict']] master_auth: The authentication information for accessing the
                Kubernetes master. Some values in this block are only returned by the API if
@@ -5292,7 +5292,7 @@ class Cluster(pulumi.CustomResource):
     @pulumi.getter(name="managedMachineLearningDiagnosticsConfig")
     def managed_machine_learning_diagnostics_config(self) -> pulumi.Output['outputs.ClusterManagedMachineLearningDiagnosticsConfig']:
         """
-        ) Configuration for the [GKE Managed ML Diagnostics](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO) feature. Structure is documented below.
+        Configuration for the GKE Managed ML Diagnostics feature. Structure is documented below.
         """
         return pulumi.get(self, "managed_machine_learning_diagnostics_config")
 
@@ -5762,4 +5762,3 @@ class Cluster(pulumi.CustomResource):
         Structure is documented below.
         """
         return pulumi.get(self, "workload_identity_config")
-


### PR DESCRIPTION
Fixes a small docs papercut.

`gcp.container.Cluster` shipped a dead `https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO` link and an extra leading `)` in the `managedMachineLearningDiagnosticsConfig` description. This keeps public docs clean, while the test still documents that upstream currently ships a TODO placeholder there. No runtime behavior change, just docs.

Repro:
1. On `master`, search `managedMachineLearningDiagnosticsConfig` in `provider/cmd/pulumi-resource-gcp/schema.json`.
2. Open `https://docs.cloud.google.com/kubernetes-engine/docs/concepts/TODO`.
3. It returns `404`, so the link is busted.

Checks:
- `cd provider && go test . -run "TestReplacementsDotJSON|TestReplacementDoesNotIncludeTodos"`
- `python3 -m py_compile sdk/python/pulumi_gcp/container/cluster.py`
- `cd sdk && go build ./go/gcp/container`
