### PR TITLE
Forward universeDomain, billingProject, and userProjectOverride to Terraform

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -555,6 +555,21 @@ func Provider() tfbridge.ProviderInfo {
 			"terraform_attribution_label_addition_strategy": {
 				Name: "pulumiAttributionLabelAdditionStrategy",
 			},
+			"universe_domain": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"GOOGLE_UNIVERSE_DOMAIN"},
+				},
+			},
+			"billing_project": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"GOOGLE_BILLING_PROJECT"},
+				},
+			},
+			"user_project_override": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"USER_PROJECT_OVERRIDE"},
+				},
+			},
 		},
 		ExtraConfig: map[string]*tfbridge.ConfigInfo{
 			"skipRegionValidation": {


### PR DESCRIPTION
`universeDomain`, `billingProject` and `userProjectOverride` are exposed in the Pulumi schema's but never reach the underlying Terraform provider. They're missing from the `Config:` map in `provider/resources.go`.

Expected behavior
----
Having these configuration knob setup in a pulumi stack should allow working in a non default google universe / non default project.
```
gcp:universeDomain: ...
gcp:billingProject: ...
gcp:userProjectOverride: ...
```

Current behavior
----
```
  error: Running program '...' failed with an unhandled exception                                                                                                                       
  Error: error serializing property "members": invocation of gcp:organizations/getProject:getProject returned an error: 1 error occurred:                                               
      * Universe domain mismatch: 'googleapis.com' does not match the universe domain '<configured-universe>' supplied directly to Terraform.
```