### PR TITLE
Add state transform for `eraseWindowsVssSignature`

### DIFF
--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -275,11 +275,8 @@ func TestAutoExtractedProgramsUpgrade(t *testing.T) {
 		//TODO: This upgrade represents a breaking change v7->v8.
 		// Must be re-recorded on new baseline: https://github.com/pulumi/pulumi-gcp/issues/2378
 		//{"cloudrunv2-service-7"},
-		//TODO: Upstream added erase_windows_vss_signature with ForceNew in v7.22.0.
-		// Since Pulumi doesn't refresh before diff, existing disks show a spurious replace.
-		// Must be re-recorded on new baseline: https://github.com/pulumi/pulumi-gcp/issues/3650
-		//{"compute-disk-1"},
-		//{"compute-disk-3"},
+		{"compute-disk-1"},
+		{"compute-disk-3"},
 	}
 
 	for _, tc := range testCases {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -1060,7 +1060,15 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "compute_backend_service_signed_url_key.html.markdown",
 				},
 			},
-			"google_compute_disk":                        {Tok: gcpResource(gcpCompute, "Disk")},
+			"google_compute_disk": {
+				Tok: gcpResource(gcpCompute, "Disk"),
+				TransformFromState: func(_ context.Context, pMap resource.PropertyMap) (resource.PropertyMap, error) {
+					if _, ok := pMap["eraseWindowsVssSignature"]; !ok {
+						pMap["eraseWindowsVssSignature"] = resource.NewBoolProperty(false)
+					}
+					return pMap, nil
+				},
+			},
 			"google_compute_firewall":                    {Tok: gcpResource(gcpCompute, "Firewall")},
 			"google_compute_firewall_policy":             {Tok: gcpResource(gcpCompute, "FirewallPolicy")},
 			"google_compute_firewall_policy_rule":        {Tok: gcpResource(gcpCompute, "FirewallPolicyRule")},
@@ -1094,6 +1102,15 @@ func Provider() tfbridge.ProviderInfo {
 			"google_compute_health_check":                  {Tok: gcpResource(gcpCompute, "HealthCheck")},
 			"google_compute_http_health_check":             {Fields: nameField(lowercaseAutoName())},
 			"google_compute_https_health_check":            {Fields: nameField(lowercaseAutoName())},
+			"google_compute_instance": {
+				Tok: gcpResource(gcpCompute, "Instance"),
+				TransformFromState: func(_ context.Context, pMap resource.PropertyMap) (resource.PropertyMap, error) {
+					if _, ok := pMap["eraseWindowsVssSignature"]; !ok {
+						pMap["eraseWindowsVssSignature"] = resource.NewBoolProperty(false)
+					}
+					return pMap, nil
+				},
+			},
 			"google_compute_instance_iam_binding": {
 				Tok: gcpResource(gcpCompute, "InstanceIAMBinding"),
 				Docs: &tfbridge.DocInfo{
@@ -1129,17 +1146,25 @@ func Provider() tfbridge.ProviderInfo {
 					Source: "compute_network_endpoint_group.html.markdown",
 				},
 			},
-			"google_compute_network_firewall_policy":        {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicy")},
-			"google_compute_network_firewall_policy_rule":   {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicyRule")},
-			"google_compute_network_peering":                {Tok: gcpResource(gcpCompute, "NetworkPeering")},
-			"google_compute_network_peering_routes_config":  {Tok: gcpResource(gcpCompute, "NetworkPeeringRoutesConfig")},
-			"google_compute_network":                        {Fields: nameField(lowercaseAutoName())},
-			"google_compute_project_default_network_tier":   {Tok: gcpResource(gcpCompute, "ProjectDefaultNetworkTier")},
-			"google_compute_project_metadata":               {Tok: gcpResource(gcpCompute, "ProjectMetadata")},
-			"google_compute_project_metadata_item":          {Tok: gcpResource(gcpCompute, "ProjectMetadataItem")},
-			"google_compute_region_autoscaler":              {Tok: gcpResource(gcpCompute, "RegionAutoscaler")},
-			"google_compute_region_backend_service":         {Tok: gcpResource(gcpCompute, "RegionBackendService")},
-			"google_compute_region_disk":                    {Tok: gcpResource(gcpCompute, "RegionDisk")},
+			"google_compute_network_firewall_policy":       {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicy")},
+			"google_compute_network_firewall_policy_rule":  {Tok: gcpResource(gcpCompute, "NetworkFirewallPolicyRule")},
+			"google_compute_network_peering":               {Tok: gcpResource(gcpCompute, "NetworkPeering")},
+			"google_compute_network_peering_routes_config": {Tok: gcpResource(gcpCompute, "NetworkPeeringRoutesConfig")},
+			"google_compute_network":                       {Fields: nameField(lowercaseAutoName())},
+			"google_compute_project_default_network_tier":  {Tok: gcpResource(gcpCompute, "ProjectDefaultNetworkTier")},
+			"google_compute_project_metadata":              {Tok: gcpResource(gcpCompute, "ProjectMetadata")},
+			"google_compute_project_metadata_item":         {Tok: gcpResource(gcpCompute, "ProjectMetadataItem")},
+			"google_compute_region_autoscaler":             {Tok: gcpResource(gcpCompute, "RegionAutoscaler")},
+			"google_compute_region_backend_service":        {Tok: gcpResource(gcpCompute, "RegionBackendService")},
+			"google_compute_region_disk": {
+				Tok: gcpResource(gcpCompute, "RegionDisk"),
+				TransformFromState: func(_ context.Context, pMap resource.PropertyMap) (resource.PropertyMap, error) {
+					if _, ok := pMap["eraseWindowsVssSignature"]; !ok {
+						pMap["eraseWindowsVssSignature"] = resource.NewBoolProperty(false)
+					}
+					return pMap, nil
+				},
+			},
 			"google_compute_region_network_firewall_policy": {Tok: gcpResource(gcpCompute, "RegionNetworkFirewallPolicy")},
 			"google_compute_region_ssl_certificate":         {Tok: gcpResource(gcpCompute, "RegionSslCertificate")},
 			"google_compute_region_target_http_proxy":       {Tok: gcpResource(gcpCompute, "RegionTargetHttpProxy")},


### PR DESCRIPTION
Upstream added `erase_windows_vss_signature` (ForceNew, default `false`) to `google_compute_disk`, `google_compute_region_disk`, and `google_compute_instance` in v9.15.0, causing a replace diff on upgrade. This pull request adds state transformers to mitigate that and avoid users having to refresh by hand.

Also re-enables the `compute-disk-1/3` upgrade tests, which passing should prove a smooth upgrade.

Fixes #3883
Fixes #3650

## Test plan
- Re-enabled `TestAutoExtractedProgramsUpgrade/compute-disk-{1,3}` (baseline 6.67.0 → HEAD) assert `HasNoReplacements`/`HasNoDeletes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSc6Mysh8tByFfFxsWdW3c