### PR TITLE
Align Plugin Framework external_credentials block cardinality

### DIFF
--- a/patches/0008-Align-Plugin-Framework-external-credentials-cardinal.patch
+++ b/patches/0008-Align-Plugin-Framework-external-credentials-cardinal.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nobody <nobody@users.noreply.github.com>
+Date: Wed, 12 Aug 2026 11:35:54 +0100
+Subject: [PATCH] Align Plugin Framework external credentials cardinality
+
+The SDKv2 provider schema limits external_credentials to a single item
+via MaxItems: 1. Apply the same constraint to the duplicated Plugin
+Framework schema so consumers do not derive incompatible provider
+configuration shapes from the two halves of the muxed provider.
+
+listvalidator.SizeAtMost(1) is load bearing rather than incidental: the
+Pulumi Terraform bridge recovers a Plugin Framework block's MaxItems by
+matching the validator's description string, "list must contain at most
+1 elements". An equivalent hand-rolled validator would satisfy Terraform
+and still leave the constraint undetectable downstream.
+
+diff --git a/google-beta/fwprovider/framework_provider.go b/google-beta/fwprovider/framework_provider.go
+index d9b575a69f..8dd3276711 100644
+--- a/google-beta/fwprovider/framework_provider.go
++++ b/google-beta/fwprovider/framework_provider.go
+@@ -21,6 +21,7 @@ import (
+ 
+ 	sdk_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+ 
++	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+ 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+ 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+ 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+@@ -1361,6 +1362,9 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest,
+ 				},
+ 			},
+ 			"external_credentials": schema.ListNestedBlock{
++				Validators: []validator.List{
++					listvalidator.SizeAtMost(1),
++				},
+ 				NestedObject: schema.NestedBlockObject{
+ 					Attributes: map[string]schema.Attribute{
+ 						"audience": schema.StringAttribute{

--- a/provider/provider_config_test.go
+++ b/provider/provider_config_test.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+package gcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// A syntactically valid, cryptographically meaningless JWT. Upstream validates
+// identity_token with ValidateJWT, which requires exactly three non-empty base64url
+// segments; it does not verify the signature.
+//
+//nolint:gosec // Not a credential: three base64url segments that decode to nothing useful.
+const testIdentityToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+	"eyJhdWQiOiIvL2lhbS5nb29nbGVhcGlzLmNvbS8iLCJzdWIiOiJwdWx1bWkifQ." +
+	"bm90LWEtcmVhbC1zaWduYXR1cmU"
+
+// checkConfigEnvVars is every environment variable that can influence CheckConfig for
+// this provider, whether through tfbridge.DefaultInfo.EnvVars in resources.go or through
+// tfbridge.ConfigStringValue lookups in preConfigureCallbackWithLogger.
+//
+// Clearing the project variables is load bearing rather than cosmetic. If project
+// resolves to a non-empty value then preConfigureCallbackWithLogger calls
+// config.LoadAndValidate, and CheckConfig fails on missing credentials before the
+// provider configuration is ever encoded, which is the code path under test here. CI
+// sets GOOGLE_PROJECT.
+var checkConfigEnvVars = []string{
+	"GOOGLE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT",
+	"GOOGLE_REGION", "GCLOUD_REGION", "CLOUDSDK_COMPUTE_REGION",
+	"GOOGLE_ZONE", "GCLOUD_ZONE", "CLOUDSDK_COMPUTE_ZONE",
+	"GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON",
+	"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_OAUTH_ACCESS_TOKEN",
+	"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
+}
+
+// TestCheckConfigExternalCredentials is a regression test for
+// https://github.com/pulumi/pulumi-gcp/issues/3869.
+//
+// external_credentials is declared upstream as an SDKv2 TypeList block with
+// MaxItems: 1, so tfgen flattens it and the Pulumi schema types externalCredentials as
+// an object. The duplicated Plugin Framework provider schema declares the same block as
+// a bare schema.ListNestedBlock. The bridge can only recover MaxItems for a Plugin
+// Framework block by matching a size validator's description, so without
+// listvalidator.SizeAtMost(1) the Plugin Framework side of the muxed server builds a
+// plain list encoder and rejects the object the SDKs actually send:
+//
+//	cannot encode provider configuration to call ValidateProviderConfig:
+//	objectEncoder failed on property "external_credentials": Expected an Array PropertyValue
+//
+// Note the sibling batching block has the same SDKv2/Plugin Framework asymmetry but does
+// not reproduce this: its value is silently dropped on the Plugin Framework encode path
+// rather than encoded, so both object and list shapes are accepted today. It is
+// deliberately not covered here.
+func TestCheckConfigExternalCredentials(t *testing.T) {
+	// Do not call t.Parallel: this test uses t.Setenv.
+	for _, envVar := range checkConfigEnvVars {
+		t.Setenv(envVar, "")
+	}
+
+	externalCredentials := resource.PropertyMap{
+		"audience":            resource.NewStringProperty("//iam.googleapis.com/"),
+		"identityToken":       resource.NewStringProperty(testIdentityToken),
+		"serviceAccountEmail": resource.NewStringProperty("pulumi@pulumi.iam.gserviceaccount.com"),
+	}
+
+	news, err := plugin.MarshalProperties(resource.PropertyMap{
+		"version": resource.NewStringProperty("0.0.1"),
+		// Suppresses the "no project configured" warning from
+		// preConfigureCallbackWithLogger. ExtraConfig keys are exempt from the Plugin
+		// Framework unknown-key check, so this is not a CheckFailure.
+		"disableGlobalProjectWarning": resource.NewBoolProperty(true),
+		"externalCredentials":         resource.NewObjectProperty(externalCredentials),
+	}, plugin.MarshalOptions{})
+	require.NoError(t, err)
+
+	response, err := providerServer(t).CheckConfig(context.Background(), &pulumirpc.CheckRequest{
+		Urn:  "urn:pulumi:dev::gcp-3869::pulumi:providers:gcp::provider",
+		News: news,
+	})
+	// Without the upstream patch this fails inside the Plugin Framework half of the
+	// muxed server with "Expected an Array PropertyValue".
+	require.NoError(t, err)
+	require.Empty(t, response.GetFailures())
+
+	// CheckConfig folds non-string provider configuration back into JSON strings, see
+	// tfbridge.ConfigEncoding.FoldProperties.
+	inputs, err := plugin.UnmarshalProperties(response.GetInputs(), plugin.MarshalOptions{})
+	require.NoError(t, err)
+
+	actual, ok := inputs["externalCredentials"]
+	require.Truef(t, ok, "CheckConfig did not echo externalCredentials; got %v", inputs)
+	require.Truef(t, actual.IsString(),
+		"expected externalCredentials to be JSON-encoded back as a string, got %v", actual)
+
+	expected, err := json.Marshal(externalCredentials.Mappable())
+	require.NoError(t, err)
+	require.JSONEq(t, string(expected), actual.StringValue())
+}


### PR DESCRIPTION
The SDKv2 provider schema limits `external_credentials` to one item, so the Pulumi schema exposes it as an object, but the duplicated Plugin Framework schema declares no size validator. The bridge recovers a Plugin Framework block's `MaxItems` by matching the validator's description, so the two halves disagree and object-shaped provider configuration fails to encode for `ValidateProviderConfig`.

Adds the missing `listvalidator.SizeAtMost(1)` as a temporary upstream patch, plus a regression test driving an object-shaped `externalCredentials` through the muxed server's `CheckConfig`. The test reproduces the failure without the patch and passes with it; also confirmed end to end with `pulumi preview`.

Patch removal tracked by #3922. Bridge-level handling remains pulumi/pulumi-terraform-bridge#3566.

Part of #3869
