### PR TITLE
Update Go SDK version references in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Fgcp.svg)](https://npmjs.com/package/@pulumi/gcp)
 [![NuGet version](https://badge.fury.io/nu/pulumi.gcp.svg)](https://badge.fury.io/nu/pulumi.gcp)
 [![Python version](https://badge.fury.io/py/pulumi-gcp.svg)](https://pypi.org/project/pulumi-gcp)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gcp/sdk/v6/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gcp/sdk/v6/go)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gcp/sdk/v9/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gcp/sdk/v9/go)
 [![License](https://img.shields.io/npm/l/%40pulumi%2Fgcp.svg?color=limegreen)](https://github.com/pulumi/pulumi-gcp/blob/master/LICENSE)
 
 # Google Cloud Platform Resource Provider
@@ -41,7 +41,7 @@ To use from Python, install using `pip`:
 
 To use from Go, use `go get` to grab the latest version of the library
 
-    $ go get github.com/pulumi/pulumi-gcp/sdk/v6
+    $ go get github.com/pulumi/pulumi-gcp/sdk/v9
 
 ### .NET 
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -50,7 +50,7 @@ bucket = storage.Bucket('my-bucket')
 ```go
 import (
     "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-    "github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
+    "github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp/storage"
 )
 
 func main() {

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -10,7 +10,7 @@ The Google Cloud (GCP) Classic provider is available as a package in all Pulumi 
 
 * JavaScript/TypeScript: [`@pulumi/gcp`](https://www.npmjs.com/package/@pulumi/gcp)
 * Python: [`pulumi-gcp`](https://pypi.org/project/pulumi-gcp/)
-* Go: [`github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp`](https://github.com/pulumi/pulumi-gcp)
+* Go: [`github.com/pulumi/pulumi-gcp/sdk/v9/go/gcp`](https://github.com/pulumi/pulumi-gcp)
 * .NET: [`Pulumi.Gcp`](https://www.nuget.org/packages/Pulumi.Gcp)
 * Java: [`com.pulumi.gcp`](https://search.maven.org/search?q=com.pulumi.gcp)
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Fgcp.svg)](https://npmjs.com/package/@pulumi/gcp)
 [![NuGet version](https://badge.fury.io/nu/pulumi.gcp.svg)](https://badge.fury.io/nu/pulumi.gcp)
 [![Python version](https://badge.fury.io/py/pulumi-gcp.svg)](https://pypi.org/project/pulumi-gcp)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gcp/sdk/v6/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gcp/sdk/v6/go)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/pulumi/pulumi-gcp/sdk/v9/go)](https://pkg.go.dev/github.com/pulumi/pulumi-gcp/sdk/v9/go)
 [![License](https://img.shields.io/npm/l/%40pulumi%2Fgcp.svg?color=limegreen)](https://github.com/pulumi/pulumi-gcp/blob/master/LICENSE)
 
 # Google Cloud Platform Resource Provider
@@ -41,7 +41,7 @@ To use from Python, install using `pip`:
 
 To use from Go, use `go get` to grab the latest version of the library
 
-    $ go get github.com/pulumi/pulumi-gcp/sdk/v6
+    $ go get github.com/pulumi/pulumi-gcp/sdk/v9
 
 ### .NET 
 


### PR DESCRIPTION
Points the Go SDK badge, `go get` line, and doc import examples at the module path for the current major so they track `sdk/v9` alongside the rest of the repo. `sdk/python/README.md` is a generated copy of the root README and refreshes on the next Python SDK build.

Part of #3931
