### PR TITLE
Read package.json directly instead of via @npmcli/package-json

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2905,8 +2905,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			Dependencies: map[string]string{
-				"@npmcli/package-json": "^6.2.0",
-				"@types/express":       "^4.16.0",
+				"@types/express": "^4.16.0",
 			},
 			DevDependencies: map[string]string{
 				"@types/node": "^18.0.0", // so we can access strongly typed node definitions.

--- a/sdk/nodejs/cloudfunctions/zMixins.ts
+++ b/sdk/nodejs/cloudfunctions/zMixins.ts
@@ -268,7 +268,15 @@ async function computeCodePaths(
 // generate the new package.json to be uploaded to GCP.
 // GCP will restore the packages itself.
 async function producePackageJson(excludedPackages: Set<string>): Promise<string> {
-    const packageJson = JSON.parse(await fs.promises.readFile("./package.json", "utf8"));
+    let packageJson: any;
+    try {
+        // Strip a leading UTF-8 BOM: JSON.parse rejects it, but package.json files
+        // written by some Windows tooling carry one.
+        const raw = await fs.promises.readFile("./package.json", "utf8");
+        packageJson = JSON.parse(raw.replace(/^\uFEFF/, ""));
+    } catch (err) {
+        throw new Error(`Could not read package.json: ${err}`);
+    }
 
     // Override dependencies by removing @pulumi and excludedPackages
     const dependencies = Object.keys(packageJson.dependencies || {})

--- a/sdk/nodejs/cloudfunctions/zMixins.ts
+++ b/sdk/nodejs/cloudfunctions/zMixins.ts
@@ -18,6 +18,7 @@ import * as cloudfunctions from ".";
 import * as storage from "../storage";
 import * as inputs from "../types/input";
 
+import * as fs from "fs";
 import * as filepath from "path";
 
 import * as utils from "../utils";
@@ -267,9 +268,7 @@ async function computeCodePaths(
 // generate the new package.json to be uploaded to GCP.
 // GCP will restore the packages itself.
 async function producePackageJson(excludedPackages: Set<string>): Promise<string> {
-    const PackageJson = require("@npmcli/package-json");
-    const pkgJson = await PackageJson.load('./');
-    const packageJson = pkgJson.content;
+    const packageJson = JSON.parse(await fs.promises.readFile("./package.json", "utf8"));
 
     // Override dependencies by removing @pulumi and excludedPackages
     const dependencies = Object.keys(packageJson.dependencies || {})

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -13,7 +13,6 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@npmcli/package-json": "^6.2.0",
         "@pulumi/pulumi": "^3.142.0",
         "@types/express": "^4.16.0"
     },


### PR DESCRIPTION
The Cloud Functions callback overlay only needed a read and a JSON parse, which is all `@npmcli/package-json`'s `load()` does without options. Dropping it removes the dependency and its transitive tree from every Node consumer of the SDK.

`@npmcli/package-json` parsed via `json-parse-even-better-errors`, which strips a leading UTF-8 BOM, so that behavior is preserved explicitly here rather than dropped.

Verified with a full `tsc` build of the regenerated Node SDK. `TestCloudfunctionWithCallbackPackageJson` needs GCP credentials, so CI covers that.

Part of #3916
