### PR TITLE
Drop the fs and path npm packages from the webserver example

### DIFF
--- a/examples/webserver/package.json
+++ b/examples/webserver/package.json
@@ -9,9 +9,7 @@
         "@pulumi/gcp": "latest"
     },
     "devDependencies": {
-        "@types/node": "^24.0.0",
-        "fs": "*",
-        "path": "*"
+        "@types/node": "^24.0.0"
     },
     "license": "MIT"
 }


### PR DESCRIPTION
`examples/webserver/package.json` lists `"fs": "*"` and `"path": "*"` as devDependencies. Both are Node builtins, so those names resolve to unrelated third-party uploads on the public registry rather than anything the example needs. `index.ts` imports neither; its only import is `@pulumi/gcp`.

The wildcard range means `npm install` takes whatever the registry currently serves for both, on every CI run. Renovate already refuses to touch one of them, logging `Dependency fs has update(s) proposed which would update you to a malicious version - skipping` against this file and raising a repository-problems banner on the dependency dashboard.

Verified `npm install` still resolves (342 packages) and `tsc --noEmit` reports nothing in `index.ts` after the removal.
