### PR TITLE
Update patch 0007's test for upstream v8's CustomEndpoints

### DIFF
--- a/patches/0007-compute-fix-empty-boot-disk-resource_policies-guard.patch
+++ b/patches/0007-compute-fix-empty-boot-disk-resource_policies-guard.patch
@@ -154,7 +154,7 @@ index 41a22e9fd..87568027e 100644
 +
 +	return &transport_tpg.Config{
 +		Client:          server.Client(),
-+		ComputeBasePath: server.URL + "/",
++		CustomEndpoints: map[string]string{"compute_custom_endpoint": server.URL + "/"},
 +		Context:         context.Background(),
 +		Project:         "test-project",
 +		UserAgent:       "test-agent",


### PR DESCRIPTION
Upstream v8.0.0 replaced the per-product `XxxBasePath` fields on `transport.Config` with a single `CustomEndpoints map[string]string`, keyed by each product's `CustomEndpointField`. The test that patch 0007 adds still constructed `transport.Config{ComputeBasePath: ...}`, so after the v8 rebase `google-beta/services/compute` failed to build with `unknown field ComputeBasePath in struct literal of type transport.Config`.

Verified by re-applying all eight patches from pristine v8.0.0 and running the compute package tests, which build and pass, `TestComputeInstance_flattenBootDiskResourcePoliciesGuard` included.

Part of #3936
