### PR TITLE
Move the compute examples to the debian-13 image family

### DIFF
--- a/examples/loadbalancer/index.ts
+++ b/examples/loadbalancer/index.ts
@@ -18,7 +18,7 @@ const regionZone = gcp.config.zone;
 const projectName = gcp.config.project;
 
 const machineTypeName = "f1-micro";
-const imageName = "debian-cloud/debian-11";
+const imageName = "debian-cloud/debian-13";
 const tag = "http-tag";
 
 let network = new gcp.compute.Network("default-network", {

--- a/examples/webserver-py-old/__main__.py
+++ b/examples/webserver-py-old/__main__.py
@@ -46,7 +46,7 @@ compute_instance = compute.Instance(
     zone=region_zone,
     boot_disk={
         "initialize_params": {
-            "image": "debian-cloud/debian-11",
+            "image": "debian-cloud/debian-13",
         },
     },
     network_interfaces=[{

--- a/examples/webserver-py/__main__.py
+++ b/examples/webserver-py/__main__.py
@@ -44,7 +44,7 @@ compute_instance = compute.Instance(
     zone=region_zone,
     boot_disk=compute.InstanceBootDiskArgs(
         initialize_params=compute.InstanceBootDiskInitializeParamsArgs(
-            image="debian-cloud/debian-11",
+            image="debian-cloud/debian-13",
         ),
     ),
     network_interfaces=[compute.InstanceNetworkInterfaceArgs(

--- a/examples/webserver/index.ts
+++ b/examples/webserver/index.ts
@@ -46,7 +46,7 @@ const computeIntance = new gcp.compute.Instance("ts-instance", {
     zone: regionZone,
     bootDisk: {
         initializeParams: {
-            image: "debian-cloud/debian-11",
+            image: "debian-cloud/debian-13",
         },
     },
     networkInterfaces: [


### PR DESCRIPTION
`debian-cloud/debian-11` no longer resolves, so the four examples that pin it cannot create their instances. This moves them to `debian-13`, which has been available on Compute Engine since Debian 13 Trixie shipped.

Going to `debian-13` rather than `debian-12` is deliberate: an image family only tracks the newest image within its own major version, so this line has to be touched once per Debian major release either way. Starting from 13 makes that interval as long as possible.

The affected examples are `webserver`, `webserver-py`, `webserver-py-old` and `loadbalancer`, exercised by `TestAccWebserverNode`, `TestAccWebserverPy` and `TestAccLoadbalancer`. Those tests are the verification.
