### PR TITLE
Add missing outputs to the YAML labels-secret program and unskip its test

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -23,7 +23,6 @@ func TestHttpHealthCheck(t *testing.T) {
 }
 
 func TestPulumiLabelsSecretYAML(t *testing.T) {
-	t.Skip("Skipping due to secrets bug in YAML")
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: filepath.Join(getCwd(t), "test-pulumi-labels-secret", "yaml"),
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/examples/test-pulumi-labels-secret/yaml/Pulumi.yaml
+++ b/examples/test-pulumi-labels-secret/yaml/Pulumi.yaml
@@ -20,3 +20,5 @@ resources:
         hello: goodbye
         new: defaultlabel
 
+outputs:
+  pulumiLabels: ${my-bucket.pulumiLabels}


### PR DESCRIPTION
Part of #3989

`examples/test-pulumi-labels-secret/yaml/Pulumi.yaml` declared only `resources:`, so `pulumiLabels` was never exported and `TestPulumiLabelsSecretYAML`'s assertions had nothing to read. The program now exports the whole map, as the Go equivalent does, and the test is unskipped.

The `t.Skip` referred to a real gap in the YAML runtime, which did not forward schema `secret: true` properties to the engine as `AdditionalSecretOutputs`. That was fixed upstream in pulumi/pulumi-yaml#526, released in pulumi-yaml v1.4.2, and the bundled version has carried the fix for some time. No upstream change or version bump is needed here.

Verified against real GCP: `TestPulumiLabelsSecretYAML` passes with `pulumiLabels` present, the plaintext default-label value absent, and `ciphertext` present, with `TestPulumiLabelsSecretGo` passing as a control.
