### PR TITLE
Re-anchor patch 0005's read after the planned settings are captured

### DIFF
--- a/patches/0005-Fix-794-with-an-unconditional-read.patch
+++ b/patches/0005-Fix-794-with-an-unconditional-read.patch
@@ -3,12 +3,21 @@ From: Aaron Friel <mayreply@aaronfriel.com>
 Date: Thu, 7 Sep 2023 16:28:00 -0700
 Subject: [PATCH] Fix #794 with an unconditional read.
 
+Read unconditionally so that settings.version is refreshed before the
+update call builds its patch body.
+
+The read has to sit after the planned settings are captured.
+resourceSqlDatabaseInstanceRead calls d.Set("settings", ...), and
+helper/schema resolves d.Get at the set level in preference to diff, so a
+capture taken after the read yields remote values rather than planned
+ones. Upstream places its own capture below the conditional reads, so
+this patch hoists it back above them.
 
 diff --git a/google-beta/services/sql/resource_sql_database_instance.go b/google-beta/services/sql/resource_sql_database_instance.go
-index 90bb70114..4ef26b615 100644
+index 90bb701141..8707708e5b 100644
 --- a/google-beta/services/sql/resource_sql_database_instance.go
 +++ b/google-beta/services/sql/resource_sql_database_instance.go
-@@ -3011,10 +3011,11 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
+@@ -3011,10 +3011,17 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
  		if err != nil {
  			return err
  		}
@@ -18,9 +27,23 @@ index 90bb70114..4ef26b615 100644
 -		}
 +	}
 +
++	// Capture the planned settings before the read below. resourceSqlDatabaseInstanceRead
++	// calls d.Set("settings", ...), and helper/schema resolves d.Get at the set level in
++	// preference to diff, so any d.Get("settings") after the read returns remote values
++	// rather than planned ones.
++	desiredSetting := d.Get("settings")
++
 +	err = resourceSqlDatabaseInstanceRead(d, meta)
 +	if err != nil {
 +		return err
  	}
  
  	if d.HasChange("settings.0.entraid_config") {
+@@ -3050,7 +3057,6 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
+ 		}
+ 	}
+ 
+-	desiredSetting := d.Get("settings")
+ 	instance = &sqladmin.DatabaseInstance{
+ 		Settings: expandSqlDatabaseInstanceSettings(desiredSetting.([]interface{}), databaseVersion),
+ 	}


### PR DESCRIPTION
`resourceSqlDatabaseInstanceUpdate` builds its PATCH body from `desiredSetting := d.Get("settings")`. Patch 0005 inserts an unconditional `resourceSqlDatabaseInstanceRead` above that point, and the read calls `d.Set("settings", ...)`. helper/schema resolves `d.Get` at the set level in preference to diff, so the capture returns remote values rather than planned ones and the PATCH is built from what the server already has.

Upstream `2e4184b54` ([MM #18439](https://github.com/GoogleCloudPlatform/magic-modules/pull/18439)) moved its own capture below the conditional reads. This hoists it back above them, restoring the order the patch was written against: capture, read, use. It also returns the patch to a pure insertion rather than deleting the edition block's read.

Verified by applying all eight patches to upstream v7.45.0 and building and testing the sql package.

Part of #3970
Part of #3988
