### PR TITLE
Update patch 0007's test for CustomEndpoints

### DIFF
--- a/patches/0005-compute-fix-empty-boot-disk-resource_policies-guard.patch
+++ b/patches/0005-compute-fix-empty-boot-disk-resource_policies-guard.patch
@@ -154,7 +154,7 @@ index 41a22e9fd9db..87568027ef4f 100644
 +
 +	return &transport_tpg.Config{
 +		Client:          server.Client(),
-+		ComputeBasePath: server.URL + "/",
++		CustomEndpoints: map[string]string{"compute_custom_endpoint": server.URL + "/"},
 +		Context:         context.Background(),
 +		Project:         "test-project",
 +		UserAgent:       "test-agent",


### PR DESCRIPTION
`transport.Config` dropped the per-product `XxxBasePath` fields in favour of a single `CustomEndpoints` map in upstream v7.33.0, so the test that patch 0007 adds no longer compiles against the pinned upstream and takes the compute package's test binary with it.

Verified against the pin (v7.46.0) with all eight patches applied: `go vet ./google-beta/services/compute/` reports `unknown field ComputeBasePath in struct literal of type transport.Config` at `resource_compute_instance_internal_test.go:263:3` before this change, and no longer reports it after. The three `unreachable code` findings that remain are pre-existing, in unrelated upstream files that no patch touches.

Same one-liner as #3991, which applies it on `upgrade-to-v10-major`.
